### PR TITLE
Fix and speed up travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,6 @@ matrix:
   allow_failures:
     - python: 2.7
 before_install:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
   - pip install -U pip
   - pip install wheel
 install:
@@ -51,7 +49,8 @@ install:
   - pip install coveralls
   - pip install nose
   - pip install -e .
-script: 
+  - "sed -i 's/^backend.*/backend : Agg/' /home/travis/virtualenv/*/lib/python*/site-packages/matplotlib/mpl-data/matplotlibrc"
+script:
   - nosetests --with-coverage --cover-package oggm --logging-level=INFO
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
   - pip install wheel
 install:
   - travis_wait pip wheel -r ci/requirements.txt
-  - travis_wait pip install -r ci/requirements.txt
+  - travis_wait pip install --upgrade --force-reinstall -r ci/requirements.txt
   - pip wheel scikit-image
   - pip install scikit-image
   - pip install gdal==1.10.0 --install-option="build_ext" --install-option="--include-dirs=/usr/include/gdal"

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,6 @@ matrix:
     - python: 2.7
     - python: 3.4
     - python: 3.5
-  allow_failures:
-    - python: 2.7
 before_install:
   - pip install -U pip
   - pip install wheel


### PR DESCRIPTION
The python 2.7 builds were failing because the pip wheel downloaded and compiled a local numpy version, which all the other pip packages were using.
But because of the installed system numpy, pip install never installed it, so the other packages failed because of the incompatible ABI of the system numpy.

In turn I also made python 2.7 required for Travis to pass again, so no python2 incompatible code sneaks in.

This also gets rid of xvfb, and instead switches matplotlib to a headless backend.
Speeds up the build by a few minutes.