### PR TITLE
Fix ProgressBar exception on unknown length

### DIFF
--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -67,11 +67,14 @@ def _urlretrieve(url, ofile, *args, **kwargs):
 def progress_urlretrieve(url, ofile):
     print("Downloading %s ..." % url)
     try:
-        from progressbar import ProgressBar, Percentage, Bar, DataSize, FileTransferSpeed, ETA
-        pbar = ProgressBar(widgets=[Percentage(), ' ', Bar(), ' ', DataSize(), ' ', FileTransferSpeed(), ' ', ETA()])
+        from progressbar import DataTransferBar, UnknownLength
+        pbar = DataTransferBar()
         def _upd(count, size, total):
             if pbar.max_value is None:
-                pbar.start(total)
+                if total > 0:
+                    pbar.start(total)
+                else:
+                    pbar.start(UnknownLength)
             pbar.update(min(count * size, total))
         res = _urlretrieve(url, ofile, reporthook=_upd)
         pbar.finish()


### PR DESCRIPTION
urlretrieve returns -1 as total size if the size is unknown for some reason.
ProgressBar does not expect this and throws an exception, so translate values <=0 to UnknownLength.