### PR TITLE
Workaround bug in some progressbar versions

### DIFF
--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -77,7 +77,10 @@ def progress_urlretrieve(url, ofile):
                     pbar.start(UnknownLength)
             pbar.update(min(count * size, total))
         res = _urlretrieve(url, ofile, reporthook=_upd)
-        pbar.finish()
+        try:
+            pbar.finish()
+        except:
+            pass
         return res
     except ImportError:
         return _urlretrieve(url, ofile)


### PR DESCRIPTION
Some progressbar versions miscalculate the progress, causing ValueError from math.log on finish.
As errors from progressbar are not fatal for us, just ignore them.