### PR TITLE
Multiprocessing fixes and improvements

### DIFF
--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -985,7 +985,7 @@ def _get_cru_file_unlocked(var=None):
     # Be sure the user gave a sensible path to the climate dir
     cru_dir = cfg.PATHS['cru_dir']
     if not os.path.exists(cru_dir):
-        raise ValueError('The CRU data directory does not exist!')
+        raise ValueError('The CRU data directory({}) does not exist!'.format(cru_dir))
 
     # Be sure input makes sense
     if var not in ['tmp', 'pre']:

--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -41,10 +41,10 @@ from salem import wgs84
 import xarray as xr
 import rasterio
 from rasterio.tools.merge import merge as merge_tool
+import multiprocessing as mp
 
 # Locals
 import oggm.cfg as cfg
-import oggm.workflow.download_lock as download_lock
 
 SAMPLE_DATA_GH_REPO = 'OGGM/oggm-sample-data'
 CRU_SERVER = 'https://crudata.uea.ac.uk/cru/data/hrg/cru_ts_3.23/cruts' \
@@ -54,6 +54,9 @@ MEMORY = Memory(cachedir=cfg.CACHE_DIR, verbose=0)
 
 # Function
 tuple2int = partial(np.array, dtype=np.int64)
+
+# File Download lock
+download_lock = mp.Lock()
 
 
 def _urlretrieve(url, ofile, *args, **kwargs):

--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -98,9 +98,16 @@ def empty_cache():  # pragma: no cover
     os.makedirs(cfg.CACHE_DIR)
 
 
+def expand_path(p):
+    """Helper function for os.path.expanduser and os.path.expandvars"""
+
+    return os.path.expandvars(os.path.expanduser(p))
+
+
 def _download_oggm_files():
     with download_lock:
         return _download_oggm_files_unlocked()
+
 
 def _download_oggm_files_unlocked():
     """Checks if the demo data is already on the cache and downloads it."""

--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -460,6 +460,7 @@ def mkdir(path, reset=False):
     if not os.path.exists(path):
         os.makedirs(path)
 
+
 def query_yes_no(question, default="yes"):
     """Ask a yes/no question via raw_input() and return their answer.
 
@@ -989,8 +990,14 @@ def _get_cru_file_unlocked(var=None):
     path to the CRU file
     """
 
-    # Be sure the user gave a sensible path to the climate dir
     cru_dir = cfg.PATHS['cru_dir']
+
+    # Handle ~ special case
+    if cru_dir == '~':
+        cru_dir = os.path.join(cfg.PATHS['working_dir'], 'cru')
+        mkdir(cru_dir)
+
+    # Be sure the user gave a sensible path to the climate dir
     if not os.path.exists(cru_dir):
         raise ValueError('The CRU data directory({}) does not exist!'.format(cru_dir))
 

--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -44,6 +44,7 @@ from rasterio.tools.merge import merge as merge_tool
 
 # Locals
 import oggm.cfg as cfg
+import oggm.workflow.download_lock as download_lock
 
 SAMPLE_DATA_GH_REPO = 'OGGM/oggm-sample-data'
 CRU_SERVER = 'https://crudata.uea.ac.uk/cru/data/hrg/cru_ts_3.23/cruts' \
@@ -95,6 +96,10 @@ def empty_cache():  # pragma: no cover
 
 
 def _download_oggm_files():
+    with download_lock:
+        return _download_oggm_files_unlocked()
+
+def _download_oggm_files_unlocked():
     """Checks if the demo data is already on the cache and downloads it."""
 
     master_sha_url = 'https://api.github.com/repos/%s/commits/master' % \
@@ -160,6 +165,11 @@ def _download_oggm_files():
 
 
 def _download_srtm_file(zone):
+    with download_lock:
+        return _download_srtm_file_unlocked(zone)
+
+
+def _download_srtm_file_unlocked(zone):
     """Checks if the srtm data is in the directory and if not, download it.
     """
 
@@ -204,6 +214,11 @@ def _download_srtm_file(zone):
 
 
 def _download_dem3_viewpano(zone, specialzones):
+    with download_lock:
+        return _download_dem3_viewpano_unlocked(zone, specialzones)
+
+
+def _download_dem3_viewpano_unlocked(zone, specialzones):
     """Checks if the srtm data is in the directory and if not, download it.
     """
 
@@ -292,6 +307,11 @@ def _download_dem3_viewpano(zone, specialzones):
 
 
 def _download_aster_file(zone, unit):
+    with download_lock:
+        return _download_aster_file_unlocked(zone, unit)
+
+
+def _download_aster_file_unlocked(zone, unit):
     """Checks if the aster data is in the directory and if not, download it.
 
     You need AWS cli and AWS credentials for this. Quoting Timo:
@@ -327,6 +347,11 @@ def _download_aster_file(zone, unit):
 
 
 def _download_alternate_topo_file(fname):
+    with download_lock:
+        return _download_alternate_topo_file_unlocked(fname)
+
+
+def _download_alternate_topo_file_unlocked(fname):
     """Checks if the special topo data is in the directory and if not,
     download it from AWS.
 
@@ -384,6 +409,11 @@ def _get_centerline_lonlat(gdir):
 
 
 def aws_file_download(aws_path, local_path, reset=False):
+    with download_lock:
+        return _aws_file_download_unlocked(aws_path, local_path, reset)
+
+
+def _aws_file_download_unlocked(aws_path, local_path, reset=False):
     """Download a file from the AWS drive s3://astgtmv2/
 
     **Note:** you need AWS credentials for this to work.
@@ -883,6 +913,11 @@ def get_glathida_file():
 
 
 def get_rgi_dir():
+    with download_lock:
+        return _get_rgi_dir_unlocked()
+
+
+def _get_rgi_dir_unlocked():
     """
     Returns a path to the RGI directory.
 
@@ -925,6 +960,11 @@ def get_rgi_dir():
 
 
 def get_cru_file(var=None):
+    with download_lock:
+        return _get_cru_file_unlocked(var)
+
+
+def _get_cru_file_unlocked(var=None):
     """
     Returns a path to the desired CRU TS file.
 

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -20,13 +20,21 @@ log = logging.getLogger(__name__)
 # Multiprocessing pool
 mppool = None
 
+# File Download lock
+download_lock = mp.Lock()
+
+
+def _init_pool_globals(_dl_lock):
+    global download_lock
+    download_lock = _dl_lock
+
 
 def _init_pool():
     """Necessary because at import time, cfg might be unitialized"""
 
     global mppool
     if cfg.PARAMS['use_multiprocessing']:
-        mppool = mp.Pool(cfg.PARAMS['mp_processes'])
+        mppool = mp.Pool(cfg.PARAMS['mp_processes'], initializer=_init_pool_globals, initargs=(download_lock,))
 
 
 def execute_entity_task(task, gdirs):

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -18,9 +18,6 @@ from oggm.utils import download_lock
 # Module logger
 log = logging.getLogger(__name__)
 
-# Multiprocessing pool
-mppool = None
-
 
 def _init_pool_globals(_dl_lock, _cfg_contents):
     global download_lock
@@ -33,21 +30,19 @@ def _init_pool_globals(_dl_lock, _cfg_contents):
 def _init_pool():
     """Necessary because at import time, cfg might be unitialized"""
 
-    global mppool
-    if cfg.PARAMS['use_multiprocessing']:
-        cfg_variables = [
-            'IS_INITIALIZED',
-            'CONTINUE_ON_ERROR',
-            'PARAMS',
-            'PATHS',
-            'BASENAMES'
-        ]
+    cfg_variables = [
+        'IS_INITIALIZED',
+        'CONTINUE_ON_ERROR',
+        'PARAMS',
+        'PATHS',
+        'BASENAMES'
+    ]
 
-        cfg_contents = []
-        for v in cfg_variables:
-            cfg_contents.append((v, getattr(cfg, v)))
+    cfg_contents = []
+    for v in cfg_variables:
+        cfg_contents.append((v, getattr(cfg, v)))
 
-        mppool = mp.Pool(cfg.PARAMS['mp_processes'], initializer=_init_pool_globals, initargs=(download_lock, cfg_contents))
+    return mp.Pool(cfg.PARAMS['mp_processes'], initializer=_init_pool_globals, initargs=(download_lock, cfg_contents))
 
 
 def execute_entity_task(task, gdirs):
@@ -64,10 +59,8 @@ def execute_entity_task(task, gdirs):
     """
 
     if cfg.PARAMS['use_multiprocessing']:
-        if mppool is None:
-            _init_pool()
-        poolargs = gdirs
-        mppool.map(task, poolargs, chunksize=1)
+        mppool = _init_pool()
+        mppool.map(task, gdirs, chunksize=1)
     else:
         for gdir in gdirs:
             task(gdir)

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -24,9 +24,12 @@ mppool = None
 download_lock = mp.Lock()
 
 
-def _init_pool_globals(_dl_lock):
+def _init_pool_globals(_dl_lock, _cfg_contents):
     global download_lock
     download_lock = _dl_lock
+
+    for v, c in _cfg_contents:
+        setattr(cfg, v, c)
 
 
 def _init_pool():
@@ -34,7 +37,19 @@ def _init_pool():
 
     global mppool
     if cfg.PARAMS['use_multiprocessing']:
-        mppool = mp.Pool(cfg.PARAMS['mp_processes'], initializer=_init_pool_globals, initargs=(download_lock,))
+        cfg_variables = [
+            'IS_INITIALIZED',
+            'CONTINUE_ON_ERROR',
+            'PARAMS',
+            'PATHS',
+            'BASENAMES'
+        ]
+
+        cfg_contents = []
+        for v in cfg_variables:
+            cfg_contents.append((v, getattr(cfg, v)))
+
+        mppool = mp.Pool(cfg.PARAMS['mp_processes'], initializer=_init_pool_globals, initargs=(download_lock, cfg_contents))
 
 
 def execute_entity_task(task, gdirs):

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -12,6 +12,7 @@ import multiprocessing as mp
 # Locals
 import oggm
 from oggm import cfg, tasks, utils
+from oggm.utils import download_lock
 
 
 # Module logger
@@ -19,9 +20,6 @@ log = logging.getLogger(__name__)
 
 # Multiprocessing pool
 mppool = None
-
-# File Download lock
-download_lock = mp.Lock()
 
 
 def _init_pool_globals(_dl_lock, _cfg_contents):


### PR DESCRIPTION
Create a global mp.Lock() which is then used to guard all download operations, so they don't happen in parallel.

In turn, also passes cfg.PARAMS to all newly created processes.