### PR TITLE
Use Docker for Travis Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,61 +1,41 @@
-language: python
-sudo: false
+sudo: required
+dist: trusty
+services:
+  - docker
+
 notifications:
   email: false
+
 branches:  # blacklist
   except:
     - appveyor
     - docs
-cache:
-  directories:
-    - ~/.cache/pip
-env:
-  global:
-    - PIP_WHEEL_DIR=$HOME/.cache/pip/wheels
-    - PIP_FIND_LINKS=file://$HOME/.cache/pip/wheels
-addons:
-  apt:
-    packages:
-      # copied those from scipy
-      - libatlas-dev
-      - libatlas-base-dev
-      - liblapack-dev
-      - gfortran
-      # copied those from rasterio
-      - libgdal1h
-      - gdal-bin
-      - libgdal-dev
+
 matrix:
   fast_finish: true
   include:
-    - python: 2.7
-    - python: 3.5
-      env: OGGM_ENV=prepro
-    - python: 3.5
-      env: OGGM_ENV=models
-    - python: 3.5
-      env: OGGM_ENV=workflow
-    - python: 3.5
-      env: OGGM_ENV=graphics
+    - env: OGGM_ENV=prepro
+    - env: OGGM_ENV=models
+    - env: OGGM_ENV=workflow
+    - env: OGGM_ENV=graphics
+
 before_install:
-  - pip install -U pip
-  - pip install wheel
+  - docker pull oggm/base:latest
 install:
-  - travis_wait pip wheel -r ci/requirements.txt
-  - travis_wait pip install --upgrade --force-reinstall -r ci/requirements.txt
-  - pip wheel scikit-image
-  - pip install scikit-image
-  - pip install gdal==1.10.0 --install-option="build_ext" --install-option="--include-dirs=/usr/include/gdal"
-  - pip install fiona --install-option="build_ext" --install-option="--include-dirs=/usr/include/gdal"
-  - pip install geopandas
-  - pip install git+https://github.com/fmaussion/motionless.git
-  - pip install git+https://github.com/fmaussion/salem.git
-  - pip install git+https://github.com/fmaussion/cleo.git
-  - pip install coveralls
-  - pip install nose
-  - pip install -e .
-  - "sed -i 's/^backend.*/backend : Agg/' /home/travis/virtualenv/*/lib/python*/site-packages/matplotlib/mpl-data/matplotlibrc"
+  - |
+    cat <<EOF >test.sh
+    set -x
+    set -e
+    pip3 install coveralls
+    cd /root/oggm
+    pip3 install -e .
+    nosetests --verbose --with-coverage --cover-package oggm --logging-level=INFO
+    coveralls || true
+    exit 0
+    EOF
+  - docker create --name oggm_travis -ti -e OGGM_ENV -e CI -e TRAVIS -e TRAVIS_JOB_ID -e TRAVIS_BRANCH -e TRAVIS_PULL_REQUEST oggm/base:latest /bin/bash /root/oggm/test.sh
+  - docker cp $PWD oggm_travis:/root/oggm
 script:
-  - nosetests --verbose --with-coverage --cover-package oggm --logging-level=INFO
-after_success:
-  - coveralls
+  - docker start -ai oggm_travis
+after_script:
+  - docker rm oggm_travis

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,21 +12,20 @@ notifications:
 
 environment:
   matrix:
-    - PYTHON: "C:\\Python27-conda32"
+    - PYTHON: "C:\\Python2-conda32"
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "32"
-    - PYTHON: "C:\\Python35-conda64"
-      PYTHON_VERSION: "3.5"
+    - PYTHON: "C:\\Python3-conda64"
+      PYTHON_VERSION: "3.4"
       PYTHON_ARCH: "64"
 
 install:
   # Install miniconda Python
   - "powershell ./ci/install_python.ps1"
 
-  # Prepend newly installed Python to the PATH of this build (this cannot be
-  # done from inside the powershell script as it would require to restart
-  # the parent CMD process).
+  # Create environment with desired python version and activate it
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - "conda install --yes --quiet python=%PYTHON_VERSION%"
 
   # Check that we have the expected version and architecture for Python
   - "python --version"

--- a/ci/install_python.ps1
+++ b/ci/install_python.ps1
@@ -9,9 +9,9 @@ $BASE_URL = "https://www.python.org/ftp/python/"
 function DownloadMiniconda ($python_version, $platform_suffix) {
     $webclient = New-Object System.Net.WebClient
     if ($python_version -eq "3.4") {
-        $filename = "Miniconda3-3.7.3-Windows-" + $platform_suffix + ".exe"
+        $filename = "Miniconda3-latest-Windows-" + $platform_suffix + ".exe"
     } else {
-        $filename = "Miniconda-3.7.3-Windows-" + $platform_suffix + ".exe"
+        $filename = "Miniconda2-latest-Windows-" + $platform_suffix + ".exe"
     }
     $url = $MINICONDA_URL + $filename
 


### PR DESCRIPTION
This runs the Travis-Tests via Docker, on Ubuntu 16.04 with Python 3.5 and libgdal 1.11.3

It's also quite a bit faster.