### PR TITLE
Add MPI support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ install:
 
   # install dependencies
   - "python -m pip install --upgrade pip"
-  - "conda install --yes --quiet -c conda-forge geopandas matplotlib Pillow joblib netCDF4 scikit-image configobj nose pyproj numpy rasterio krb5 xarray"
+  - "conda install --yes --quiet -c conda-forge geopandas matplotlib Pillow joblib netCDF4 scikit-image configobj nose pyproj numpy rasterio krb5 xarray filelock"
   - "pip install git+https://github.com/fmaussion/motionless.git"
   - "pip install git+https://github.com/fmaussion/salem.git"
   - "pip install git+https://github.com/fmaussion/cleo.git"

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -15,6 +15,7 @@ dependencies:
   - krb5
   - rasterio
   - xarray
+  - filelock
   - numpydoc
   - ipython=4.0.1
   - sphinx=1.2.3  # pin to avoid https://github.com/sphinx-doc/sphinx/issues/1822

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,6 +33,7 @@ Documentation
     ice-dynamics
     inversion
     glacierdir-gen
+    mpi
     api
 
 

--- a/docs/installing-oggm.rst
+++ b/docs/installing-oggm.rst
@@ -60,6 +60,7 @@ Testing:
     - nose
 
 Other libraries:
+    - filelock
     - `salem <https://github.com/fmaussion/salem>`_
     - `cleo <https://github.com/fmaussion/cleo>`_
     - `motionless (py3) <https://github.com/fmaussion/motionless>`_
@@ -125,7 +126,7 @@ Packages
 
 Install the packages from the `conda-forge`_ channel::
 
-    conda install -c conda-forge geopandas matplotlib Pillow joblib netCDF4 scikit-image configobj nose pyproj numpy krb5 rasterio xarray
+    conda install -c conda-forge geopandas matplotlib Pillow joblib netCDF4 scikit-image configobj nose pyproj numpy krb5 rasterio xarray filelock
 
 .. warning::
 
@@ -327,7 +328,7 @@ using the system binaries::
 
 Install further stuffs::
 
-    $ pip install pyproj rasterio Pillow geopandas netcdf4 scikit-image configobj joblib xarray progressbar2
+    $ pip install pyproj rasterio Pillow geopandas netcdf4 scikit-image configobj joblib xarray filelock progressbar2
 
 And the external libraries::
 

--- a/docs/mpi.rst
+++ b/docs/mpi.rst
@@ -1,0 +1,25 @@
+Using OGGM with MPI
+=============
+
+OGGM can be run in a clustered environment, using standard mpi features.
+
+OGGM depends on mpi4py in that case, which can be installed via either conda
+
+    conda install -c conda-forge mpi4py
+
+or pip
+
+    pip install mpi4py
+
+
+Be aware that mpi4py itself depends on a working mpi environment, which is usually supplied by the maintainers of your cluster.
+On conda, it comes with its own copy of mpich, which is nice and easy for quick testing, but likely undesireable for the performance of actual runs.
+
+
+For an actual run, invoke any script using oggm via mpiexec, and pass the --mpi parameter to the script itself:
+
+    mpiexec -n 10 python ./run_rgi_region.py --mpi
+
+Be aware that the first process with rank 0 is the manager process, that by itself does not do any calculations and is only used to distribute tasks.
+So the actual number of working processes is one lower than the number passed to mpiexec/your clusters scheduler.
+

--- a/oggm/__init__.py
+++ b/oggm/__init__.py
@@ -28,3 +28,9 @@ logging.basicConfig(format='%(asctime)s: %(name)s: %(message)s',
 logging.getLogger("Fiona").setLevel(logging.WARNING)
 logging.getLogger("shapely").setLevel(logging.WARNING)
 logging.getLogger("rasterio").setLevel(logging.WARNING)
+
+try:
+    from oggm.mpi import _init_oggm_mpi
+    _init_oggm_mpi()
+except ImportError:
+    pass

--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -309,7 +309,7 @@ def pack_config():
         'CONTINUE_ON_ERROR': CONTINUE_ON_ERROR,
         'PARAMS': PARAMS,
         'PATHS': PATHS,
-        'BASENAMES': BASENAMES
+        'BASENAMES': dict(BASENAMES)
     }
 
 def unpack_config(cfg_dict):
@@ -321,4 +321,8 @@ def unpack_config(cfg_dict):
     CONTINUE_ON_ERROR = cfg_dict['CONTINUE_ON_ERROR']
     PARAMS = cfg_dict['PARAMS']
     PATHS = cfg_dict['PATHS']
-    BASENAMES = cfg_dict['BASENAMES']
+
+    # BASENAMES is a DocumentedDict, which cannot be pickled because set intentionally mismatches with get
+    BASENAMES = DocumentedDict()
+    for k in cfg_dict['BASENAMES']:
+        BASENAMES[k] = (cfg_dict['BASENAMES'][k], 'Imported Pickle')

--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -299,3 +299,26 @@ def reset_working_dir():
     if os.path.exists(PATHS['working_dir']):
         shutil.rmtree(PATHS['working_dir'])
     os.makedirs(PATHS['working_dir'])
+
+
+def pack_config():
+    """Pack the entire configuration in one pickleable dict."""
+
+    return {
+        'IS_INITIALIZED': IS_INITIALIZED,
+        'CONTINUE_ON_ERROR': CONTINUE_ON_ERROR,
+        'PARAMS': PARAMS,
+        'PATHS': PATHS,
+        'BASENAMES': BASENAMES
+    }
+
+def unpack_config(cfg_dict):
+    """Unpack and apply the config packed via pack_config."""
+
+    global IS_INITIALIZED, CONTINUE_ON_ERROR, PARAMS, PATHS, BASENAMES
+
+    IS_INITIALIZED = cfg_dict['IS_INITIALIZED']
+    CONTINUE_ON_ERROR = cfg_dict['CONTINUE_ON_ERROR']
+    PARAMS = cfg_dict['PARAMS']
+    PATHS = cfg_dict['PATHS']
+    BASENAMES = cfg_dict['BASENAMES']

--- a/oggm/mpi.py
+++ b/oggm/mpi.py
@@ -1,0 +1,103 @@
+"""MPI process management helpers and setup"""
+from mpi4py import MPI
+from oggm import cfg
+import atexit
+import argparse
+import sys, os
+import time
+
+OGGM_MPI_SIZE = 0
+OGGM_MPI_COMM = None
+OGGM_MPI_ROOT = 0
+
+def _imprint(s):
+    print(s)
+    sys.stdout.flush()
+
+def _shutdown_slaves():
+    global OGGM_MPI_COMM
+    if OGGM_MPI_COMM is not None and OGGM_MPI_COMM != MPI.COMM_NULL:
+        msgs = [StopIteration] * OGGM_MPI_SIZE
+        status = MPI.Status()
+        OGGM_MPI_COMM.bcast((None, None), root=OGGM_MPI_ROOT)
+        for msg in msgs:
+            OGGM_MPI_COMM.recv(source=MPI.ANY_SOURCE, status=status)
+            OGGM_MPI_COMM.send(obj=msg, dest=status.Get_source())
+        OGGM_MPI_COMM.gather(sendobj=None, root=OGGM_MPI_ROOT)
+    OGGM_MPI_COMM = None
+
+def _init_oggm_mpi():
+    global OGGM_MPI_COMM, OGGM_MPI_SIZE
+
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument('--mpi-help', action='help', help='Prints this help text')
+    parser.add_argument('--mpi', action='store_true', help='Run OGGM in mpi mode')
+    args, unkn = parser.parse_known_args()
+
+    if not args.mpi:
+        return
+
+    OGGM_MPI_COMM = MPI.COMM_WORLD
+    OGGM_MPI_SIZE = OGGM_MPI_COMM.Get_size() - 1
+    rank          = OGGM_MPI_COMM.Get_rank()
+
+    if OGGM_MPI_SIZE <= 0:
+        _imprint("Error: MPI world size is too small, at least one worker process is required.")
+        sys.exit(1)
+
+    if rank != OGGM_MPI_ROOT:
+        _mpi_slave()
+        sys.exit(0)
+
+    if OGGM_MPI_SIZE < 2:
+        _imprint("Warning: MPI world size is small, this is pointless and has no benefit.")
+
+    atexit.register(_shutdown_slaves)
+
+    _imprint("MPI initialized with a worker count of %s" % OGGM_MPI_SIZE)
+
+
+def mpi_master_spin_tasks(task, gdirs):
+    comm = OGGM_MPI_COMM
+    cfg_store = cfg.pack_config()
+    msg_list = [gdir for gdir in gdirs if gdir is not None] + ([None] * OGGM_MPI_SIZE)
+
+    _imprint("Starting MPI task distribution...")
+
+    comm.bcast((cfg_store, task), root=OGGM_MPI_ROOT)
+
+    status = MPI.Status()
+    for msg in msg_list:
+        comm.recv(source=MPI.ANY_SOURCE, status=status)
+        comm.send(obj=msg, dest=status.Get_source())
+
+    _imprint("MPI task distribution done, collecting results...")
+
+    comm.gather(sendobj=None, root=OGGM_MPI_ROOT)
+
+    _imprint("MPI task results gotten!")
+
+
+def _mpi_slave_bcast(comm):
+    cfg_store, task_func = comm.bcast(None, root=OGGM_MPI_ROOT)
+    if cfg_store is not None:
+        cfg.unpack_config(cfg_store)
+    return task_func
+
+def _mpi_slave():
+    comm = OGGM_MPI_COMM
+    rank = comm.Get_rank()
+
+    _imprint("MPI worker %s ready!" % rank)
+
+    task_func = _mpi_slave_bcast(comm)
+    for task in iter(lambda: comm.sendrecv("dummy", dest=OGGM_MPI_ROOT), StopIteration):
+        if task is None:
+            comm.gather(sendobj="TASK_DONE", root=OGGM_MPI_ROOT)
+            task_func = _mpi_slave_bcast(comm)
+            continue
+        task_func(task)
+    comm.gather(sendobj="WORKER_SHUTDOWN", root=OGGM_MPI_ROOT)
+
+    _imprint("MPI Worker %s exiting" % rank)
+    sys.exit(0)

--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -81,6 +81,7 @@ def _urlretrieve(url, ofile, *args, **kwargs):
 
 def progress_urlretrieve(url, ofile):
     print("Downloading %s ..." % url)
+    sys.stdout.flush()
     try:
         from progressbar import DataTransferBar, UnknownLength
         pbar = DataTransferBar()
@@ -91,6 +92,7 @@ def progress_urlretrieve(url, ofile):
                 else:
                     pbar.start(UnknownLength)
             pbar.update(min(count * size, total))
+            sys.stdout.flush()
         res = _urlretrieve(url, ofile, reporthook=_upd)
         try:
             pbar.finish()

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -22,26 +22,12 @@ log = logging.getLogger(__name__)
 def _init_pool_globals(_dl_lock, _cfg_contents):
     global download_lock
     download_lock = _dl_lock
-
-    for v, c in _cfg_contents:
-        setattr(cfg, v, c)
+    cfg.unpack_config(_cfg_contents)
 
 
 def _init_pool():
     """Necessary because at import time, cfg might be unitialized"""
-
-    cfg_variables = [
-        'IS_INITIALIZED',
-        'CONTINUE_ON_ERROR',
-        'PARAMS',
-        'PATHS',
-        'BASENAMES'
-    ]
-
-    cfg_contents = []
-    for v in cfg_variables:
-        cfg_contents.append((v, getattr(cfg, v)))
-
+    cfg_contents = cfg.pack_config()
     return mp.Pool(cfg.PARAMS['mp_processes'], initializer=_init_pool_globals, initargs=(download_lock, cfg_contents))
 
 

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -12,7 +12,6 @@ import multiprocessing as mp
 # Locals
 import oggm
 from oggm import cfg, tasks, utils
-from oggm.utils import download_lock
 
 # MPI
 try:
@@ -25,16 +24,14 @@ except ImportError:
 log = logging.getLogger(__name__)
 
 
-def _init_pool_globals(_dl_lock, _cfg_contents):
-    global download_lock
-    download_lock = _dl_lock
+def _init_pool_globals(_cfg_contents):
     cfg.unpack_config(_cfg_contents)
 
 
 def _init_pool():
     """Necessary because at import time, cfg might be unitialized"""
     cfg_contents = cfg.pack_config()
-    return mp.Pool(cfg.PARAMS['mp_processes'], initializer=_init_pool_globals, initargs=(download_lock, cfg_contents))
+    return mp.Pool(cfg.PARAMS['mp_processes'], initializer=_init_pool_globals, initargs=(cfg_contents,))
 
 
 class _pickle_copier(object):

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -14,6 +14,12 @@ import oggm
 from oggm import cfg, tasks, utils
 from oggm.utils import download_lock
 
+# MPI
+try:
+    import oggm.mpi as ogmpi
+    _have_ogmpi = True
+except ImportError:
+    _have_ogmpi = False
 
 # Module logger
 log = logging.getLogger(__name__)
@@ -56,6 +62,11 @@ def execute_entity_task(task, gdirs, **kwargs):
     gdirs: list
         the list of oggm.GlacierDirectory to process
     """
+
+    if _have_ogmpi:
+        if ogmpi.OGGM_MPI_COMM is not None:
+            ogmpi.mpi_master_spin_tasks(_pickle_copier(task, **kwargs), gdirs)
+            return
 
     if cfg.PARAMS['use_multiprocessing']:
         mppool = _init_pool()

--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,8 @@ req_packages = ['six',
                 'configobj',
                 'nose',
                 'xarray',
-                'progressbar2']
+                'progressbar2',
+                'filelock']
 check_dependencies(req_packages)
 
 


### PR DESCRIPTION
Adds support for distributing tasks via MPI.
MPI allows for distributing the tasks across multiple hosts.
Primarily used on clusters and similar environments.

Usage:
`mpiexec python3 ./run_rgi_region.py --mpi-master --mpi-count=16`

One limitation of this is the lack of a common lock for safe downloads.
And it seems like nothing like this exists, so preventing accidental parallel downloads of the same file is not possible with the current approach.

I'll look into implementing a fetch-only run, that doesn't do any calculation and just downloads all the required data, if that's possible at all.