### PR TITLE
Various MPI related improvements

### DIFF
--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -237,6 +237,7 @@ def initialize(file=None):
     PARAMS['topo_interp'] = cp['topo_interp']
     PARAMS['use_divides'] = cp.as_bool('use_divides')
     PARAMS['use_compression'] = cp.as_bool('use_compression')
+    PARAMS['mpi_recv_buf_size'] = cp.as_int('mpi_recv_buf_size')
     PARAMS['use_multiple_flowlines'] = cp.as_bool('use_multiple_flowlines')
     PARAMS['optimize_thick'] = cp.as_bool('optimize_thick')
 
@@ -263,7 +264,7 @@ def initialize(file=None):
            'topo_interp', 'use_compression', 'bed_shape', 'continue_on_error',
            'use_optimized_inversion_params', 'invert_with_sliding', 'rgi_dir',
            'optimize_inversion_params' , 'use_multiple_flowlines',
-           'leclercq_rgi_links', 'optimize_thick']
+           'leclercq_rgi_links', 'optimize_thick', 'mpi_recv_buf_size']
     for k in ltr:
         del cp[k]
 

--- a/oggm/mpi.py
+++ b/oggm/mpi.py
@@ -85,8 +85,13 @@ def _mpi_slave_bcast(comm):
     return task_func
 
 def _mpi_slave_sendrecv(comm):
+    try:
+        bufsize = int(cfg.PARAMS['mpi_recv_buf_size'])
+    except:
+        bufsize = None
+
     sreq = comm.isend(1, dest=OGGM_MPI_ROOT)
-    rreq = comm.irecv(source=OGGM_MPI_ROOT)
+    rreq = comm.irecv(source=OGGM_MPI_ROOT, buf=bufsize)
     return sreq, rreq
 
 def _mpi_slave():

--- a/oggm/mpi.py
+++ b/oggm/mpi.py
@@ -84,6 +84,11 @@ def _mpi_slave_bcast(comm):
         cfg.unpack_config(cfg_store)
     return task_func
 
+def _mpi_slave_sendrecv(comm):
+    sreq = comm.isend(1, dest=OGGM_MPI_ROOT)
+    rreq = comm.irecv(source=OGGM_MPI_ROOT)
+    return sreq, rreq
+
 def _mpi_slave():
     comm = OGGM_MPI_COMM
     rank = comm.Get_rank()
@@ -91,11 +96,19 @@ def _mpi_slave():
     _imprint("MPI worker %s ready!" % rank)
 
     task_func = _mpi_slave_bcast(comm)
-    for task in iter(lambda: comm.sendrecv("dummy", dest=OGGM_MPI_ROOT), StopIteration):
+    sreq, rreq = _mpi_slave_sendrecv(comm)
+
+    while True:
+        sreq.wait()
+        task = rreq.wait()
         if task is None:
             comm.gather(sendobj="TASK_DONE", root=OGGM_MPI_ROOT)
             task_func = _mpi_slave_bcast(comm)
+            sreq, rreq = _mpi_slave_sendrecv(comm)
             continue
+        elif task is StopIteration:
+            break
+        sreq, rreq = _mpi_slave_sendrecv(comm)
         task_func(task)
     comm.gather(sendobj="WORKER_SHUTDOWN", root=OGGM_MPI_ROOT)
 

--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -60,6 +60,10 @@ continue_on_error = False
 # Both the performance loss (0% ?) and the space gain (-10%) seem to be low
 use_compression = True
 
+# MPI recv buffer size
+# If you receive "Message truncated" errors from MPI, increase this
+mpi_recv_buf_size = 131072
+
 ### CENTERLINE determination
 
 # Decision on grid spatial resolution for each glacier

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -107,11 +107,14 @@ def init_glacier_regions(rgidf, reset=False, force=False):
             rmtree(fpath)
 
     gdirs = []
+    new_gdirs = []
     for _, entity in rgidf.iterrows():
         gdir = oggm.GlacierDirectory(entity, reset=reset)
         if not os.path.exists(gdir.get_filepath('dem')):
-            tasks.define_glacier_region(gdir, entity=entity)
+            new_gdirs.append((gdir, dict(entity=entity)))
         gdirs.append(gdir)
+
+    execute_entity_task(tasks.define_glacier_region, new_gdirs)
 
     return gdirs
 

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -5,6 +5,7 @@ from __future__ import division
 import logging
 import os
 from shutil import rmtree
+import collections
 # External libs
 import pandas as pd
 import multiprocessing as mp
@@ -34,17 +35,29 @@ def _init_pool():
     return mp.Pool(cfg.PARAMS['mp_processes'], initializer=_init_pool_globals, initargs=(cfg_contents,))
 
 
+def _merge_dicts(*dicts):
+    r = {}
+    for d in dicts:
+        r.update(d)
+    return r
+
+
 class _pickle_copier(object):
     """Pickleable alternative to functools.partial,
     Which is not pickleable in python2 and thus doesn't work
     with Multiprocessing."""
 
-    def __init__(self, func, **kwargs):
+    def __init__(self, func, kwargs):
         self.call_func = func
         self.out_kwargs = kwargs
 
     def __call__(self, gdir):
-        return self.call_func(gdir, **self.out_kwargs)
+        if isinstance(gdir, collections.Sequence):
+            gdir, gdir_kwargs = gdir
+            gdir_kwargs = _merge_dicts(self.out_kwargs, gdir_kwargs)
+            return self.call_func(gdir, **gdir_kwargs)
+        else:
+            return self.call_func(gdir, **self.out_kwargs)
 
 
 def execute_entity_task(task, gdirs, **kwargs):
@@ -58,19 +71,24 @@ def execute_entity_task(task, gdirs, **kwargs):
         the entity task to apply
     gdirs: list
         the list of oggm.GlacierDirectory to process
+        optionally, each list element can be a tuple, with the first element being
+        the oggm.GlacierDirectory, and the second element a dict that will be passed
+        to the task function as **kwargs.
     """
+
+    pc = _pickle_copier(task, kwargs)
 
     if _have_ogmpi:
         if ogmpi.OGGM_MPI_COMM is not None:
-            ogmpi.mpi_master_spin_tasks(_pickle_copier(task, **kwargs), gdirs)
+            ogmpi.mpi_master_spin_tasks(pc, gdirs)
             return
 
     if cfg.PARAMS['use_multiprocessing']:
         mppool = _init_pool()
-        mppool.map(_pickle_copier(task, **kwargs), gdirs, chunksize=1)
+        mppool.map(pc, gdirs, chunksize=1)
     else:
         for gdir in gdirs:
-            task(gdir, **kwargs)
+            pc(gdir)
 
 
 def init_glacier_regions(rgidf, reset=False, force=False):


### PR DESCRIPTION
Use async recv/send functions in the slave process, so it can receive the next task in the background while the task is calculating, greatly reducing idle times.

Add some helper functions to speed up setting up an MPI-Capable cluster on multiple AWS nodes to our fabfile.

Improve overall parallelization, by making init_glacier_regions parallel as well.
For this to work, execute_entity_task was extended with a mode for per-gdir kwargs.

Add a cfg setting for the mpi recv buffer size. The default size is too small to hold some of the parameters.
So instead of hardcoding a higher guess, I made it available as config parameter, with the default being high enough for the entire rgi region test script.