### PR TITLE
Various Updates for File-Downloads

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ install:
 
   # install dependencies
   - "python -m pip install --upgrade pip"
-  - "conda install --yes --quiet -c conda-forge geopandas matplotlib Pillow joblib netCDF4 scikit-image configobj pytest pyproj numpy rasterio krb5 xarray filelock"
+  - "conda install --yes --quiet -c conda-forge geopandas matplotlib Pillow joblib netCDF4 scikit-image configobj pytest pyproj numpy rasterio krb5 xarray boto3"
   - "pip install motionless"
   - "pip install git+https://github.com/fmaussion/salem.git"
   - "pip install -e ."

--- a/deployment/fabfile.py
+++ b/deployment/fabfile.py
@@ -594,7 +594,7 @@ def install_node_pip(nn='', inst=None):
     pip install gdal==1.11.2 --install-option="build_ext" --install-option="--include-dirs=/usr/include/gdal" &&
     pip install fiona --install-option="build_ext" --install-option="--include-dirs=/usr/include/gdal" &&
     pip install mpi4py &&
-    pip install pyproj rasterio Pillow geopandas netcdf4 scikit-image configobj joblib xarray filelock motionless pytest progressbar2 &&
+    pip install pyproj rasterio Pillow geopandas netcdf4 scikit-image configobj joblib xarray boto3 motionless pytest progressbar2 &&
     pip install git+https://github.com/fmaussion/salem.git &&
     sed -i 's/^backend.*/backend      : Agg/' "${WORKON_HOME}"/oggm_env/lib/python?.?/site-packages/matplotlib/mpl-data/matplotlibrc
     """, pty=False)

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - geos=3.5.0 # https://github.com/conda-forge/fiona-feedstock/issues/21
   - rasterio=1.0a7
   - xarray=0.9.1
-  - filelock
+  - boto3
   - numpydoc
   - ipython=5.3.0
   - sphinx=1.3.5  # because RTD installs this version anyway

--- a/docs/installing-oggm.rst
+++ b/docs/installing-oggm.rst
@@ -65,7 +65,7 @@ Testing:
     - pytest
 
 Other libraries:
-    - filelock
+    - boto3
     - `salem <https://github.com/fmaussion/salem>`_
     - `motionless <https://github.com/ryancox/motionless/>`_
 
@@ -314,7 +314,7 @@ If no matching distribution could be found for your gdal version, try out a vers
 
 Install further stuffs::
 
-    $ pip install pyproj rasterio Pillow geopandas netcdf4 scikit-image configobj joblib xarray filelock progressbar2 pytest motionless
+    $ pip install pyproj rasterio Pillow geopandas netcdf4 scikit-image configobj joblib xarray boto3 progressbar2 pytest motionless
 
 And the salem library::
 

--- a/oggm/__init__.py
+++ b/oggm/__init__.py
@@ -20,7 +20,6 @@ except ImportError:  # pragma: no cover
 logging.getLogger("Fiona").setLevel(logging.WARNING)
 logging.getLogger("shapely").setLevel(logging.WARNING)
 logging.getLogger("rasterio").setLevel(logging.WARNING)
-logging.getLogger("filelock").setLevel(logging.WARNING)
 
 # Basic config
 logging.basicConfig(format='%(asctime)s: %(name)s: %(message)s',

--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -225,10 +225,6 @@ def initialize(file=None):
     global RGI_REG_NAMES
     global RGI_SUBREG_NAMES
 
-    # Make sure we have a proper cache dir
-    from oggm.utils import _download_oggm_files
-    _download_oggm_files()
-
     if file is None:
         file = os.path.join(os.path.abspath(os.path.dirname(__file__)),
                             'params.cfg')
@@ -252,6 +248,17 @@ def initialize(file=None):
         cp['cru_dir'] = os.path.join(homedir, 'OGGM_data', 'cru')
     if cp['rgi_dir'] == '~':
         cp['rgi_dir'] = os.path.join(homedir, 'OGGM_data', 'rgi')
+
+    # Setup Download-Cache-Dir
+    if os.environ.get('OGGM_DOWNLOAD_CACHE') is not None:
+        cp['dl_cache_dir'] = os.environ.get('OGGM_DOWNLOAD_CACHE')
+    PATHS['dl_cache_dir'] = cp['dl_cache_dir']
+    if PATHS['dl_cache_dir'] and not os.path.exists(PATHS['dl_cache_dir']):
+        os.makedirs(PATHS['dl_cache_dir'])
+
+    # Make sure we have a proper cache dir
+    from oggm.utils import _download_oggm_files
+    _download_oggm_files()
 
     # Parse RGI metadata
     _d = os.path.join(CACHE_DIR, 'oggm-sample-data-master', 'rgi_meta')
@@ -321,7 +328,7 @@ def initialize(file=None):
            'optimize_inversion_params', 'use_multiple_flowlines',
            'leclercq_rgi_links', 'optimize_thick', 'mpi_recv_buf_size',
            'tstar_search_window', 'use_bias_for_run', 'run_period',
-           'prcp_scaling_factor', 'use_intersects']
+           'prcp_scaling_factor', 'use_intersects', 'dl_cache_dir']
     for k in ltr:
         del cp[k]
 
@@ -338,11 +345,11 @@ def initialize(file=None):
 
 def get_lru_handler(tmpdir=None, maxsize=100, ending='.tif'):
     """LRU handler for a given temporary directory (singleton).
-    
+
     Parameters
     ----------
     tmpdir : str
-        path to the temporary directory to handle. Default is "tmp" in the 
+        path to the temporary directory to handle. Default is "tmp" in the
         working directory.
     maxsize : int
         the max number of files to keep in the directory

--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -10,6 +10,7 @@ import shutil
 import sys
 import glob
 from collections import OrderedDict
+from distutils.util import strtobool
 
 import numpy as np
 import pandas as pd
@@ -250,11 +251,17 @@ def initialize(file=None):
         cp['rgi_dir'] = os.path.join(homedir, 'OGGM_data', 'rgi')
 
     # Setup Download-Cache-Dir
+    if os.environ.get('OGGM_DOWNLOAD_CACHE_RO') is not None:
+        cp['dl_cache_readonly'] = bool(strtobool(os.environ.get('OGGM_DOWNLOAD_CACHE_RO')))
     if os.environ.get('OGGM_DOWNLOAD_CACHE') is not None:
         cp['dl_cache_dir'] = os.environ.get('OGGM_DOWNLOAD_CACHE')
+
     PATHS['dl_cache_dir'] = cp['dl_cache_dir']
+    PARAMS['dl_cache_readonly'] = cp.as_bool('dl_cache_readonly')
+
     if PATHS['dl_cache_dir'] and not os.path.exists(PATHS['dl_cache_dir']):
-        os.makedirs(PATHS['dl_cache_dir'])
+        if not PARAMS['dl_cache_readonly']:
+            os.makedirs(PATHS['dl_cache_dir'])
 
     # Make sure we have a proper cache dir
     from oggm.utils import _download_oggm_files
@@ -328,7 +335,8 @@ def initialize(file=None):
            'optimize_inversion_params', 'use_multiple_flowlines',
            'leclercq_rgi_links', 'optimize_thick', 'mpi_recv_buf_size',
            'tstar_search_window', 'use_bias_for_run', 'run_period',
-           'prcp_scaling_factor', 'use_intersects', 'dl_cache_dir']
+           'prcp_scaling_factor', 'use_intersects',
+           'dl_cache_dir', 'dl_cache_readonly']
     for k in ltr:
         del cp[k]
 

--- a/oggm/core/preprocessing/climate.py
+++ b/oggm/core/preprocessing/climate.py
@@ -1025,6 +1025,7 @@ def compute_ref_t_stars(gdirs):
     df['prcp_fac'] = prcp_facs
     df['bias'] = biases
     file = os.path.join(cfg.PATHS['working_dir'], 'ref_tstars.csv')
+    utils.mkdir(cfg.PATHS['working_dir'])
     df.sort_index().to_csv(file)
 
 

--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -17,6 +17,12 @@ cru_dir = ~
 # download the data
 rgi_dir = ~
 
+# Cache directory for downloads. If set, all downloaded data will be stored here
+# initially. If a file requested for download is present in the cache, it will be
+# copied from there instead of downloaded again.
+# Can be overridden via OGGM_DOWNLOAD_CACHE environment variable.
+dl_cache_dir =
+
 # Users can specify their own topography file if they want to. In this case,
 # the topo_dir above will be ignored. This is useful for testing, or if you
 # are simulating a single region with better data.

--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -23,6 +23,12 @@ rgi_dir = ~
 # Can be overridden via OGGM_DOWNLOAD_CACHE environment variable.
 dl_cache_dir =
 
+# Set to True if the download cache is readonly.
+# Downloads will be written to their normal location if neccessary.
+# Alternatively set the OGGM_DOWNLOAD_CACHE_RO environment variable to indicate
+# a read-only cache dir.
+dl_cache_readonly = False
+
 # Users can specify their own topography file if they want to. In this case,
 # the topo_dir above will be ignored. This is useful for testing, or if you
 # are simulating a single region with better data.

--- a/oggm/sandbox/run_demtests.py
+++ b/oggm/sandbox/run_demtests.py
@@ -6,7 +6,6 @@ import logging
 
 logging.getLogger("rasterio").setLevel(logging.WARNING)
 logging.getLogger("shapely").setLevel(logging.WARNING)
-logging.getLogger("filelock").setLevel(logging.WARNING)
 
 logging.basicConfig(format='%(asctime)s: %(name)s: %(message)s',
                     datefmt='%Y-%m-%d %H:%M:%S', level=logging.DEBUG)

--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -116,8 +116,7 @@ def _urlretrieve(url, ofile, *args, **kwargs):
 
 
 def progress_urlretrieve(url, ofile):
-    print("Downloading %s ..." % url)
-    sys.stdout.flush()
+    logging.getLogger('download').info("Downloading %s ..." % url)
     try:
         from progressbar import DataTransferBar, UnknownLength
         pbar = DataTransferBar()
@@ -588,10 +587,12 @@ def _aws_file_download_unlocked(aws_path, local_path, reset=False):
     if reset and os.path.exists(local_path):
         os.remove(local_path)
 
-    cmd = 'aws --region eu-west-1 s3 cp s3://astgtmv2/'
-    cmd = cmd + aws_path + ' ' + local_path
     if not os.path.exists(local_path):
-        subprocess.call(cmd, shell=True)
+        import boto3
+        client = boto3.client('s3')
+        logging.getLogger('download').info("Downloading %s from s3..." % aws_path)
+        client.download_file('astgtmv2', aws_path, local_path)
+
     if not os.path.exists(local_path):
         raise RuntimeError('Something went wrong with the download')
 

--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -222,17 +222,17 @@ class SuperclassMeta(type):
 
 class LRUFileCache():
     """A least recently used cache for temporary files.
-    
+
     The files which are no longer used are deleted from the disk.
     """
     def __init__(self, l0=None, maxsize=100):
         """Instanciate.
-        
+
         Parameters
         ----------
         l0 : list
             a list of file paths
-        maxsize : int 
+        maxsize : int
             the max number of files to keep
         """
         self.files = [] if l0 is None else l0
@@ -1417,9 +1417,9 @@ def get_topo_file(lon_ex, lat_ex, rgi_region=None, source=None):
 
 
 def compile_run_output(gdirs, filesuffix=''):
-    """Merge the runs output of the glacier directories into one file. 
-    
-    
+    """Merge the runs output of the glacier directories into one file.
+
+
     Parameters
     ----------
     gdirs: the list of GlacierDir to process.
@@ -1940,7 +1940,7 @@ class GlacierDirectory(object):
         delete : bool
             delete the file if exists
         filesuffix : str
-            append a suffix to the filename (useful for model runs). Note 
+            append a suffix to the filename (useful for model runs). Note
             that the BASENAME remains same.
 
         Returns

--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -44,7 +44,6 @@ try:
 except ImportError:
     from rasterio.tools.merge import merge as merge_tool
 import multiprocessing as mp
-import filelock
 
 # Locals
 import oggm.cfg as cfg
@@ -80,18 +79,12 @@ MEMORY = Memory(cachedir=cfg.CACHE_DIR, verbose=0)
 # Function
 tuple2int = partial(np.array, dtype=np.int64)
 
+# Global Lock
+lock = mp.Lock()
+
 
 def _get_download_lock():
-    try:
-        lock_dir = cfg.PATHS['working_dir']
-    except:
-        lock_dir = cfg.CACHE_DIR
-    mkdir(lock_dir)
-    lockfile = os.path.join(lock_dir, 'oggm_data_download.lock')
-    try:
-        return filelock.FileLock(lockfile).acquire()
-    except:
-        return filelock.SoftFileLock(lockfile).acquire()
+    return lock
 
 
 def _urlretrieve(url, ofile, *args, **kwargs):

--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -491,12 +491,8 @@ def _download_aster_file_unlocked(zone, unit):
     mkdir(tmpdir)
     outpath = os.path.join(tmpdir, 'ASTGTM2_' + zone + '_dem.tif')
 
-    cmd = 'aws --region eu-west-1 s3 cp s3://astgtmv2/ASTGTM_V2/'
-    cmd = cmd + dirbname + '/' + fbname + ' ' + dfile
-
-    if not os.path.exists(dfile):
-        print('Downloading ' + fbname + ' from AWS s3...')
-        subprocess.call(cmd, shell=True)
+    aws_path = 'ASTGTM_V2/' + dirbname + '/' + fbname
+    _aws_file_download_unlocked(aws_path, dfile)
 
     if os.path.exists(dfile):
         # Ok so the tile is a valid one
@@ -538,11 +534,8 @@ def _download_alternate_topo_file_unlocked(fname):
     mkdir(tmpdir)
     outpath = os.path.join(tmpdir, fname)
 
-    cmd = 'aws --region eu-west-1 s3 cp s3://astgtmv2/topo/'
-    cmd = cmd + fname + '.zip' + ' ' + dfile
-    if not os.path.exists(dfile):
-        print('Downloading ' + fname + '.zip' + ' from AWS s3...')
-        subprocess.call(cmd, shell=True)
+    aws_path = 'topo/' + fname + '.zip'
+    _aws_file_download_unlocked(aws_path, dfile)
 
     if not os.path.exists(outpath):
         print('Extracting ' + fname + '.zip ...')

--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -95,6 +95,7 @@ def _get_download_lock():
 
 
 def _urlretrieve(url, ofile, *args, **kwargs):
+    p = None
     try:
         cache_dir = cfg.PATHS['dl_cache_dir']
         if cache_dir and os.path.isdir(cache_dir):
@@ -112,6 +113,8 @@ def _urlretrieve(url, ofile, *args, **kwargs):
     except:
         if os.path.exists(ofile):
             os.remove(ofile)
+        if p and os.path.exists(p):
+            os.remove(p)
         raise
 
 

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -24,6 +24,9 @@ except ImportError:
 # Module logger
 log = logging.getLogger(__name__)
 
+# Multiprocessing Pool
+_mp_pool = None
+
 
 def _init_pool_globals(_cfg_contents, global_lock):
     cfg.unpack_config(_cfg_contents)
@@ -32,12 +35,16 @@ def _init_pool_globals(_cfg_contents, global_lock):
 
 def _init_pool():
     """Necessary because at import time, cfg might be unitialized"""
+    global _mp_pool
+    if _mp_pool:
+        return _mp_pool
     cfg_contents = cfg.pack_config()
     global_lock = mp.Manager().Lock()
     mpp = cfg.PARAMS['mp_processes']
     mpp = None if mpp == -1 else mpp
-    return mp.Pool(mpp, initializer=_init_pool_globals,
-                   initargs=(cfg_contents, global_lock))
+    _mp_pool = mp.Pool(mpp, initializer=_init_pool_globals,
+                       initargs=(cfg_contents, global_lock))
+    return _mp_pool
 
 
 def _merge_dicts(*dicts):

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -72,6 +72,18 @@ class _pickle_copier(object):
             return self.call_func(gdir, **self.out_kwargs)
 
 
+def reset_multiprocessing():
+    """Reset multiprocessing state
+
+    Call this if you changed configuration parameters mid-run and need them to
+    be re-propagated to child processes.
+    """
+    global _mp_pool
+    if _mp_pool:
+        _mp_pool.terminate()
+        _mp_pool = None
+
+
 def execute_entity_task(task, gdirs, **kwargs):
     """Execute a task on gdirs.
 

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -25,17 +25,19 @@ except ImportError:
 log = logging.getLogger(__name__)
 
 
-def _init_pool_globals(_cfg_contents):
+def _init_pool_globals(_cfg_contents, global_lock):
     cfg.unpack_config(_cfg_contents)
+    utils.lock = global_lock
 
 
 def _init_pool():
     """Necessary because at import time, cfg might be unitialized"""
     cfg_contents = cfg.pack_config()
+    global_lock = mp.Manager().Lock()
     mpp = cfg.PARAMS['mp_processes']
     mpp = None if mpp == -1 else mpp
     return mp.Pool(mpp, initializer=_init_pool_globals,
-                   initargs=(cfg_contents,))
+                   initargs=(cfg_contents, global_lock))
 
 
 def _merge_dicts(*dicts):

--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,8 @@ req_packages = ['six',
                 'pytest',
                 'xarray',
                 'progressbar2',
-                'filelock']
+                'filelock',
+                'boto3']
 check_dependencies(req_packages)
 
 

--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,6 @@ req_packages = ['six',
                 'pytest',
                 'xarray',
                 'progressbar2',
-                'filelock',
                 'boto3']
 check_dependencies(req_packages)
 


### PR DESCRIPTION
Offer a global Cache-Directory for all Downloads.
This enables easy Download-Caching on Travis and HLRN.

Switches to using boto3 for downloads from S3. Calling a command-line utility is not pretty, specially when there is an official library for the job.
Nothing changed about setting credentials for it.

Get rid of the FileLock. Specially on Windows, it's not working too great, getting stuck every once in a while.
This now uses a SyncManager from multiprocessing, which should work everywhere.