### PR TITLE
Further Updates for Download-Cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ branches:  # blacklist
     - appveyor
     - docs
 
+cache:
+  directories:
+    - $HOME/dl_cache
+
 matrix:
   fast_finish: true
   include:
@@ -34,9 +38,12 @@ install:
     coveralls || true
     exit 0
     EOF
-  - docker create --name oggm_travis -ti -e OGGM_ENV -e CI -e TRAVIS -e TRAVIS_JOB_ID -e TRAVIS_BRANCH -e TRAVIS_PULL_REQUEST oggm/untested_base:latest /bin/bash /root/oggm/test.sh
+  - mkdir -p $HOME/dl_cache
+  - export OGGM_DOWNLOAD_CACHE=/dl_cache
+  - docker create --name oggm_travis -ti -v $HOME/dl_cache:/dl_cache -e OGGM_DOWNLOAD_CACHE -e OGGM_ENV -e CI -e TRAVIS -e TRAVIS_JOB_ID -e TRAVIS_BRANCH -e TRAVIS_PULL_REQUEST oggm/untested_base:latest /bin/bash /root/oggm/test.sh
   - docker cp $PWD oggm_travis:/root/oggm
 script:
+  - export OGGM_DOWNLOAD_CACHE=/dl_cache
   - docker start -ai oggm_travis
 after_script:
   - docker rm oggm_travis

--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -263,17 +263,6 @@ def initialize(file=None):
         if not PARAMS['dl_cache_readonly']:
             os.makedirs(PATHS['dl_cache_dir'])
 
-    # Make sure we have a proper cache dir
-    from oggm.utils import _download_oggm_files
-    _download_oggm_files()
-
-    # Parse RGI metadata
-    _d = os.path.join(CACHE_DIR, 'oggm-sample-data-master', 'rgi_meta')
-    RGI_REG_NAMES = pd.read_csv(os.path.join(_d, 'rgi_regions.csv'),
-                                index_col=0)
-    RGI_SUBREG_NAMES = pd.read_csv(os.path.join(_d, 'rgi_subregions.csv'),
-                                   index_col=0)
-
     CONTINUE_ON_ERROR = cp.as_bool('continue_on_error')
 
     PATHS['working_dir'] = cp['working_dir']
@@ -324,6 +313,17 @@ def initialize(file=None):
     PARAMS['bed_shape'] = cp['bed_shape']
     _k = 'use_optimized_inversion_params'
     PARAMS[_k] = cp.as_bool(_k)
+
+    # Make sure we have a proper cache dir
+    from oggm.utils import _download_oggm_files
+    _download_oggm_files()
+
+    # Parse RGI metadata
+    _d = os.path.join(CACHE_DIR, 'oggm-sample-data-master', 'rgi_meta')
+    RGI_REG_NAMES = pd.read_csv(os.path.join(_d, 'rgi_regions.csv'),
+                                index_col=0)
+    RGI_SUBREG_NAMES = pd.read_csv(os.path.join(_d, 'rgi_subregions.csv'),
+                                   index_col=0)
 
     # Delete non-floats
     ltr = ['working_dir', 'dem_file', 'climate_file', 'wgms_rgi_links',

--- a/oggm/sandbox/run_alps.py
+++ b/oggm/sandbox/run_alps.py
@@ -42,8 +42,9 @@ cfg.PATHS['rgi_dir'] = os.path.join(DATA_DIR, 'rgi')
 
 # Climate file
 hist_path = os.path.join(DATA_DIR, 'histalp_merged_with_cru_hydro_yrs.nc')
-utils.aws_file_download('alps/histalp_merged_with_cru_hydro_yrs.nc',
-                        hist_path, reset=False)
+dl_hist_path = utils.aws_file_download('alps/histalp_merged_with_cru_hydro_yrs.nc')
+shutil.copy(dl_hist_path, hist_path)
+
 cfg.PATHS['cru_dir'] = '~'
 cfg.PATHS['climate_file'] = hist_path
 
@@ -72,8 +73,7 @@ cfg.PARAMS['optimize_thick'] = True
 cfg.PARAMS['force_one_flowline'] = ['RGI50-11.01270']
 
 # Read in the Alps RGI file
-rgi_pkl_path = os.path.join(DATA_DIR, 'rgi_ref_alps.pkl')
-utils.aws_file_download('alps/rgi_ref_alps.pkl', rgi_pkl_path, reset=False)
+rgi_pkl_path = utils.aws_file_download('alps/rgi_ref_alps.pkl')
 rgidf = pd.read_pickle(rgi_pkl_path)
 
 log.info('Number of glaciers: {}'.format(len(rgidf)))

--- a/oggm/sandbox/run_benchmark.py
+++ b/oggm/sandbox/run_benchmark.py
@@ -53,8 +53,7 @@ cfg.PARAMS['use_multiprocessing'] = True
 cfg.CONTINUE_ON_ERROR = False
 
 # Read in the Benchmark RGI file
-rgi_pkl_path = os.path.join(DATA_DIR, 'rgi_benchmark.pkl')
-utils.aws_file_download('rgi_benchmark.pkl', rgi_pkl_path, reset=False)
+rgi_pkl_path = utils.aws_file_download('rgi_benchmark.pkl')
 rgidf = pd.read_pickle(rgi_pkl_path)
 
 log.info('Number of glaciers: {}'.format(len(rgidf)))


### PR DESCRIPTION
This changes the semantics of the two download-functions.
They don't take a destination path anymore, but instead return the path where they decided to download the file to, which is either the specified download cache dir, or a path inside of the configured working dir.

If a function then wants to make changes to the downloaded file, it should make a copy and not work on it in-place.
So far, nothing in the entire code base does that, so no additional copying is necessary.

Also makes use of the Cache on Travis now, so using Downloads in test should not be too horribly anymore now.