### PR TITLE
Inversion now takes ice divides into account

### DIFF
--- a/docs/_code/prepare_climate.py
+++ b/docs/_code/prepare_climate.py
@@ -66,8 +66,7 @@ res = t_star_from_refmb(gdir, mbdf.ANNUAL_BALANCE)
 # For the mass flux
 majid = gdir.read_pickle('major_divide', div_id=0)
 cl = gdir.read_pickle('inversion_input', div_id=majid)[-1]
-mbmod = ConstantMassBalanceModel(gdir, optim_zminmax=[np.min(cl['hgt'])-50,
-                                                      np.max(cl['hgt'])+50])
+mbmod = ConstantMassBalanceModel(gdir)
 mbx = mbmod.get_annual_mb(cl['hgt']) * cfg.SEC_IN_YEAR * cfg.RHO
 fdf = pd.DataFrame(index=np.arange(len(mbx))*cl['dx'])
 fdf['Flux'] = cl['flux']

--- a/docs/_code/prepare_climate.py
+++ b/docs/_code/prepare_climate.py
@@ -7,9 +7,11 @@ import xarray as xr
 import matplotlib.pyplot as plt
 from oggm import cfg, tasks
 from oggm.utils import get_demo_file
-from oggm.core.preprocessing.climate import mb_yearly_climate_on_glacier, \
-    t_star_from_refmb, local_mustar_apparent_mb
-from oggm.core.models.massbalance import PastMassBalanceModel
+from oggm.core.preprocessing.climate import (mb_yearly_climate_on_glacier,
+                                             t_star_from_refmb,
+                                             local_mustar_apparent_mb)
+from oggm.core.models.massbalance import (PastMassBalanceModel,
+                                          ConstantMassBalanceModel)
 
 cfg.initialize()
 cfg.PATHS['dem_file'] = get_demo_file('hef_srtm.tif')
@@ -23,6 +25,7 @@ gdir = oggm.GlacierDirectory(entity, base_dir=base_dir)
 tasks.define_glacier_region(gdir, entity=entity)
 tasks.glacier_masks(gdir)
 tasks.compute_centerlines(gdir)
+tasks.compute_downstream_lines(gdir)
 
 tasks.initialize_flowlines(gdir)
 tasks.catchment_area(gdir)
@@ -36,6 +39,9 @@ mbdf = gdir.get_ref_mb_data()
 res = t_star_from_refmb(gdir, mbdf.ANNUAL_BALANCE)
 local_mustar_apparent_mb(gdir, tstar=res['t_star'][-1], bias=res['bias'][-1],
                          prcp_fac=res['prcp_fac'])
+
+# For flux plot
+tasks.prepare_for_inversion(gdir, add_debug_var=True)
 
 # For plots
 mu_yr_clim = gdir.read_pickle('mu_candidates')[pcp_fac]
@@ -57,6 +63,16 @@ pdf[r'$\mu (t)$'] = mu_yr_clim
 pdf['bias'] = diff
 res = t_star_from_refmb(gdir, mbdf.ANNUAL_BALANCE)
 
+# For the mass flux
+majid = gdir.read_pickle('major_divide', div_id=0)
+cl = gdir.read_pickle('inversion_input', div_id=majid)[-1]
+mbmod = ConstantMassBalanceModel(gdir, optim_zminmax=[np.min(cl['hgt'])-50,
+                                                      np.max(cl['hgt'])+50])
+mbx = mbmod.get_annual_mb(cl['hgt']) * cfg.SEC_IN_YEAR * cfg.RHO
+fdf = pd.DataFrame(index=np.arange(len(mbx))*cl['dx'])
+fdf['Flux'] = cl['flux']
+fdf['Mass balance'] = mbx
+
 # plot functions
 def example_plot_temp_ts():
     d = xr.open_dataset(gdir.get_filepath('climate_monthly'))
@@ -70,12 +86,14 @@ def example_plot_temp_ts():
     plt.tight_layout()
     plt.show()
 
+
 def example_plot_mu_ts():
     ax = mu_yr_clim.plot(figsize=(8, 4), label=r'$\mu (t)$');
     plt.legend(loc='best'); plt.title(r'$\mu$ candidates Hintereisferner');
     plt.ylabel(r'$\mu$ (mm yr$^{-1}$ K$^{-1}$)')
     plt.tight_layout()
     plt.show()
+
 
 def example_plot_bias_ts():
     ax = pdf.plot(figsize=(8, 4), secondary_y='bias')
@@ -87,5 +105,18 @@ def example_plot_bias_ts():
     for ts in res['t_star']:
         plt.plot((ts, ts), (yl[0], 0), linestyle=':', color='grey')
     plt.ylim(yl)
+    plt.tight_layout()
+    plt.show()
+
+
+def example_plot_massflux():
+    fig, ax = plt.subplots(figsize=(8, 4))
+    fdf.plot(ax=ax, secondary_y='Mass balance', style=['C1-', 'C0-'])
+    plt.axhline(0., color='grey', linestyle=':')
+    ax.set_ylim([0, 0.18])
+    ax.set_ylabel('Flux [m$^3$ s$^{-1}$]')
+    ax.right_ax.set_ylabel('MB [kg m$^{-2}$ yr$^{-1}$]')
+    ax.set_xlabel('Distance along flowline (m)')
+    plt.title('Mass flux and mass balance along flowline')
     plt.tight_layout()
     plt.show()

--- a/docs/installing-oggm.rst
+++ b/docs/installing-oggm.rst
@@ -157,17 +157,16 @@ No scientific python installation is complete without installing
 OGGM
 ~~~~
 
-You can install OGGM as a normal python package (in that case you will be able
-to use the model but not change its code)::
+**If you are using conda**, you can install OGGM as a normal python package
+(in that case you will be able to use the model but you cannot change its
+code)::
 
     conda install -c oggm -c conda-forge oggm
 
-.. warning::
 
-    Skip the step above, if you are not working with a conda environment.
-
-We recommend to clone the git repository (or a fork if you want
-to participate to the development, see also :ref:`contributing`)::
+If you want to explore the code or participate to its
+development, we recommend to clone the git repository (or your own fork ,
+see also :ref:`contributing`)::
 
     git clone https://github.com/OGGM/oggm.git
 
@@ -175,7 +174,8 @@ Then go to the project root directory::
 
     cd oggm
 
-And install OGGM in development mode::
+And install OGGM in development mode (this is valid for **pip** or **conda**
+environments)::
 
     pip install -e .
 
@@ -184,9 +184,8 @@ And install OGGM in development mode::
 
     Installing OGGM in development mode means that subsequent changes to this
     code repository will be taken into account the next time you will
-    ``import oggm``. This means that you are going to
-    be able to update OGGM with a simple `git pull`_ from the head of the
-    cloned repository.
+    ``import oggm``. You can also update OGGM with a simple `git pull`_ from
+    the root of the cloned repository.
 
 .. _git pull: https://git-scm.com/docs/git-pull
 
@@ -199,7 +198,7 @@ expected. From the oggm directory, type::
 
     pytest .
 
-The tests can run for several minutes. If everything worked fine, you
+The tests can run for a couple of minutes. If everything worked fine, you
 should see something like::
 
     ==== test session starts ====
@@ -297,18 +296,21 @@ Install one by one the easy stuff::
 
    $ pip install numpy scipy pandas shapely matplotlib
 
-For **GDAL**, it's also not straight forward. First, check which version of
+For **GDAL**, it's not as straight forward. First, check which version of
 GDAL is installed::
 
-    $ dpkg -s libgdal-dev
+    $ dpkg -s libgdal-dev  | grep '^Version:'
 
-The version (10, 11, ...) should match that of the python package. Install
-using the system binaries::
+The major and minor package version (e.g. ``1.10``, ``1.11``, ...) should match
+that of the python package you want to install. For example, if the linux
+GDAL version is ``1.11.3``, install the latest corresponding python version
+(in this case, ``1.11.2``)::
 
-    $ pip install gdal==1.10.0 --install-option="build_ext" --install-option="--include-dirs=/usr/include/gdal"
+    $ pip install gdal==1.11.2 --install-option="build_ext" --install-option="--include-dirs=/usr/include/gdal"
+
+Fiona also builds upon GDAL, so let's compile it the same way:
+
     $ pip install fiona --install-option="build_ext" --install-option="--include-dirs=/usr/include/gdal"
-
-If no matching distribution could be found for your gdal version, try out a version from the list close to yours.
 
 (Details: http://tylerickson.blogspot.co.at/2011/09/installing-gdal-in-python-virtual.html )
 

--- a/docs/inversion.rst
+++ b/docs/inversion.rst
@@ -1,4 +1,121 @@
 Bed inversion
 =============
 
-In construction
+To compute the initial ice thickness :math:`h_0`, OGGM follows a methodology
+largely inspired from [Farinotti_etal_2009]_, but fully automatised and relying
+on different approaches to mass-balance and to calibration.
+
+Basics
+------
+
+The principle is simple. Let's assume for now that we know the flux of
+ice :math:`q` flowing through a section of our glacier. The flowline physics
+and geometrical assumptions can be used to solve for the ice thickness
+:math:`h`:
+
+.. math::
+
+    q = u S = \left(f_d h \tau^n + f_s \frac{\tau^n}{h}\right) S
+
+With :math:`n=3` and :math:`S = h w` (in the case of a rectangular section) or
+:math:`S = 2 / 3 h w` (parabolic section), the equation reduces to
+solving a polynomial of degree 5 with one unique solution in
+:math:`\mathbb{R}_+`. If we neglect sliding (the default in OGGM and in
+[Farinotti_etal_2009]_), the solution is even simpler.
+
+
+Ice flux
+--------
+
+.. ipython:: python
+   :suppress:
+
+    fpath = "_code/prepare_climate.py"
+    with open(fpath) as f:
+        code = compile(f.read(), fpath, 'exec')
+        exec(code)
+
+If we consider a point on the flowline and the catchment area :math:`\Omega`
+upstream of this point we have:
+
+.. math::
+
+    q = \int_{\Omega} (\dot{m} - \rho \frac{\partial h}{\partial t}) \ dA = \int_{\Omega} \widetilde{m} \ dA
+
+with :math:`\dot{m}` the mass balance, and
+:math:`\widetilde{m} = \dot{m} - \rho \partial h / \partial t` the
+"apparent mass-balance" after [Farinotti_etal_2009]_. If the glacier is in
+steady state, the apparent mass-balance is equivalent to the the actual (and
+observable) mass-balance. Unfortunately, :math:`\partial h / \partial t` is not
+known and there is no easy way to compute it. In order to continue, we have
+to make the assumption that our geometry is in equilibrium.
+
+This however has a very useful consequence: indeed, for the calibration
+of our :ref:`mass-balance` model it is required to find a date :math:`t^*`
+at which the glacier would be in equilibrium with its average climate
+*while conserving its modern geometry*. Thus, we have
+:math:`\widetilde{m} = \dot{m}_{t^*}`, where :math:`\dot{m}_{t^*}` is the
+31-yr average mass-balance centered at :math:`t^*` (which is known since
+the mass-balance model calibration).
+
+The plot below shows the mass flux along the major flowline of Hintereisferner
+glacier. By construction, the flux is maximal at the equilibrium line and
+zero at the glacier tongue.
+
+.. ipython:: python
+
+    @savefig example_plot_massflux.png width=100%
+    example_plot_massflux()
+
+
+Calibration
+-----------
+
+A number of climate and glacier related parameters are fixed prior to
+the inversion, leaving only one free parameter for the calibration of the
+bed inversion procedure: the inversion factor :math:`f_{inv}`. It is defined
+such as:
+
+.. math::
+
+    A = f_{inv} \, A_0
+
+With :math:`A_0` the standard creep parameter (2.4e-24). Currently,
+:math:`f_{inv}` is calibrated to minimize the volume RMSD of all glaciers
+with a volume estimation in the `GlaThiDa`_ database. It is therefore
+neither glacier nor temperature dependent and does not account for
+uncertainties in GlaThiDa's glacier-wide thickness estimations, two
+approximations which should be better handled in the future.
+
+.. _GlaThiDa: http://www.gtn-g.ch/data_catalogue_glathida/
+
+
+Distributed ice thickness
+-------------------------
+
+
+
+References
+----------
+
+.. [Cuffey_Paterson_2010] Cuffey, K., and W. S. B. Paterson (2010).
+    The Physics of Glaciers, Butterworth‐Heinemann, Oxford, U.K.
+
+.. [Farinotti_etal_2009] Farinotti, D., Huss, M., Bauder, A., Funk, M., &
+    Truffer, M. (2009). A method to estimate the ice volume and
+    ice-thickness distribution of alpine glaciers. Journal of Glaciology, 55
+    (191), 422–430.
+
+.. [Golledge_Levy_2011] Golledge, N. R., and Levy, R. H. (2011).
+    Geometry and dynamics of an East Antarctic Ice Sheet outlet glacier, under
+    past and present climates. Journal of Geophysical Research:
+    Earth Surface, 116(3), 1–13.
+
+.. [Jarosch_etal_2013] Jarosch, a. H., Schoof, C. G., & Anslow, F. S. (2013).
+    Restoring mass conservation to shallow ice flow models over complex
+    terrain. Cryosphere, 7(1), 229–240. http://doi.org/10.5194/tc-7-229-2013
+
+.. [Oerlemans_1997] Oerlemans, J. (1997).
+    A flowline model for Nigardsbreen, Norway:
+    projection of future glacier length based on dynamic calibration with the
+    historic record. Journal of Glaciology, 24, 382–389.

--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -15,6 +15,7 @@ from distutils.util import strtobool
 import numpy as np
 import pandas as pd
 import geopandas as gpd
+from scipy.signal import gaussian
 from configobj import ConfigObj, ConfigObjError
 
 # Defaults
@@ -95,18 +96,9 @@ FOUR_THIRDS = 4./3.
 ONE_FIFTH = 1./5.
 
 GAUSSIAN_KERNEL = dict()
-GAUSSIAN_KERNEL[9] = np.array([1.33830625e-04, 4.43186162e-03,
-                               5.39911274e-02, 2.41971446e-01,
-                               3.98943469e-01, 2.41971446e-01,
-                               5.39911274e-02, 4.43186162e-03,
-                               1.33830625e-04])
-GAUSSIAN_KERNEL[7] = np.array([1.78435052e-04, 1.51942011e-02,
-                               2.18673667e-01, 5.31907394e-01,
-                               2.18673667e-01, 1.51942011e-02,
-                               1.78435052e-04])
-GAUSSIAN_KERNEL[5] = np.array([2.63865083e-04, 1.06450772e-01,
-                               7.86570726e-01, 1.06450772e-01,
-                               2.63865083e-04])
+for ks in [5, 7, 9]:
+    kernel = gaussian(ks, 1)
+    GAUSSIAN_KERNEL[ks] = kernel / kernel.sum()
 
 # TODO: document all files
 _doc = 'A geotiff file containing the DEM (reprojected into the local grid).'

--- a/oggm/core/models/flowline.py
+++ b/oggm/core/models/flowline.py
@@ -545,11 +545,11 @@ class FlowlineModel(object):
             v_bef = self.volume_m3
             self.run_until(self.yr + ystep)
             v_af = self.volume_m3
-            t_rate = np.abs(v_af - v_bef) / v_bef
             if np.isclose(v_bef, 0., atol=1):
                 t_rate = 1
                 was_close_zero += 1
-
+            else:
+                t_rate = np.abs(v_af - v_bef) / v_bef
         if ite > max_ite:
             raise RuntimeError('Did not find equilibrium.')
 

--- a/oggm/core/models/massbalance.py
+++ b/oggm/core/models/massbalance.py
@@ -283,7 +283,7 @@ class ConstantMassBalanceModel(MassBalanceModel):
     """
 
     def __init__(self, gdir, mu_star=None, bias=None, prcp_fac=None,
-                 y0=None, halfsize=15):
+                 y0=None, halfsize=15, optim_zminmax=None):
         """Initialize
 
         Parameters
@@ -304,6 +304,9 @@ class ConstantMassBalanceModel(MassBalanceModel):
             is to use tstar as center.
         halfsize : int, optional
             the half-size of the time window (window size = 2 * halfsize + 1)
+        optim_zminmax : [int, int]
+            interpolation window (for optimization purposes). Default is to
+            use the actual glacier geometry to infer the bounds (recommended).
         """
 
         self.mbmod = PastMassBalanceModel(gdir, mu_star=mu_star, bias=bias,
@@ -314,11 +317,13 @@ class ConstantMassBalanceModel(MassBalanceModel):
             y0 = df['t_star'][0]
 
         # This is a quick'n dirty optimisation
-        fls = gdir.read_pickle('model_flowlines')
-        hbins = np.array([])
-        for fl in fls:
-            hbins = np.append(hbins, fl.surface_h)
-        self.hbins = np.arange(np.min(hbins)-50, np.max(hbins)+500, step=5)
+        if not optim_zminmax:
+            fls = gdir.read_pickle('model_flowlines')
+            hbins = np.array([])
+            for fl in fls:
+                hbins = np.append(hbins, fl.surface_h)
+            optim_zminmax = [np.min(hbins)-50, np.max(hbins)+500]
+        self.hbins = np.arange(*optim_zminmax, step=5)
         self.years = np.arange(y0-halfsize, y0+halfsize+1)
 
     @MassBalanceModel.temp_bias.setter

--- a/oggm/core/models/massbalance.py
+++ b/oggm/core/models/massbalance.py
@@ -283,7 +283,7 @@ class ConstantMassBalanceModel(MassBalanceModel):
     """
 
     def __init__(self, gdir, mu_star=None, bias=None, prcp_fac=None,
-                 y0=None, halfsize=15, optim_zminmax=None):
+                 y0=None, halfsize=15):
         """Initialize
 
         Parameters
@@ -304,9 +304,6 @@ class ConstantMassBalanceModel(MassBalanceModel):
             is to use tstar as center.
         halfsize : int, optional
             the half-size of the time window (window size = 2 * halfsize + 1)
-        optim_zminmax : [int, int]
-            interpolation window (for optimization purposes). Default is to
-            use the actual glacier geometry to infer the bounds (recommended).
         """
 
         self.mbmod = PastMassBalanceModel(gdir, mu_star=mu_star, bias=bias,
@@ -317,13 +314,9 @@ class ConstantMassBalanceModel(MassBalanceModel):
             y0 = df['t_star'][0]
 
         # This is a quick'n dirty optimisation
-        if not optim_zminmax:
-            fls = gdir.read_pickle('model_flowlines')
-            hbins = np.array([])
-            for fl in fls:
-                hbins = np.append(hbins, fl.surface_h)
-            optim_zminmax = [np.min(hbins)-50, np.max(hbins)+500]
-        self.hbins = np.arange(*optim_zminmax, step=5)
+        with netCDF4.Dataset(gdir.get_filepath('gridded_data')) as nc:
+            zminmax = [nc.min_h_dem-50, nc.max_h_dem+500]
+        self.hbins = np.arange(*zminmax, step=5)
         self.years = np.arange(y0-halfsize, y0+halfsize+1)
 
     @MassBalanceModel.temp_bias.setter

--- a/oggm/core/preprocessing/gis.py
+++ b/oggm/core/preprocessing/gis.py
@@ -538,7 +538,7 @@ def glacier_masks(gdir):
     assert ny == gdir.grid.ny
 
     # Proj
-    transf = dem_dr.affine
+    transf = dem_dr.transform
     x0 = transf[2]  # UL corner
     y0 = transf[5]  # UL corner
     dx = transf[0]

--- a/oggm/core/preprocessing/gis.py
+++ b/oggm/core/preprocessing/gis.py
@@ -24,6 +24,7 @@ import os
 import logging
 from shutil import copyfile
 from functools import partial
+from distutils.version import LooseVersion
 # External libs
 import salem
 import pyproj
@@ -538,7 +539,10 @@ def glacier_masks(gdir):
     assert ny == gdir.grid.ny
 
     # Proj
-    transf = dem_dr.transform
+    if LooseVersion(rasterio.__version__) >= LooseVersion('1.0'):
+        transf = dem_dr.transform
+    else:
+        transf = dem_dr.affine
     x0 = transf[2]  # UL corner
     y0 = transf[5]  # UL corner
     dx = transf[0]

--- a/oggm/core/preprocessing/gis.py
+++ b/oggm/core/preprocessing/gis.py
@@ -414,11 +414,10 @@ def define_glacier_region(gdir, entity=None):
     profile = dem.profile
     profile.update({
         'crs': proj4_str,
-        'affine': dst_transform,
+        'transform': dst_transform,
         'width': nx,
         'height': ny
     })
-    profile.pop('transform')
 
     # Could be extended so that the cfg file takes all Resampling.* methods
     if cfg.PARAMS['topo_interp'] == 'bilinear':
@@ -436,7 +435,7 @@ def define_glacier_region(gdir, entity=None):
             # Source parameters
             source=rasterio.band(dem, 1),
             src_crs=dem.crs,
-            src_transform=dem.affine,
+            src_transform=dem.transform,
             # Destination parameters
             destination=dst_array,
             dst_transform=dst_transform,

--- a/oggm/core/preprocessing/inversion.py
+++ b/oggm/core/preprocessing/inversion.py
@@ -46,9 +46,10 @@ from oggm.core.preprocessing.gis import gaussian_blur
 # Module logger
 log = logging.getLogger(__name__)
 
+
 @entity_task(log, writes=['inversion_input'])
 @divide_task(log, add_0=False)
-def prepare_for_inversion(gdir, div_id=None):
+def prepare_for_inversion(gdir, div_id=None, add_debug_var=False):
     """Prepares the data needed for the inversion.
 
     Mostly the mass flux and slope angle, the rest (width, height) was already
@@ -91,9 +92,17 @@ def prepare_for_inversion(gdir, div_id=None):
                 raise RuntimeError(msg)
             flux[-1] = 0.
 
-        # add to output
-        cl_dic = dict(dx=dx, flux=flux, width=widths, hgt=hgt,
-                      slope_angle=angle, is_last=fl.flows_to is None)
+        # Optimisation: we need to compute this term of a0 only once
+        flux_a0 = np.where(fl.touches_border, 1, 1.5)
+        flux_a0 *= flux / widths
+
+        # Add to output
+        cl_dic = dict(dx=dx, flux_a0=flux_a0, width=widths,
+                      slope_angle=angle, is_rectangular=fl.touches_border,
+                      is_last=fl.flows_to is None)
+        if add_debug_var:
+            cl_dic['flux'] = flux
+            cl_dic['hgt'] = hgt
         towrite.append(cl_dic)
 
     # Write out
@@ -113,16 +122,11 @@ def _inversion_simple(a3, a0):
     return (-a0)**cfg.ONE_FIFTH
 
 
-def invert_parabolic_bed(gdir, glen_a=cfg.A, fs=0., write=True):
+def mass_conservation_inversion(gdir, glen_a=cfg.A, fs=0., write=True):
     """ Compute the glacier thickness along the flowlines
 
     More or less following Farinotti et al., (2009).
-
-    The thickness estimation is computed under the assumption of a parabolic
-    bed section.
-
-    It returns (vol, thick) in (m3, m).
-
+    
     Parameters
     ----------
     gdir : oggm.GlacierDirectory
@@ -134,6 +138,10 @@ def invert_parabolic_bed(gdir, glen_a=cfg.A, fs=0., write=True):
         default behavior is to compute the thickness and write the
         results in the pickle. Set to False in order to spare time
         during calibration.
+    
+    Returns
+    -------
+    (vol, thick) in [m3, m]
     """
 
     # Check input
@@ -146,11 +154,6 @@ def invert_parabolic_bed(gdir, glen_a=cfg.A, fs=0., write=True):
     fd = 2. / (cfg.N+2) * glen_a
     a3 = fs / fd
 
-    # sometimes the width is small and the flux is big. crop this
-    max_ratio = cfg.PARAMS['max_thick_to_width_ratio']
-    max_shape = cfg.PARAMS['max_shape_param']
-    # sigma of the smoothing window after inversion
-    sec_smooth = cfg.PARAMS['section_smoothing']
     # Clip the slope, in degrees
     clip_angle = cfg.PARAMS['min_slope']
 
@@ -164,61 +167,23 @@ def invert_parabolic_bed(gdir, glen_a=cfg.A, fs=0., write=True):
 
             # Parabolic bed rock
             w = cl['width']
-            a0s = -(3*cl['flux'])/(2*w*((cfg.RHO*cfg.G*slope)**3)*fd)
+            a0s = - cl['flux_a0'] / ((cfg.RHO*cfg.G*slope)**3*fd)
+
             if np.any(~np.isfinite(a0s)):
-                raise RuntimeError('{}: something went wrong with '
+                raise RuntimeError('{}: something went wrong with the'
                                    'inversion'.format(gdir.rgi_id))
 
             # GO
             out_thick = np.zeros(len(slope))
-            for i, (a0, Q) in enumerate(zip(a0s, cl['flux'])):
+            for i, (a0, Q) in enumerate(zip(a0s, cl['flux_a0'])):
                 if Q > 0.:
                     out_thick[i] = _inv_function(a3, a0)
                 else:
                     out_thick[i] = 0.
 
-            # this filtering stuff below is not explained in Farinotti's
-            # paper. I did this because it looks better, but I'm not sure
-            # (yet) that this is a good idea
-
-            # However for tidewater we have to be carefull at the tongue
-            if gdir.is_tidewater and cl['is_last']:
-                # store it to restore it later
-                tongue_thick = out_thick[-5:]
-
-            # Check for thick to width ratio (should ne be too large)
-            ratio = out_thick / w  # there's no 0 width so we're good
-            pno = np.where(ratio > max_ratio)
-            if len(pno[0]) > 0:
-                ratio[pno] = np.NaN
-                ratio = utils.interp_nans(ratio, default=max_ratio)
-                out_thick = w * ratio
-
-            # TODO: last thicknesses can be noisy sometimes: interpolate?
-            if cl['is_last']:
-               out_thick[-4:-1] = np.NaN
-               out_thick = utils.interp_nans(out_thick)
-
-            # Check for the shape parameter (should not be too large)
-            out_shape = (4*out_thick)/(w**2)
-            pno = np.where(out_shape > max_shape)
-            if len(pno[0]) > 0:
-                out_shape[pno] = np.NaN
-                out_shape = utils.interp_nans(out_shape, default=max_shape)
-                out_thick = (out_shape * w**2) / 4
-
-            # smooth section
-            if sec_smooth != 0.:
-                section = cfg.TWO_THIRDS * w * out_thick * cl['dx']
-                section = gaussian_filter1d(section, sec_smooth)
-                out_thick = section / (w * cfg.TWO_THIRDS * cl['dx'])
-
-            if gdir.is_tidewater and cl['is_last']:
-                # restore the last thicknesses
-                out_thick[-5:] = tongue_thick
-
             # volume
-            volume = cfg.TWO_THIRDS * out_thick * w * cl['dx']
+            fac = np.where(cl['is_rectangular'], 1, cfg.TWO_THIRDS)
+            volume = fac * out_thick * w * cl['dx']
 
             if write:
                 cl['thick'] = out_thick
@@ -289,8 +254,8 @@ def optimize_inversion_params(gdirs):
             glen_a = cfg.A * x[0]
             fs = cfg.FS * x[1]
             for i, gdir in enumerate(ref_gdirs):
-                v, a = invert_parabolic_bed(gdir, glen_a=glen_a,
-                                            fs=fs, write=False)
+                v, a = mass_conservation_inversion(gdir, glen_a=glen_a,
+                                                   fs=fs, write=False)
                 if optim_t:
                     tmp_ref[i] = v / a
                 else:
@@ -311,8 +276,8 @@ def optimize_inversion_params(gdirs):
             tmp_ref = np.zeros(len(ref_gdirs))
             glen_a = cfg.A * x[0]
             for i, gdir in enumerate(ref_gdirs):
-                v, a = invert_parabolic_bed(gdir, glen_a=glen_a,
-                                            fs=0., write=False)
+                v, a = mass_conservation_inversion(gdir, glen_a=glen_a,
+                                                   fs=0., write=False)
                 if optim_t:
                     tmp_ref[i] = v / a
                 else:
@@ -329,8 +294,8 @@ def optimize_inversion_params(gdirs):
     oggm_volume_m3 = np.zeros(len(ref_gdirs))
     rgi_area_m2 = np.zeros(len(ref_gdirs))
     for i, gdir in enumerate(ref_gdirs):
-        v, a = invert_parabolic_bed(gdir, glen_a=glen_a, fs=fs,
-                                    write=False)
+        v, a = mass_conservation_inversion(gdir, glen_a=glen_a, fs=fs,
+                                           write=False)
         oggm_volume_m3[i] = v
         rgi_area_m2[i] = a
     assert np.allclose(rgi_area_m2 * 1e-6, ref_area_km2)
@@ -405,7 +370,7 @@ def volume_inversion(gdir, use_cfg_params=None):
         glen_a = d['glen_a']
 
     # go
-    return invert_parabolic_bed(gdir, glen_a=glen_a, fs=fs, write=True)
+    return mass_conservation_inversion(gdir, glen_a=glen_a, fs=fs, write=True)
 
 
 def _distribute_thickness_per_altitude(glacier_mask, topo, cls, fls, grid,

--- a/oggm/core/preprocessing/inversion.py
+++ b/oggm/core/preprocessing/inversion.py
@@ -66,7 +66,7 @@ def prepare_for_inversion(gdir, div_id=None, add_debug_var=False,
 
     # for testing only
     if 'invert_with_rectangular' in cfg.PARAMS:
-        invert_with_rectangular = cfg.PARAM['invert_with_rectangular']
+        invert_with_rectangular = cfg.PARAMS['invert_with_rectangular']
 
     towrite = []
     for fl in fls:

--- a/oggm/core/preprocessing/inversion.py
+++ b/oggm/core/preprocessing/inversion.py
@@ -383,7 +383,7 @@ def _distribute_thickness_per_altitude(glacier_mask, topo, cls, fls, grid,
     hs, ts, vs, xs, ys = [], [], [], [] ,[]
     for cl, fl in zip(cls, fls):
         # TODO: here one should see if parabola is always the best choice
-        hs = np.append(hs, cl['hgt'])
+        hs = np.append(hs, fl.surface_h)
         ts = np.append(ts, cl['thick'])
         vs = np.append(vs, cl['volume'])
         x, y = fl.line.xy

--- a/oggm/sandbox/itmix/itmix.py
+++ b/oggm/sandbox/itmix/itmix.py
@@ -24,7 +24,7 @@ import oggm.cfg as cfg
 from oggm import entity_task
 from oggm import utils
 from oggm.core.preprocessing.gis import gaussian_blur, _mask_per_divide
-from oggm.core.preprocessing.inversion import invert_parabolic_bed
+from oggm.core.preprocessing.inversion import mass_conservation_inversion
 from oggm.sandbox.itmix.itmix_cfg import DATA_DIR, ITMIX_ODIR
 
 # Module logger
@@ -477,8 +477,8 @@ def optimize_thick(gdirs):
         tmp_ = np.zeros(len(ref_gdirs))
         glen_a = cfg.A * x[0]
         for i, gdir in enumerate(ref_gdirs):
-            v, a = invert_parabolic_bed(gdir, glen_a=glen_a,
-                                        fs=0., write=False)
+            v, a = mass_conservation_inversion(gdir, glen_a=glen_a,
+                                               fs=0., write=False)
             tmp_[i] = v / a
         return utils.rmsd(tmp_, ref_thickness_m)
     opti = optimization.minimize(to_optimize, [1.],
@@ -492,8 +492,8 @@ def optimize_thick(gdirs):
     oggm_volume_m3 = np.zeros(len(ref_gdirs))
     rgi_area_m2 = np.zeros(len(ref_gdirs))
     for i, gdir in enumerate(ref_gdirs):
-        v, a = invert_parabolic_bed(gdir, glen_a=glen_a, fs=fs,
-                                    write=False)
+        v, a = mass_conservation_inversion(gdir, glen_a=glen_a, fs=fs,
+                                           write=False)
         oggm_volume_m3[i] = v
         rgi_area_m2[i] = a
     assert np.allclose(rgi_area_m2 * 1e-6, ref_area_km2)

--- a/oggm/tasks.py
+++ b/oggm/tasks.py
@@ -19,6 +19,7 @@ from oggm.core.preprocessing.climate import process_custom_climate_data
 from oggm.core.preprocessing.climate import process_cesm_data
 from oggm.core.preprocessing.inversion import prepare_for_inversion
 from oggm.core.preprocessing.inversion import volume_inversion
+from oggm.core.preprocessing.inversion import filter_inversion_output
 from oggm.core.preprocessing.inversion import distribute_thickness
 from oggm.core.models.flowline import init_present_time_glacier
 from oggm.core.models.flowline import random_glacier_evolution

--- a/oggm/tests/__init__.py
+++ b/oggm/tests/__init__.py
@@ -179,7 +179,8 @@ def assertDatasetAllClose(d1, d2, rtol=1e-05, atol=1e-08):
         assertVariableAllClose(v1, v2, rtol=rtol, atol=atol)
 
 
-def init_hef(reset=False, border=40, invert_with_sliding=True):
+def init_hef(reset=False, border=40, invert_with_sliding=True,
+             invert_with_rectangular=True):
 
     from oggm.core.preprocessing import gis, centerlines, geometry
     from oggm.core.preprocessing import climate, inversion
@@ -191,6 +192,8 @@ def init_hef(reset=False, border=40, invert_with_sliding=True):
     testdir = TESTDIR_BASE + '_border{}'.format(border)
     if not invert_with_sliding:
         testdir += '_withoutslide'
+    if not invert_with_rectangular:
+        testdir += '_withoutrectangular'
     if not os.path.exists(testdir):
         os.makedirs(testdir)
         reset = True
@@ -229,7 +232,8 @@ def init_hef(reset=False, border=40, invert_with_sliding=True):
                                      bias=res['bias'][-1],
                                      prcp_fac=res['prcp_fac'])
 
-    inversion.prepare_for_inversion(gdir, add_debug_var=True)
+    inversion.prepare_for_inversion(gdir, add_debug_var=True,
+                                    invert_with_rectangular=invert_with_rectangular)
     ref_v = 0.573 * 1e9
 
     if invert_with_sliding:
@@ -273,6 +277,9 @@ def init_hef(reset=False, border=40, invert_with_sliding=True):
     except IndexError:
         d['factor_fs'] = 0.
     gdir.write_pickle(d, 'inversion_params')
+
+    # filter
+    inversion.filter_inversion_output(gdir)
 
     inversion.distribute_thickness(gdir, how='per_altitude',
                                    add_nc_name=True)

--- a/oggm/tests/__init__.py
+++ b/oggm/tests/__init__.py
@@ -229,7 +229,7 @@ def init_hef(reset=False, border=40, invert_with_sliding=True):
                                      bias=res['bias'][-1],
                                      prcp_fac=res['prcp_fac'])
 
-    inversion.prepare_for_inversion(gdir)
+    inversion.prepare_for_inversion(gdir, add_debug_var=True)
     ref_v = 0.573 * 1e9
 
     if invert_with_sliding:
@@ -238,8 +238,8 @@ def init_hef(reset=False, border=40, invert_with_sliding=True):
             _fd = 1.9e-24 * x[0]
             glen_a = (cfg.N+2) * _fd / 2.
             fs = 5.7e-20 * x[1]
-            v, _ = inversion.invert_parabolic_bed(gdir, fs=fs,
-                                                  glen_a=glen_a)
+            v, _ = inversion.mass_conservation_inversion(gdir, fs=fs,
+                                                         glen_a=glen_a)
             return (v - ref_v)**2
 
         out = optimization.minimize(to_optimize, [1, 1],
@@ -248,14 +248,14 @@ def init_hef(reset=False, border=40, invert_with_sliding=True):
         _fd = 1.9e-24 * out[0]
         glen_a = (cfg.N+2) * _fd / 2.
         fs = 5.7e-20 * out[1]
-        v, _ = inversion.invert_parabolic_bed(gdir, fs=fs,
-                                              glen_a=glen_a,
-                                              write=True)
+        v, _ = inversion.mass_conservation_inversion(gdir, fs=fs,
+                                                     glen_a=glen_a,
+                                                     write=True)
     else:
         def to_optimize(x):
             glen_a = cfg.A * x[0]
-            v, _ = inversion.invert_parabolic_bed(gdir, fs=0.,
-                                                  glen_a=glen_a)
+            v, _ = inversion.mass_conservation_inversion(gdir, fs=0.,
+                                                         glen_a=glen_a)
             return (v - ref_v)**2
 
         out = optimization.minimize(to_optimize, [1],
@@ -263,9 +263,9 @@ def init_hef(reset=False, border=40, invert_with_sliding=True):
                                     tol=1e-4)['x']
         glen_a = cfg.A * out[0]
         fs = 0.
-        v, _ = inversion.invert_parabolic_bed(gdir, fs=fs,
-                                              glen_a=glen_a,
-                                              write=True)
+        v, _ = inversion.mass_conservation_inversion(gdir, fs=fs,
+                                                     glen_a=glen_a,
+                                                     write=True)
     d = dict(fs=fs, glen_a=glen_a)
     d['factor_glen_a'] = out[0]
     try:

--- a/oggm/tests/__init__.py
+++ b/oggm/tests/__init__.py
@@ -135,48 +135,11 @@ def is_download(test):
     msg = "requires explicit environment for download tests"
     return test if RUN_DOWNLOAD_TESTS else unittest.skip(msg)(test)
 
+
 def is_performance_test(test):
     # Test decorator
     msg = "requires explicit environment for performance tests"
     return test if RUN_PERFORMANCE_TESTS else unittest.skip(msg)(test)
-
-# the code below is copy/pasted from xarray
-# TODO: go back to xarray when https://github.com/pydata/xarray/issues/754
-def assertEqual(a1, a2):
-    assert a1 == a2 or (a1 != a1 and a2 != a2)
-
-
-def decode_string_data(data):
-    if data.dtype.kind == 'S':
-        return np.core.defchararray.decode(data, 'utf-8', 'replace')
-
-
-def data_allclose_or_equiv(arr1, arr2, rtol=1e-05, atol=1e-08):
-    from xarray.core import ops
-
-    if any(arr.dtype.kind == 'S' for arr in [arr1, arr2]):
-        arr1 = decode_string_data(arr1)
-        arr2 = decode_string_data(arr2)
-    exact_dtypes = ['M', 'm', 'O', 'U']
-    if any(arr.dtype.kind in exact_dtypes for arr in [arr1, arr2]):
-        return ops.array_equiv(arr1, arr2)
-    else:
-        return ops.allclose_or_equiv(arr1, arr2, rtol=rtol, atol=atol)
-
-
-def assertVariableAllClose(v1, v2, rtol=1e-05, atol=1e-08):
-    assertEqual(v1.dims, v2.dims)
-    allclose = data_allclose_or_equiv(
-        v1.values, v2.values, rtol=rtol, atol=atol)
-    assert allclose, (v1.values, v2.values)
-
-
-def assertDatasetAllClose(d1, d2, rtol=1e-05, atol=1e-08):
-    assertEqual(sorted(d1, key=str), sorted(d2, key=str))
-    for k in d1:
-        v1 = d1.variables[k]
-        v2 = d2.variables[k]
-        assertVariableAllClose(v1, v2, rtol=rtol, atol=atol)
 
 
 def init_hef(reset=False, border=40, invert_with_sliding=True,

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -241,6 +241,9 @@ class TestInitFlowline(unittest.TestCase):
         self.assertTrue(gdir.rgi_date.year == 2003)
         self.assertTrue(len(fls) == 4)
 
+        # TODO: test below are broken since removed filtering
+        return
+
         vol = 0.
         area = 0.
         for fl in fls:
@@ -1759,9 +1762,10 @@ class TestHEF(unittest.TestCase):
             vol = model.volume_km3_ts()
             len = model.length_m_ts()
             area = model.area_km2_ts()
-            np.testing.assert_allclose(vol.iloc[0], np.mean(vol), rtol=0.1)
-            np.testing.assert_allclose(0.05, np.std(vol), atol=0.02)
-            np.testing.assert_allclose(area.iloc[0], np.mean(area), rtol=0.1)
+            # TODO: test below are broken since removed filtering
+            # np.testing.assert_allclose(vol.iloc[0], np.mean(vol), rtol=0.1)
+            # np.testing.assert_allclose(0.05, np.std(vol), atol=0.02)
+            # np.testing.assert_allclose(area.iloc[0], np.mean(area), rtol=0.1)
 
             if do_plot:
                 fig, (ax1, ax2, ax3) = plt.subplots(3, 1, figsize=(6, 10))

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -24,8 +24,8 @@ import pandas as pd
 from oggm.tests import init_hef
 from oggm.core.models import massbalance, flowline
 from oggm.core.models.massbalance import LinearMassBalanceModel
-from oggm.tests import (is_slow, assertDatasetAllClose, RUN_MODEL_TESTS,
-                        is_performance_test)
+from oggm.tests import is_slow, RUN_MODEL_TESTS, is_performance_test
+import xarray as xr
 from oggm import utils, cfg
 from oggm.cfg import N, SEC_IN_DAY, SEC_IN_YEAR, SEC_IN_MONTHS
 from oggm.core.preprocessing import climate
@@ -847,7 +847,7 @@ class TestIO(unittest.TestCase):
             np.testing.assert_allclose(fl.section, fl_.section)
             np.testing.assert_allclose(fl._ptrap, fl_._ptrap)
             np.testing.assert_allclose(fl.bed_h, fl_.bed_h)
-            assertDatasetAllClose(ds, ds_)
+            xr.testing.assert_allclose(ds, ds_)
 
         for fl, fl_ in zip(fls[:-1], fls_[:-1]):
             self.assertEqual(fl.flows_to_indice, fl_.flows_to_indice)

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -1760,7 +1760,7 @@ class TestHEF(unittest.TestCase):
             len = model.length_m_ts()
             area = model.area_km2_ts()
             np.testing.assert_allclose(vol.iloc[0], np.mean(vol), rtol=0.1)
-            np.testing.assert_allclose(0.05, np.std(vol), atol=0.02)
+            np.testing.assert_allclose(0.07, np.std(vol), atol=0.02)
             np.testing.assert_allclose(area.iloc[0], np.mean(area), rtol=0.1)
 
             if do_plot:

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -229,7 +229,7 @@ class TestInitFlowline(unittest.TestCase):
 
     def test_init_present_time_glacier(self):
 
-        gdir = init_hef(border=DOM_BORDER)
+        gdir = init_hef(border=DOM_BORDER, invert_with_rectangular=False)
         flowline.init_present_time_glacier(gdir)
 
         fls = gdir.read_pickle('model_flowlines')
@@ -240,9 +240,6 @@ class TestInitFlowline(unittest.TestCase):
 
         self.assertTrue(gdir.rgi_date.year == 2003)
         self.assertTrue(len(fls) == 4)
-
-        # TODO: test below are broken since removed filtering
-        return
 
         vol = 0.
         area = 0.
@@ -1653,7 +1650,7 @@ class TestHEF(unittest.TestCase):
 
     def setUp(self):
 
-        self.gdir = init_hef(border=DOM_BORDER)
+        self.gdir = init_hef(border=DOM_BORDER, invert_with_rectangular=False)
         d = self.gdir.read_pickle('inversion_params')
         self.fs = d['fs']
         self.glen_a = d['glen_a']
@@ -1762,10 +1759,9 @@ class TestHEF(unittest.TestCase):
             vol = model.volume_km3_ts()
             len = model.length_m_ts()
             area = model.area_km2_ts()
-            # TODO: test below are broken since removed filtering
-            # np.testing.assert_allclose(vol.iloc[0], np.mean(vol), rtol=0.1)
-            # np.testing.assert_allclose(0.05, np.std(vol), atol=0.02)
-            # np.testing.assert_allclose(area.iloc[0], np.mean(area), rtol=0.1)
+            np.testing.assert_allclose(vol.iloc[0], np.mean(vol), rtol=0.1)
+            np.testing.assert_allclose(0.05, np.std(vol), atol=0.02)
+            np.testing.assert_allclose(area.iloc[0], np.mean(area), rtol=0.1)
 
             if do_plot:
                 fig, (ax1, ax2, ax3) = plt.subplots(3, 1, figsize=(6, 10))

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -371,7 +371,7 @@ class TestOtherDivides(unittest.TestCase):
             climate.local_mustar_apparent_mb(gdir, tstar=1930, bias=0,
                                              prcp_fac=2.5)
             inversion.prepare_for_inversion(gdir)
-            v, ainv = inversion.invert_parabolic_bed(gdir)
+            v, ainv = inversion.mass_conservation_inversion(gdir)
             flowline.init_present_time_glacier(gdir)
 
         myarea = 0.

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -1246,12 +1246,27 @@ class TestInversion(unittest.TestCase):
             _max = np.max(thick)
             if _max > maxs:
                 maxs = _max
-            # This doesn't pass because of smoothing
             if fl.flows_to is None:
                 self.assertEqual(cl['volume'][-1], 0)
                 self.assertEqual(cl['thick'][-1], 0)
 
         np.testing.assert_allclose(242, maxs, atol=40)
+
+        # Filter
+        inversion.filter_inversion_output(gdir)
+        maxs = 0.
+        v = 0.
+        for div_id in gdir.divide_ids:
+            cls = gdir.read_pickle('inversion_output', div_id=div_id)
+            for cl in cls:
+                thick = cl['thick']
+                _max = np.max(thick)
+                if _max > maxs:
+                    maxs = _max
+                v += np.nansum(cl['volume'])
+        np.testing.assert_allclose(242, maxs, atol=40)
+        np.testing.assert_allclose(ref_v, v)
+
 
     @is_slow
     def test_distribute(self):

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -1383,7 +1383,7 @@ class TestInversion(unittest.TestCase):
             _max = np.max(thick)
             if _max > maxs:
                 maxs = _max
-        np.testing.assert_allclose(242, maxs, atol=25)
+        np.testing.assert_allclose(242, maxs, atol=31)
 
         # check that its not tooo sensitive to the dx
         cfg.PARAMS['flowline_dx'] = 1.
@@ -1414,7 +1414,7 @@ class TestInversion(unittest.TestCase):
             if _max > maxs:
                 maxs = _max
 
-        np.testing.assert_allclose(242, maxs, atol=25)
+        np.testing.assert_allclose(242, maxs, atol=31)
 
     def test_continue_on_error(self):
 

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -9,7 +9,7 @@ import time
 import salem
 import numpy as np
 import pandas as pd
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_allclose
 
 from oggm.tests import is_download
 from oggm import utils
@@ -37,6 +37,15 @@ class TestFuncs(unittest.TestCase):
         ts = pd.Series([-2., -1., 1., 2., 3][::-1], index=np.arange(5))
         sc = utils.signchange(ts)
         assert_array_equal(sc, [0, 0, 0, 1, 0])
+
+    def test_smooth(self):
+        a = np.array([1., 4, 7, 7, 4, 1])
+        b = utils.smooth1d(a, 3, kernel='mean')
+        assert_allclose(b, [3, 4, 6, 6, 4, 3])
+        kernel = [0.60653066,  1., 0.60653066]
+        b = utils.smooth1d(a, 3, kernel=kernel)
+        c = utils.smooth1d(a, 3)
+        assert_allclose(b, c)
 
     def test_filter_rgi_name(self):
 

--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -77,7 +77,7 @@ def up_to_climate(reset=False):
     cfg.PARAMS['border'] = 70
     cfg.PARAMS['use_optimized_inversion_params'] = True
     cfg.PARAMS['tstar_search_window'] = [1902, 0]
-    cfg.PARAM['invert_with_rectangular'] = False
+    cfg.PARAMS['invert_with_rectangular'] = False
 
     # Go
     gdirs = workflow.init_glacier_regions(rgidf)

--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -77,6 +77,7 @@ def up_to_climate(reset=False):
     cfg.PARAMS['border'] = 70
     cfg.PARAMS['use_optimized_inversion_params'] = True
     cfg.PARAMS['tstar_search_window'] = [1902, 0]
+    cfg.PARAM['invert_with_rectangular'] = False
 
     # Go
     gdirs = workflow.init_glacier_regions(rgidf)

--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -1743,7 +1743,7 @@ def filter_rgi_name(name):
     if name is None or len(name) == 0:
         return ''
 
-    if name[-1] == 'À' or name[-1] == '\x9c' or name[-1] == '3':
+    if name[-1] in ['À', 'È', 'è', '\x9c', '3', 'Ð', '°']:
         return filter_rgi_name(name[:-1])
 
     return name.strip().title()

--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -736,28 +736,42 @@ def interp_nans(array, default=None):
     return _tmp
 
 
-def smooth1d(array, window=None, kernel='gaussian'):
-    # TODO: documentation
+def smooth1d(array, window_size=None, kernel='gaussian'):
+    """Apply a centered window smoothing to a 1D array.
+    
+    Parameters
+    ----------
+    array : ndarray
+        the array to apply the smoothing to
+    window_size : int 
+        the size of the smoothing window
+    kernel : str
+        the type of smoothing (`gaussian`, `mean`)
+
+    Returns
+    -------
+    the smoothed array (same dim as input)
+    """
 
     # some defaults
-    if window is None:
+    if window_size is None:
         if len(array) >= 9:
-            window = 9
+            window_size = 9
         elif len(array) >= 7:
-            window = 7
+            window_size = 7
         elif len(array) >= 5:
-            window = 5
+            window_size = 5
         elif len(array) >= 3:
-            window = 3
+            window_size = 3
 
-    if window % 2 == 0:
+    if window_size % 2 == 0:
         raise ValueError('Window should be an odd number.')
 
     if isinstance(kernel, str):
         if kernel == 'gaussian':
-            kernel = gaussian(window, 1)
+            kernel = gaussian(window_size, 1)
         elif kernel == 'mean':
-            kernel = np.ones(window)
+            kernel = np.ones(window_size)
         else:
             raise NotImplementedError('Kernel: ' + kernel)
     kernel = kernel / np.asarray(kernel).sum()

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -190,3 +190,6 @@ def inversion_tasks(gdirs):
 
     # Inversion for all glaciers
     execute_entity_task(tasks.volume_inversion, gdirs)
+
+    # Filter
+    execute_entity_task(tasks.filter_inversion_output, gdirs)


### PR DESCRIPTION
This PR is a bit larger than I wish it would be, and it brakes backwards compatibility. Non-exhaustive list of changes:
- the inversion formula takes ice divides into account (this changes the thickness estimation locally)
- the filtering that occurred during the inversion is now happening in a separate task. It has been improved to conserve volume entirely. The implications of this change aren't fully explored
- had to make some change to remove rasterio warnings and other issues related to https://github.com/OGGM/oggm/pull/216 . The differences between rasterio 1.0 and previous is a pain. (Travis still uses 0.36 and so did I).
- docs improvements

To get something close to backwards compatibility one should set ``cfg.PARAMS['invert_with_rectangular'] = False`` in the script. However I would recommend OGGM users NOT to update OGGM until the rest of the workflow can cope with rectangular beds.