### PR TITLE
Config file for download cache settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,10 @@ cache:
 matrix:
   fast_finish: true
   include:
-    - env: OGGM_ENV=prepro MPL=
-    - env: OGGM_ENV=models MPL=
-    - env: OGGM_ENV=workflow MPL=--mpl
-    - env: OGGM_ENV=graphics MPL=--mpl
+    - env: OGGM_TEST_ENV=prepro MPL=
+    - env: OGGM_TEST_ENV=models MPL=
+    - env: OGGM_TEST_ENV=workflow MPL=--mpl
+    - env: OGGM_TEST_ENV=graphics MPL=--mpl
 
 before_install:
   - docker pull oggm/untested_base:latest
@@ -40,7 +40,7 @@ install:
     EOF
   - mkdir -p $HOME/dl_cache
   - export OGGM_DOWNLOAD_CACHE=/dl_cache
-  - docker create --name oggm_travis -ti -v $HOME/dl_cache:/dl_cache -e OGGM_DOWNLOAD_CACHE -e OGGM_ENV -e CI -e TRAVIS -e TRAVIS_JOB_ID -e TRAVIS_BRANCH -e TRAVIS_PULL_REQUEST oggm/untested_base:latest /bin/bash /root/oggm/test.sh
+  - docker create --name oggm_travis -ti -v $HOME/dl_cache:/dl_cache -e OGGM_DOWNLOAD_CACHE -e OGGM_TEST_ENV -e CI -e TRAVIS -e TRAVIS_JOB_ID -e TRAVIS_BRANCH -e TRAVIS_PULL_REQUEST oggm/untested_base:latest /bin/bash /root/oggm/test.sh
   - docker cp $PWD oggm_travis:/root/oggm
 script:
   - export OGGM_DOWNLOAD_CACHE=/dl_cache

--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -331,10 +331,10 @@ def oggm_static_paths():
         dldir = os.path.join(os.path.expanduser('~'), 'OGGM_DOWNLOADS')
         config = ConfigObj()
         config['dl_cache_dir'] = dldir
-        config['tmp_dir'] = os.path.join(dldir, 'tmp')
-        config['topo_dir'] = os.path.join(dldir, 'topo')
-        config['cru_dir'] = os.path.join(dldir, 'cru')
-        config['rgi_dir'] = os.path.join(dldir, 'rgi')
+        config['tmp_dir'] = ''
+        config['topo_dir'] = ''
+        config['cru_dir'] = ''
+        config['rgi_dir'] = ''
         config['has_internet'] = True
         config.filename = CONFIG_FILE
         config.write()
@@ -351,16 +351,22 @@ def oggm_static_paths():
     for k in ['dl_cache_dir', 'tmp_dir', 'topo_dir',
               'cru_dir', 'rgi_dir', 'has_internet']:
         if k not in config:
-            raise RuntimeError('The oggm config file ({}) should have an'
+            raise RuntimeError('The oggm config file ({}) should have an '
                                'entry for {}.'.format(CONFIG_FILE, k))
 
-    # Override defaults with env variables
+    # Override defaults with env variables if available
     if os.environ.get('OGGM_DOWNLOAD_CACHE') is not None:
         config['dl_cache_dir'] = os.environ.get('OGGM_DOWNLOAD_CACHE')
+
+    if not config['dl_cache_dir']:
+        raise RuntimeError('At the very least, the "dl_cache_dir" entry '
+                           'should be provided in the oggm config file '
+                           '({})'.format(CONFIG_FILE, k))
 
     # Fill the PATH dict
     for k, v in config.iteritems():
         if not v and '_dir' in k:
+            # defaults to the cache dir
             v = os.path.join(config['dl_cache_dir'], k.replace('_dir', ''))
         PATHS[k] = os.path.abspath(os.path.expanduser(v))
 

--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -239,7 +239,8 @@ def initialize(file=None):
     PATHS['working_dir'] = cp['working_dir']
     # Default
     if not PATHS['working_dir']:
-        PATHS['working_dir'] = os.path.expanduser('~/OGGM_WORKING_DIRECTORY')
+        PATHS['working_dir'] = os.path.join(os.path.expanduser('~'),
+                                            'OGGM_WORKING_DIRECTORY')
     PATHS['dem_file'] = cp['dem_file']
     PATHS['climate_file'] = cp['climate_file']
     PATHS['wgms_rgi_links'] = cp['wgms_rgi_links']

--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -29,6 +29,8 @@ log = logging.getLogger(__name__)
 CACHE_DIR = os.path.join(os.path.expanduser('~'), '.oggm')
 if not os.path.exists(CACHE_DIR):
     os.makedirs(CACHE_DIR)
+# Path to the config file
+CONFIG_FILE = os.path.join(os.path.expanduser('~'), '.oggm_config')
 
 
 class DocumentedDict(dict):
@@ -227,40 +229,17 @@ def initialize(file=None):
     try:
         cp = ConfigObj(file, file_error=True)
     except (ConfigObjError, IOError) as e:
-        log.critical('Config file could not be parsed (%s): %s', file, e)
+        log.critical('Param file could not be parsed (%s): %s', file, e)
         sys.exit()
-
-    homedir = os.path.expanduser('~')
-
-    # Some defaults
-    if cp['working_dir'] == '~':
-        cp['working_dir'] = os.path.join(homedir, 'OGGM_wd')
-    if cp['topo_dir'] == '~':
-        cp['topo_dir'] = os.path.join(homedir, 'OGGM_data', 'topo')
-    if cp['cru_dir'] == '~':
-        cp['cru_dir'] = os.path.join(homedir, 'OGGM_data', 'cru')
-    if cp['rgi_dir'] == '~':
-        cp['rgi_dir'] = os.path.join(homedir, 'OGGM_data', 'rgi')
-
-    # Setup Download-Cache-Dir
-    if os.environ.get('OGGM_DOWNLOAD_CACHE_RO') is not None:
-        cp['dl_cache_readonly'] = bool(strtobool(os.environ.get('OGGM_DOWNLOAD_CACHE_RO')))
-    if os.environ.get('OGGM_DOWNLOAD_CACHE') is not None:
-        cp['dl_cache_dir'] = os.environ.get('OGGM_DOWNLOAD_CACHE')
-
-    PATHS['dl_cache_dir'] = cp['dl_cache_dir']
-    PARAMS['dl_cache_readonly'] = cp.as_bool('dl_cache_readonly')
-
-    if PATHS['dl_cache_dir'] and not os.path.exists(PATHS['dl_cache_dir']):
-        if not PARAMS['dl_cache_readonly']:
-            os.makedirs(PATHS['dl_cache_dir'])
 
     CONTINUE_ON_ERROR = cp.as_bool('continue_on_error')
 
+    # Paths
+    oggm_static_paths()
     PATHS['working_dir'] = cp['working_dir']
-    PATHS['topo_dir'] = cp['topo_dir']
-    PATHS['cru_dir'] = cp['cru_dir']
-    PATHS['rgi_dir'] = cp['rgi_dir']
+    # Default
+    if not PATHS['working_dir']:
+        PATHS['working_dir'] = os.path.expanduser('~/OGGM_WORKING_DIRECTORY')
     PATHS['dem_file'] = cp['dem_file']
     PATHS['climate_file'] = cp['climate_file']
     PATHS['wgms_rgi_links'] = cp['wgms_rgi_links']
@@ -307,8 +286,8 @@ def initialize(file=None):
     PARAMS[_k] = cp.as_bool(_k)
 
     # Make sure we have a proper cache dir
-    from oggm.utils import _download_oggm_files
-    _download_oggm_files()
+    from oggm.utils import download_oggm_files
+    download_oggm_files()
 
     # Parse RGI metadata
     _d = os.path.join(CACHE_DIR, 'oggm-sample-data-master', 'rgi_meta')
@@ -327,10 +306,9 @@ def initialize(file=None):
            'optimize_inversion_params', 'use_multiple_flowlines',
            'leclercq_rgi_links', 'optimize_thick', 'mpi_recv_buf_size',
            'tstar_search_window', 'use_bias_for_run', 'run_period',
-           'prcp_scaling_factor', 'use_intersects',
-           'dl_cache_dir', 'dl_cache_readonly']
+           'prcp_scaling_factor', 'use_intersects']
     for k in ltr:
-        del cp[k]
+        cp.pop(k, None)
 
     # Other params are floats
     for k in cp:
@@ -343,14 +321,61 @@ def initialize(file=None):
     IS_INITIALIZED = True
 
 
+def oggm_static_paths():
+    """Initialise the OGGM paths from the config file."""
+
+    global PATHS, PARAMS
+
+    # See if the file is there, if not create it
+    if not os.path.exists(CONFIG_FILE):
+        dldir = os.path.join(os.path.expanduser('~'), 'OGGM_DOWNLOADS')
+        config = ConfigObj()
+        config['dl_cache_dir'] = dldir
+        config['tmp_dir'] = os.path.join(dldir, 'tmp')
+        config['topo_dir'] = os.path.join(dldir, 'topo')
+        config['cru_dir'] = os.path.join(dldir, 'cru')
+        config['rgi_dir'] = os.path.join(dldir, 'rgi')
+        config['has_internet'] = True
+        config.filename = CONFIG_FILE
+        config.write()
+
+    # OK, read in the file
+    try:
+        config = ConfigObj(CONFIG_FILE, file_error=True)
+    except (ConfigObjError, IOError) as e:
+        log.critical('Config file could not be parsed (%s): %s',
+                     CONFIG_FILE, e)
+        sys.exit()
+
+    # Check that all keys are here
+    for k in ['dl_cache_dir', 'tmp_dir', 'topo_dir',
+              'cru_dir', 'rgi_dir', 'has_internet']:
+        if k not in config:
+            raise RuntimeError('The oggm config file ({}) should have an'
+                               'entry for {}.'.format(CONFIG_FILE, k))
+
+    # Override defaults with env variables
+    if os.environ.get('OGGM_DOWNLOAD_CACHE') is not None:
+        config['dl_cache_dir'] = os.environ.get('OGGM_DOWNLOAD_CACHE')
+
+    # Fill the PATH dict
+    for k, v in config.iteritems():
+        if not v and '_dir' in k:
+            v = os.path.join(config['dl_cache_dir'], k.replace('_dir', ''))
+        PATHS[k] = os.path.abspath(os.path.expanduser(v))
+
+    # Other
+    PARAMS['has_internet'] = config.as_bool('has_internet')
+
+
 def get_lru_handler(tmpdir=None, maxsize=100, ending='.tif'):
     """LRU handler for a given temporary directory (singleton).
 
     Parameters
     ----------
     tmpdir : str
-        path to the temporary directory to handle. Default is "tmp" in the
-        working directory.
+        path to the temporary directory to handle. Default is 
+        ``cfg.PATHS['tmp_dir']``.
     maxsize : int
         the max number of files to keep in the directory
     ending : str
@@ -360,7 +385,7 @@ def get_lru_handler(tmpdir=None, maxsize=100, ending='.tif'):
 
     # see if we're set up
     if tmpdir is None:
-        tmpdir = os.path.join(PATHS['working_dir'], 'tmp')
+        tmpdir = PATHS['tmp_dir']
     if not os.path.exists(tmpdir):
         os.makedirs(tmpdir)
 

--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -3,31 +3,7 @@
 ### Input/Output paths. Set to ~ to default to home directory
 
 # Where OGGM will write its output
-working_dir = ~
-
-# Input directory for topography data. It can be emtpy: in that case OGGM will
-# download the data from the SRTM (open) and ASTER (not open) databases
-topo_dir = ~
-
-# Input directory for CRU TS data. It can be emtpy: in that case OGGM will
-# download the data from https://crudata.uea.ac.uk
-cru_dir = ~
-
-# Input directory for RGI data. It can be emtpy: in that case OGGM will
-# download the data
-rgi_dir = ~
-
-# Cache directory for downloads. If set, all downloaded data will be stored here
-# initially. If a file requested for download is present in the cache, it will be
-# copied from there instead of downloaded again.
-# Can be overridden via OGGM_DOWNLOAD_CACHE environment variable.
-dl_cache_dir =
-
-# Set to True if the download cache is readonly.
-# Downloads will be written to their normal location if neccessary.
-# Alternatively set the OGGM_DOWNLOAD_CACHE_RO environment variable to indicate
-# a read-only cache dir.
-dl_cache_readonly = False
+working_dir =
 
 # Users can specify their own topography file if they want to. In this case,
 # the topo_dir above will be ignored. This is useful for testing, or if you
@@ -36,7 +12,7 @@ dl_cache_readonly = False
 dem_file =
 
 # Users can specify their own climate dataset if they want to. In this case,
-# the cru_dir above will be ignored. This is useful for testing, or if you
+# the static cru_dir will be ignored. This is useful for testing, or if you
 # are simulating a single region with better data.
 # The format of the file is not (yet) very flexible. See the HISTALP data
 # in the sample-data folder for an example:

--- a/oggm/tests/__init__.py
+++ b/oggm/tests/__init__.py
@@ -65,7 +65,7 @@ if os.environ.get('TRAVIS') is not None:
     else:
         # distribute the tests
         RUN_SLOW_TESTS = True
-        env = os.environ.get('OGGM_ENV')
+        env = os.environ.get('OGGM_TEST_ENV')
         if env == 'prepro':
             RUN_PREPRO_TESTS = True
             RUN_MODEL_TESTS = False

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -596,10 +596,10 @@ class TestClimate(unittest.TestCase):
         climate.process_histalp_nonparallel([gdirs[0]])
         cru_dir = get_demo_file('cru_ts3.23.1901.2014.tmp.dat.nc')
         cru_dir = os.path.dirname(cru_dir)
-        cfg.PATHS['climate_file'] = '~'
+        cfg.PATHS['climate_file'] = ''
         cfg.PATHS['cru_dir'] = cru_dir
         climate.process_cru_data(gdirs[1])
-        cfg.PATHS['cru_dir'] = '~'
+        cfg.PATHS['cru_dir'] = ''
         cfg.PATHS['climate_file'] = get_demo_file('histalp_merged_hef.nc')
 
         ci = gdir.read_pickle('climate_info')

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -1434,6 +1434,7 @@ class TestInversion(unittest.TestCase):
     def test_continue_on_error(self):
 
         cfg.CONTINUE_ON_ERROR = True
+        cfg.PATHS['working_dir'] = self.testdir
 
         hef_file = get_demo_file('Hintereisferner.shp')
         entity = gpd.GeoDataFrame.from_file(hef_file).iloc[0]

--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -116,7 +116,7 @@ def up_to_inversion(reset=False):
         # Use histalp for the actual inversion test
         cfg.PARAMS['temp_use_local_gradient'] = True
         cfg.PATHS['climate_file'] = get_demo_file('HISTALP_oetztal.nc')
-        cfg.PATHS['cru_dir'] = '~'
+        cfg.PATHS['cru_dir'] = ''
         workflow.climate_tasks(gdirs)
         with open(CLI_LOGF, 'wb') as f:
             pickle.dump('histalp', f)
@@ -147,7 +147,7 @@ def up_to_distrib(reset=False):
         # Use CRU
         cfg.PARAMS['prcp_scaling_factor'] = 2.5
         cfg.PARAMS['temp_use_local_gradient'] = False
-        cfg.PATHS['climate_file'] = '~'
+        cfg.PATHS['climate_file'] = ''
         cru_dir = get_demo_file('cru_ts3.23.1901.2014.tmp.dat.nc')
         cfg.PATHS['cru_dir'] = os.path.dirname(cru_dir)
         with warnings.catch_warnings():

--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -1892,10 +1892,11 @@ class GlacierDirectory(object):
         summary += ['  Area: ' + str(self.rgi_area_km2) + ' mk2']
         summary += ['  Lon, Lat: (' + str(self.cenlon) + ', ' +
                     str(self.cenlat) + ')']
-        summary += ['  Grid (nx, ny): (' + str(self.grid.nx) + ', ' +
-                    str(self.grid.ny) + ')']
-        summary += ['  Grid (dx, dy): (' + str(self.grid.dx) + ', ' +
-                    str(self.grid.dy) + ')']
+        if os.path.isfile(self.get_filepath('glacier_grid')):
+            summary += ['  Grid (nx, ny): (' + str(self.grid.nx) + ', ' +
+                        str(self.grid.ny) + ')']
+            summary += ['  Grid (dx, dy): (' + str(self.grid.dx) + ', ' +
+                        str(self.grid.dy) + ')']
         return '\n'.join(summary) + '\n'
 
     @lazy_property


### PR DESCRIPTION
This adds a new config file in home. This will come handy to set some paths once (and once for all). 

This config file is different from the params.cfg in that it stores information which is going to be consistent accross all runs (e.g.: topo data, climate data, etc).

I also had to revert some of your changes @TimoRoth because the concept of a single download cache directory is not possible for these data. Your solution was definitely more elegant, but the data we download is structured and can be used outside oggm. This change allows to keep a structure in the downloaded data. Note that the default config is to have a single cache directory with all data inside, so exactly what you had.

