### PR TITLE
Render mpl test images without text

### DIFF
--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -410,7 +410,7 @@ def _download_oggm_files_unlocked():
             if filename in out:
                 # This was a stupid thing, and should not happen
                 # TODO: duplicates in sample data...
-                k = os.path.join(os.path.dirname(root), filename)
+                k = os.path.join(os.path.basename(root), filename)
                 assert k not in out
                 out[k] = os.path.join(root, filename)
             else:


### PR DESCRIPTION
Can't really think of any automatic approach for this.
matplotlib can even come with its own statically linked version, so checking the system version is pointless.