### PR TITLE
Use different baselines images depending on freetype version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ notifications:
 environment:
   matrix:
     - PYTHON: "C:\\Python3-conda64"
-      PYTHON_VERSION: "3.5"
+      PYTHON_VERSION: "3.6"
       PYTHON_ARCH: "64"
 
 install:
@@ -22,6 +22,7 @@ install:
 
   # Create environment with desired python version and activate it
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - "SET GDAL_DATA=%PYTHON%\\Library\\share\\gdal"
   - "conda install --yes --quiet python=%PYTHON_VERSION%"
 
   # Check that we have the expected version and architecture for Python
@@ -30,7 +31,7 @@ install:
 
   # install dependencies
   - "python -m pip install --upgrade pip"
-  - "conda install --yes --quiet -c conda-forge geopandas matplotlib Pillow joblib netCDF4 scikit-image configobj pytest pyproj numpy rasterio krb5 xarray boto3"
+  - "conda install --yes --quiet -c conda-forge gdal libgdal geopandas matplotlib Pillow joblib netCDF4 scikit-image configobj pytest pyproj numpy rasterio krb5 xarray boto3"
   - "pip install motionless"
   - "pip install git+https://github.com/fmaussion/salem.git"
   - "pip install -e ."

--- a/oggm/tests/__init__.py
+++ b/oggm/tests/__init__.py
@@ -7,6 +7,7 @@ import socket
 import unittest
 import logging
 import matplotlib
+import matplotlib.ft2font
 import pandas as pd
 import geopandas as gpd
 import numpy as np
@@ -31,7 +32,12 @@ HAS_MPL_FOR_TESTS = False
 if LooseVersion(matplotlib.__version__) >= LooseVersion('2'):
     HAS_MPL_FOR_TESTS = True
     BASELINE_DIR = os.path.join(cfg.CACHE_DIR, 'oggm-sample-data-master',
-                                'baseline_images', '2.0.x')
+                                'baseline_images')
+    ftver = LooseVersion(matplotlib.ft2font.__freetype_version__)
+    if ftver >= LooseVersion('2.7.0'):
+        BASELINE_DIR = os.path.join(BASELINE_DIR, 'alt')
+    else:
+        BASELINE_DIR = os.path.join(BASELINE_DIR, '2.0.x')
 
 
 # Some control on which tests to run (useful to avoid too long tests)

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -42,9 +42,14 @@ def init_mp_pool(reset=False):
     global_lock = mp.Manager().Lock()
     mpp = cfg.PARAMS['mp_processes']
     if mpp == -1:
-        mpp = mp.cpu_count()
-        log.info('Multiprocessing: using all available '
-                 'processors (N={})'.format(mp.cpu_count()))
+        try:
+            mpp = int(os.environ['SLURM_JOB_CPUS_PER_NODE'])
+            log.info('Multiprocessing: using slurm allocated '
+                     'processors (N={})'.format(mpp))
+        except KeyError:
+            mpp = mp.cpu_count()
+            log.info('Multiprocessing: using all available '
+                     'processors (N={})'.format(mpp))
     else:
         log.info('Multiprocessing: using the requested number of '
                  'processors (N={})'.format(mpp))


### PR DESCRIPTION
Updating the images is not too complicated, on a system with a more recent freetype it's just doing

pip install --no-deps -I --no-binary :all: matplotlib
vs.
pip install --no-deps -I matplotlib

As the pre-built mpl comes with freetype 2.6.1, a self built one uses the system version.


Additionally this contains a small change for the workflow CPU count, now taking into account a potential Slurm CPU allocation.