### PR TITLE
Small bugfix in BEGINSEC_IN_MONTHS

### DIFF
--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -86,7 +86,7 @@ SEC_IN_HOUR = 3600
 DAYS_IN_MONTH = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
 SEC_IN_MONTHS = [d * SEC_IN_DAY for d in DAYS_IN_MONTH]
 CUMSEC_IN_MONTHS = np.cumsum(SEC_IN_MONTHS)
-BEGINSEC_IN_MONTHS = np.cumsum([0] + [(d + 1) * SEC_IN_DAY for d in DAYS_IN_MONTH[:-1]])
+BEGINSEC_IN_MONTHS = np.insert(CUMSEC_IN_MONTHS[:-1] + 1, [0], 0)
 
 RHO = 900.  # ice density
 G = 9.81  # gravity

--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -86,7 +86,7 @@ SEC_IN_HOUR = 3600
 DAYS_IN_MONTH = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
 SEC_IN_MONTHS = [d * SEC_IN_DAY for d in DAYS_IN_MONTH]
 CUMSEC_IN_MONTHS = np.cumsum(SEC_IN_MONTHS)
-BEGINSEC_IN_MONTHS = np.insert(CUMSEC_IN_MONTHS[:-1] + 1, [0], 0)
+BEGINSEC_IN_MONTHS = np.insert(CUMSEC_IN_MONTHS[:-1], [0], 0)
 
 RHO = 900.  # ice density
 G = 9.81  # gravity

--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -969,7 +969,8 @@ def year_to_date(yr):
         sec, out_y = math.modf(yr)
         out_y = int(out_y)
         sec = sec * SEC_IN_YEAR
-        out_m = np.nonzero(sec <= CUMSEC_IN_MONTHS)[0][0] + 1
+        sec = round(sec, 3)
+        out_m = np.nonzero(sec < CUMSEC_IN_MONTHS)[0][0] + 1
     except TypeError:
         # TODO: inefficient but no time right now
         out_y = np.zeros(len(yr), np.int64)

--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -968,8 +968,7 @@ def year_to_date(yr):
     try:
         sec, out_y = math.modf(yr)
         out_y = int(out_y)
-        sec = sec * SEC_IN_YEAR
-        sec = round(sec, 3)
+        sec = round(sec * SEC_IN_YEAR)
         out_m = np.nonzero(sec < CUMSEC_IN_MONTHS)[0][0] + 1
     except TypeError:
         # TODO: inefficient but no time right now


### PR DESCRIPTION
The begin of the month was shifted by +/- one day per month in the old version.
It did not influence the monthly calculations so far, however, for possible future changes it could be relevant.

Regarding the way of counting: as we start counting with zero, it would be more logical for me that the begin second of February, e.g., was 2678400 and not 2678401. This would break the tests though. 