### PR TITLE
Add an option to correct for negative flux during inversion

### DIFF
--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -280,6 +280,7 @@ def initialize(file=None):
     PARAMS['optimize_thick'] = cp.as_bool('optimize_thick')
     PARAMS['filter_min_slope'] = cp.as_bool('filter_min_slope')
     PARAMS['auto_skip_task'] = cp.as_bool('auto_skip_task')
+    PARAMS['correct_for_neg_flux'] = cp.as_bool('correct_for_neg_flux')
 
     # Climate
     PARAMS['temp_use_local_gradient'] = cp.as_bool('temp_use_local_gradient')
@@ -324,7 +325,7 @@ def initialize(file=None):
            'leclercq_rgi_links', 'optimize_thick', 'mpi_recv_buf_size',
            'tstar_search_window', 'use_bias_for_run', 'run_period',
            'prcp_scaling_factor', 'use_intersects', 'filter_min_slope',
-           'auto_skip_task']
+           'auto_skip_task', 'correct_for_neg_flux']
     for k in ltr:
         cp.pop(k, None)
 

--- a/oggm/core/preprocessing/climate.py
+++ b/oggm/core/preprocessing/climate.py
@@ -875,8 +875,8 @@ def local_mustar_apparent_mb(gdir, tstar=None, bias=None, prcp_fac=None,
                             '%.4f km3 ice yr-1', gdir.rgi_id, aflux)
             # If not marine and quite far from zero, error
             if cmb == 0 and not np.allclose(fls[-1].flux[-1], 0., atol=1):
-                msg = '{}: flux should be zero, but is:  %.4f km3 ice yr-1' \
-                       .format(gdir.rgi_id, aflux)
+                msg = ('{}: flux should be zero, but is: {:.4f} km3 ice yr-1'
+                       .format(gdir.rgi_id, aflux))
                 raise RuntimeError(msg)
 
             gdir.write_pickle(fls, 'inversion_flowlines', div_id=div_id)

--- a/oggm/graphics.py
+++ b/oggm/graphics.py
@@ -477,8 +477,8 @@ def plot_distributed_thickness(gdir, ax=None, salemmap=None, how=None):
 
 @entity_task(log)
 @_plot_map
-def plot_modeloutput_map(gdir, ax=None, salemmap=None, model=None, vmax=None,
-                         linewidth=3, subset=True):
+def plot_modeloutput_map(gdir, ax=None, salemmap=None, model=None,
+                         vmax=None, linewidth=3, subset=True):
     """Plots the result of the model output."""
 
     with netCDF4.Dataset(gdir.get_filepath('gridded_data')) as nc:

--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -185,6 +185,10 @@ prcp_scaling_factor = 2.5
 min_slope = 1.5
 # Do you want to consider sliding when inverting?
 invert_with_sliding = False
+# Some glacier geometries imply that some tributaries have a negative
+# mass flux, i.e. zero thickness. One can correct for this effect, but
+# this implies playing around with the mass-balance...
+correct_for_neg_flux = True
 # Do you want to optimize thickness or volume RMSD?
 optimize_thick = False
 # Do you actually want to optimize the parameters at all?

--- a/oggm/sandbox/gmd_paper/plot_hef_dynamics.py
+++ b/oggm/sandbox/gmd_paper/plot_hef_dynamics.py
@@ -7,6 +7,7 @@ from oggm.utils import get_demo_file
 import matplotlib.pyplot as plt
 import xarray as xr
 import scipy.optimize as optimization
+from oggm import utils
 from oggm.sandbox.gmd_paper import PLOT_DIR
 from oggm.core.preprocessing.climate import (t_star_from_refmb,
                                              local_mustar_apparent_mb)
@@ -39,7 +40,7 @@ tasks.catchment_intersections(gdir)
 tasks.catchment_width_geom(gdir)
 tasks.catchment_width_correction(gdir)
 tasks.process_cru_data(gdir)
-tasks.mu_candidates(gdir, div_id=0)
+tasks.mu_candidates(gdir)
 tasks.compute_ref_t_stars([gdir])
 tasks.distribute_t_stars([gdir])
 tasks.prepare_for_inversion(gdir)
@@ -47,36 +48,65 @@ tasks.volume_inversion(gdir, use_cfg_params={'glen_a':cfg.A, 'fs':0})
 tasks.filter_inversion_output(gdir)
 tasks.init_present_time_glacier(gdir)
 
+df = utils.glacier_characteristics([gdir], path=False)
 
 reset = False
-tasks.random_glacier_evolution(gdir, nyears=500, bias=0, seed=0,
-                               filesuffix='seed0', reset=reset)
+seed = 0
+tasks.random_glacier_evolution(gdir, nyears=800, bias=0, seed=seed,
+                               filesuffix='_fromzero_def', reset=reset,
+                               zero_initial_glacier=True)
 
-tasks.random_glacier_evolution(gdir, nyears=500, bias=0, seed=1,
-                               filesuffix='seed1', reset=reset)
+cfg.PARAMS['flowline_fs'] = 5.7e-20 * 0.5
+tasks.random_glacier_evolution(gdir, nyears=800, bias=0, seed=seed,
+                               filesuffix='_fromzero_fs', reset=reset,
+                               zero_initial_glacier=True)
 
-tasks.random_glacier_evolution(gdir, nyears=500, bias=0, seed=2,
-                               filesuffix='seed2', reset=reset)
+cfg.PARAMS['flowline_fs'] = 0
+cfg.PARAMS['flowline_glen_a'] = cfg.A*2
+tasks.random_glacier_evolution(gdir, nyears=800, bias=0, seed=seed,
+                               filesuffix='_fromzero_2A', reset=reset,
+                               zero_initial_glacier=True)
 
-f = gdir.get_filepath('model_diagnostics', filesuffix='seed0')
+cfg.PARAMS['flowline_fs'] = 0
+cfg.PARAMS['flowline_glen_a'] = cfg.A/2
+tasks.random_glacier_evolution(gdir, nyears=800, bias=0, seed=seed,
+                               filesuffix='_fromzero_halfA', reset=reset,
+                               zero_initial_glacier=True)
+
+
+f = gdir.get_filepath('model_diagnostics', filesuffix='_fromzero_def')
 ds1 = xr.open_dataset(f)
-f = gdir.get_filepath('model_diagnostics', filesuffix='seed1')
+f = gdir.get_filepath('model_diagnostics', filesuffix='_fromzero_fs')
 ds2 = xr.open_dataset(f)
-f = gdir.get_filepath('model_diagnostics', filesuffix='seed2')
+f = gdir.get_filepath('model_diagnostics', filesuffix='_fromzero_2A')
 ds3 = xr.open_dataset(f)
+f = gdir.get_filepath('model_diagnostics', filesuffix='_fromzero_halfA')
+ds4 = xr.open_dataset(f)
 
-# ds1.volume_m3.plot()
-# ds2.volume_m3.plot()
-# ds3.volume_m3.plot()
-# plt.show()
-#
-# ds1.area_m2.plot()
-# ds2.area_m2.plot()
-# ds3.area_m2.plot()
-# plt.show()
+letkm = dict(color='black', ha='left', va='top', fontsize=14,
+             bbox=dict(facecolor='white', edgecolor='black'))
+tx, ty = 0.017, .980
+f, (ax1, ax2) = plt.subplots(1, 2, figsize=(9, 4))
 
-ds1.length_m.rolling(time=5, center=True).mean().plot()
-ds2.length_m.rolling(time=5, center=True).mean().plot()
-ds3.length_m.rolling(time=5, center=True).mean().plot()
-plt.show()
+ax = ax1
+ax.axhline(df.inv_volume_km3.values[0], 0, 800, color='k')
+(ds1.volume_m3 * 1e-9).plot(ax=ax, linewidth=2, label='Default')
+(ds2.volume_m3 * 1e-9).plot(ax=ax, label='Sliding')
+(ds4.volume_m3 * 1e-9).plot(ax=ax, label=r'A / 2')
+ax.set_xlabel('Years')
+ax.set_ylabel('Volume [km$^3$]')
+ax.text(tx, ty, 'a', transform=ax.transAxes, **letkm)
 
+ax = ax2
+ax.axhline(gdir.read_pickle('model_flowlines')[-1].length_m / 1000, 0, 800,
+            color='k')
+(ds1.length_m / 1000).plot(ax=ax, linewidth=2, label='Default')
+(ds2.length_m / 1000).plot(ax=ax, label='Sliding')
+(ds4.length_m / 1000).plot(ax=ax, label=r'A / 2')
+ax.set_xlabel('Years')
+ax.set_ylabel('Length [km]')
+ax.text(tx, ty, 'b', transform=ax.transAxes, **letkm)
+plt.legend()
+
+plt.tight_layout()
+plt.savefig(PLOT_DIR + 'hef_dyns.pdf', dpi=150, bbox_inches='tight')

--- a/oggm/sandbox/gmd_paper/plot_hef_scenarios.py
+++ b/oggm/sandbox/gmd_paper/plot_hef_scenarios.py
@@ -1,0 +1,122 @@
+import os
+import geopandas as gpd
+import numpy as np
+import oggm
+from oggm import cfg, tasks, graphics
+from oggm.utils import get_demo_file
+import matplotlib.pyplot as plt
+import xarray as xr
+import scipy.optimize as optimization
+from oggm import utils
+from oggm.sandbox.gmd_paper import PLOT_DIR
+from oggm.core.preprocessing.climate import (t_star_from_refmb,
+                                             local_mustar_apparent_mb)
+from oggm.core.preprocessing.inversion import (mass_conservation_inversion)
+from oggm.core.models.flowline import (FluxBasedModel, FileModel)
+from oggm.core.models.massbalance import (RandomMassBalanceModel)
+
+cfg.initialize()
+
+# Don't use divides for now, or intersects
+# cfg.set_divides_db()
+# cfg.set_intersects_db()
+
+cfg.PATHS['dem_file'] = get_demo_file('hef_srtm.tif')
+cfg.PARAMS['border'] = 60
+cfg.PARAMS['auto_skip_task'] = True
+
+base_dir = os.path.join(os.path.expanduser('~/tmp'), 'OGGM_GMD', 'scenarios')
+entity = gpd.read_file(get_demo_file('Hintereisferner_RGI5.shp')).iloc[0]
+gdir = oggm.GlacierDirectory(entity, base_dir=base_dir)
+
+tasks.define_glacier_region(gdir, entity=entity)
+tasks.glacier_masks(gdir)
+tasks.compute_centerlines(gdir)
+tasks.compute_downstream_lines(gdir)
+tasks.initialize_flowlines(gdir)
+tasks.compute_downstream_bedshape(gdir)
+tasks.catchment_area(gdir)
+tasks.catchment_intersections(gdir)
+tasks.catchment_width_geom(gdir)
+tasks.catchment_width_correction(gdir)
+tasks.process_cru_data(gdir)
+tasks.mu_candidates(gdir)
+tasks.compute_ref_t_stars([gdir])
+tasks.distribute_t_stars([gdir])
+tasks.prepare_for_inversion(gdir)
+tasks.volume_inversion(gdir, use_cfg_params={'glen_a':cfg.A, 'fs':0})
+tasks.filter_inversion_output(gdir)
+tasks.init_present_time_glacier(gdir)
+
+df = utils.glacier_characteristics([gdir], path=False)
+
+reset = False
+seed = 0
+
+tasks.random_glacier_evolution(gdir, nyears=400, bias=0, seed=0, y0=2000,
+                               filesuffix='_2000_def', reset=reset)
+
+tasks.random_glacier_evolution(gdir, nyears=400, bias=0, seed=0, y0=1920,
+                               filesuffix='_1920_def', reset=reset)
+
+
+f = gdir.get_filepath('model_diagnostics', filesuffix='_2000_def')
+ds1 = xr.open_dataset(f)
+f = gdir.get_filepath('model_diagnostics', filesuffix='_1920_def')
+ds2 = xr.open_dataset(f)
+
+# f, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=(9, 4))
+
+
+f = plt.figure(figsize=(9, 6))
+from mpl_toolkits.axes_grid1 import ImageGrid
+axs = ImageGrid(f, 111,  # as in plt.subplot(111)
+                nrows_ncols=(2, 2),
+                axes_pad=0.15,
+                share_all=True,
+                cbar_location="right",
+                cbar_mode="edge",
+                cbar_size="7%",
+                cbar_pad=0.15,
+                )
+f.delaxes(axs[0])
+f.delaxes(axs[1])
+f.delaxes(axs[1].cax)
+
+tx, ty = 0.019, .975
+letkm = dict(color='black', ha='left', va='top', fontsize=14,
+             bbox=dict(facecolor='white', edgecolor='black'))
+llkw = {'interval': 0}
+
+fp = gdir.get_filepath('model_run', filesuffix='_2000_def')
+model = FileModel(fp)
+model.run_until(800)
+ax = axs[3]
+graphics.plot_modeloutput_map(gdir, model=model, ax=ax, reset=True, title='',
+                              lonlat_contours_kwargs=llkw, cbar_ax=ax.cax,
+                              subset=False, linewidth=1.5,
+                              add_scalebar=False, vmax=300)
+ax.text(tx, ty, 'c: [1985-2015]', transform=ax.transAxes, **letkm)
+
+
+fp = gdir.get_filepath('model_run', filesuffix='_1920_def')
+model = FileModel(fp)
+model.run_until(800)
+ax = axs[2]
+graphics.plot_modeloutput_map(gdir, model=model, ax=ax, reset=True, title='',
+                              lonlat_contours_kwargs=llkw,
+                              add_colorbar=False, linewidth=1.5,
+                              subset=False,
+                              add_scalebar=False, vmax=300)
+ax.text(tx, ty, 'b: [1905-1935]', transform=ax.transAxes, **letkm)
+
+ax = f.add_axes([0.25, 0.57, 0.6, 0.3])
+ax.axhline(df.inv_volume_km3.values[0], 0, 800, color='k')
+(ds2.volume_m3 * 1e-9).plot(ax=ax, label='[1905-1935]')
+(ds1.volume_m3 * 1e-9).plot(ax=ax, label='[1985-2015]')
+ax.set_xlabel('Years')
+ax.set_ylabel('Volume [km$^3$]')
+ax.legend(loc=[0.72, 0.2])
+ax.text(0.01, .97, 'a', transform=ax.transAxes, **letkm)
+
+plt.savefig(PLOT_DIR + 'hef_scenarios.pdf', dpi=150, bbox_inches='tight')


### PR DESCRIPTION
The problem that this PR tries to address is following: since we have only one mu per glacier, it can happen that low-elevation tributaries have effectively a negative flux at their last grid point. Until now OGGM was just accepting these and computed zero ice thickness.

This PR now adds an artificial mass-balance where necessary. This solution works more or less, but  is rather dirty since it is an ad-hoc solution to a deeper problem. This will have to be addressed in future versions.

There is a new parameter to control this behavior: ```'correct_for_neg_flux'```, which is set to True per default. Set it to False if you want the old behavior.