### PR TITLE
Freetype changes only happening since 2.8.0

### DIFF
--- a/oggm/tests/__init__.py
+++ b/oggm/tests/__init__.py
@@ -34,7 +34,7 @@ if LooseVersion(matplotlib.__version__) >= LooseVersion('2'):
     BASELINE_DIR = os.path.join(cfg.CACHE_DIR, 'oggm-sample-data-master',
                                 'baseline_images')
     ftver = LooseVersion(matplotlib.ft2font.__freetype_version__)
-    if ftver >= LooseVersion('2.7.0'):
+    if ftver >= LooseVersion('2.8.0'):
         BASELINE_DIR = os.path.join(BASELINE_DIR, 'alt')
     else:
         BASELINE_DIR = os.path.join(BASELINE_DIR, '2.0.x')


### PR DESCRIPTION
Seems like I never encountered 2.7.0 in the wild.
Now, anaconda updated to 2.7.0, and it's still producing the old results. So the change that broke the tests must have happened later than expected.