### PR TITLE
Further unification of log messages

### DIFF
--- a/oggm/core/models/flowline.py
+++ b/oggm/core/models/flowline.py
@@ -1588,7 +1588,7 @@ def random_glacier_evolution(gdir, nyears=1000, y0=None, bias=None,
 
     steps = ['default', 'conservative', 'ultra-conservative']
     for step in steps:
-        log.info('%s: trying %s time stepping scheme.', gdir.rgi_id, step)
+        log.info('(%s) trying %s time stepping scheme.', gdir.rgi_id, step)
         fls = gdir.read_pickle('model_flowlines')
         if zero_initial_glacier:
             for fl in fls:
@@ -1604,7 +1604,7 @@ def random_glacier_evolution(gdir, nyears=1000, y0=None, bias=None,
                 raise
             continue
         # If we get here we good
-        log.info('%s: %s time stepping was successful!', gdir.rgi_id, step)
+        log.info('(%s) %s time stepping was successful!', gdir.rgi_id, step)
         break
 
     return model

--- a/oggm/core/preprocessing/centerlines.py
+++ b/oggm/core/preprocessing/centerlines.py
@@ -778,7 +778,7 @@ def compute_centerlines(gdir, div_id=None):
 
     # Final check
     if len(cls) == 0:
-        raise RuntimeError('{} : no centerline found!'.format(gdir.rgi_id))
+        raise RuntimeError('({}) no centerline found!'.format(gdir.rgi_id))
 
     # Write the data
     gdir.write_pickle(cls, 'centerlines', div_id=div_id)
@@ -971,7 +971,7 @@ def compute_downstream_lines(gdir):
 
     # Final check
     if len(cls) == 0:
-        raise RuntimeError('{} : problem by downstream!'.format(gdir.rgi_id))
+        raise RuntimeError('({}) problem by downstream!'.format(gdir.rgi_id))
 
     # Write the data
     gdir.write_pickle(cls, 'centerlines', div_id=0)

--- a/oggm/core/preprocessing/climate.py
+++ b/oggm/core/preprocessing/climate.py
@@ -672,7 +672,7 @@ def mu_candidates(gdir, div_id=None, prcp_sf=None):
 
     # Check that we found a least one mustar
     if np.sum(np.isfinite(mu_yr_clim)) < 1:
-        raise RuntimeError('No mustar candidates found for {}'
+        raise RuntimeError('({}) no mustar candidates found.'
                            .format(gdir.rgi_id))
 
     # Write

--- a/oggm/core/preprocessing/geometry.py
+++ b/oggm/core/preprocessing/geometry.py
@@ -828,8 +828,8 @@ def catchment_width_correction(gdir, div_id=None):
                 log.warning('(%s) reduced min n per bin to %d', gdir.rgi_id,
                             nmin)
                 if nmin == 0:
-                    raise RuntimeError('NO binsize could be chosen for: '
-                                       '{}'.format(gdir.rgi_id))
+                    raise RuntimeError('({}) no binsize could be chosen '
+                                       .format(gdir.rgi_id))
         if bsize > 150:
             log.warning('(%s) chosen binsize %d', gdir.rgi_id, bsize)
         else:

--- a/oggm/core/preprocessing/gis.py
+++ b/oggm/core/preprocessing/gis.py
@@ -577,11 +577,12 @@ def glacier_masks(gdir):
         # see how many percent of the dem
         if np.sum(~isfinite) > (0.2 * nx * ny):
             raise RuntimeError('({}) too many NaNs in DEM'.format(gdir.rgi_id))
-        log.warning(gdir.rgi_id + ': DEM needed zeros somewhere.')
+        log.warning('({}) DEM needed zeros somewhere.'.format(gdir.rgi_id))
         dem[isfinite] = 0
 
     if np.min(dem) == np.max(dem):
-        raise RuntimeError(gdir.rgi_id + ': min equal max in the DEM.')
+        raise RuntimeError('({}) min equal max in the DEM.'
+                           .format(gdir.rgi_id))
 
     # Proj
     if LooseVersion(rasterio.__version__) >= LooseVersion('1.0'):

--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -1978,7 +1978,7 @@ class entity_task(object):
 
             # Log what we are doing
             if not task_func.__dict__.get('divide_task', False):
-                self.log.info('%s: %s', gdir.rgi_id, task_func.__name__)
+                self.log.info('(%s) %s', gdir.rgi_id, task_func.__name__)
 
             # Run the task
             try:
@@ -1989,7 +1989,7 @@ class entity_task(object):
                 out = None
                 gdir.log(task_func, err=err)
                 pipe_log(gdir, task_func, err=err)
-                self.log.error('%s occured during task %s on %s!',
+                self.log.error('%s occurred during task %s on %s!',
                         type(err).__name__, task_func.__name__, gdir.rgi_id)
                 if not cfg.PARAMS['continue_on_error']:
                     raise
@@ -2017,7 +2017,7 @@ class divide_task(object):
         self.add_0 = add_0
         self._cdoc = """"
             div_id : int
-                the ID of the divide to process. Should be left to  the default
+                the ID of the divide to process. Should be left to the default
                 ``None`` unless you know what you do.
         """
 
@@ -2031,7 +2031,7 @@ class divide_task(object):
                 if self.add_0:
                     ids = list(ids) + [0]
                 for i in ids:
-                    self.log.info('%s: %s, divide %d', gdir.rgi_id,
+                    self.log.info('(%s) %s, divide %d', gdir.rgi_id,
                                   task_func.__name__, i)
                     task_func(gdir, div_id=i, **kwargs)
             else:


### PR DESCRIPTION
I try to remove all semicolons (``:``) because this is how I parse for error messages in the logs. 

However my add-hoc solution isn't really good, because:
- the parenthesis are bit ugly (the RGI id is given in parenthesis)
- it would be MUCH better to have automatic logging / error tools on ourselves. We could easily make an OGGM specific Logger and Error subclasses instead.  