### PR TITLE
Run workflow tests both with and without multiprocessing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,8 @@ matrix:
     - env: OGGM_TEST_ENV=prepro MPL=
     - env: OGGM_TEST_ENV=numerics MPL=
     - env: OGGM_TEST_ENV=models MPL=
-    - env: OGGM_TEST_ENV=workflow MPL=--mpl
+    - env: OGGM_TEST_ENV=workflow MPL=--mpl OGGM_TEST_MULTIPROC=False
+    - env: OGGM_TEST_ENV=workflow MPL=--mpl OGGM_TEST_MULTIPROC=True
     - env: OGGM_TEST_ENV=graphics MPL=--mpl
 
 before_install:
@@ -42,7 +43,7 @@ install:
     EOF
   - mkdir -p $HOME/dl_cache
   - export OGGM_DOWNLOAD_CACHE=/dl_cache
-  - docker create --name oggm_travis -ti -v $HOME/dl_cache:/dl_cache -e OGGM_DOWNLOAD_CACHE -e OGGM_TEST_ENV -e CI -e TRAVIS -e TRAVIS_JOB_ID -e TRAVIS_BRANCH -e TRAVIS_PULL_REQUEST oggm/untested_base:latest /bin/bash /root/oggm/test.sh
+  - docker create --name oggm_travis -ti -v $HOME/dl_cache:/dl_cache -e OGGM_DOWNLOAD_CACHE -e OGGM_TEST_ENV -e OGGM_TEST_MULTIPROC -e CI -e TRAVIS -e TRAVIS_JOB_ID -e TRAVIS_BRANCH -e TRAVIS_PULL_REQUEST oggm/untested_base:latest /bin/bash /root/oggm/test.sh
   - docker cp $PWD oggm_travis:/root/oggm
 script:
   - export OGGM_DOWNLOAD_CACHE=/dl_cache

--- a/oggm/tests/funcs.py
+++ b/oggm/tests/funcs.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+from distutils.util import strtobool
 
 import geopandas as gpd
 import shapely.geometry as shpg
@@ -207,6 +208,13 @@ def dummy_width_bed_tributary(map_dx=100.):
                                          bed_h[0:20], widths[0:20])
     fl_1.set_flows_to(fl_0)
     return [fl_1, fl_0]
+
+
+def use_multiprocessing():
+    try:
+        return strtobool(os.getenv("OGGM_TEST_MULTIPROC", "True"))
+    except:
+        return True
 
 
 def get_ident():

--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -23,7 +23,7 @@ from oggm import workflow
 from oggm.utils import get_demo_file, rmsd, write_centerlines_to_shape
 from oggm.tests import is_slow, RUN_WORKFLOW_TESTS
 from oggm.tests import requires_mpltest, BASELINE_DIR
-from oggm.tests.funcs import get_test_dir
+from oggm.tests.funcs import get_test_dir, use_multiprocessing
 from oggm.core.models import flowline, massbalance
 from oggm import tasks
 from oggm import utils
@@ -59,7 +59,7 @@ def up_to_climate(reset=False):
     cfg.initialize()
 
     # Use multiprocessing
-    cfg.PARAMS['use_multiprocessing'] = True
+    cfg.PARAMS['use_multiprocessing'] = use_multiprocessing()
 
     # Working dir
     cfg.PATHS['working_dir'] = TEST_DIR


### PR DESCRIPTION
This should make coverage happy and test both code paths, which might be a good idea.