### PR TITLE
Force single flowline for ice caps

### DIFF
--- a/oggm/core/preprocessing/centerlines.py
+++ b/oggm/core/preprocessing/centerlines.py
@@ -84,7 +84,7 @@ class Centerline(object):
         self.dx = dx  # dx in pixels (assumes the line is on constant dx
         self._surface_h = surface_h
         self._widths = None
-        self.touches_border = None
+        self.is_rectangular = None
 
         # Set by external funcs
         self.geometrical_widths = None  # these are kept for plotting and such
@@ -678,9 +678,12 @@ def compute_centerlines(gdir, div_id=None):
     single_fl = not cfg.PARAMS['use_multiple_flowlines']
     do_filter_slope = cfg.PARAMS['filter_min_slope']
 
+    # Force single flowline for ice caps
+    if gdir.is_icecap:
+        single_fl = True
+
     if 'force_one_flowline' in cfg.PARAMS:
-        if gdir.rgi_id in cfg.PARAMS['force_one_flowline']:
-            single_fl = True
+        raise ValueError('`force_one_flowline` is deprecated')
 
     # open
     geom = gdir.read_pickle('geometries', div_id=div_id)

--- a/oggm/core/preprocessing/geometry.py
+++ b/oggm/core/preprocessing/geometry.py
@@ -627,10 +627,10 @@ def catchment_width_geom(gdir, div_id=None):
         # Ok now the entire centerline is computed.
         # I take all these widths for geometrically valid, and see if they
         # intersect with our buffered catchment/glacier intersections
-        touches_border = []
+        is_rectangular = []
         for wg in wlines:
-            touches_border.append(np.any(gdfi.intersects(wg)))
-        touches_border = _filter_grouplen(touches_border, minsize=5)
+            is_rectangular.append(np.any(gdfi.intersects(wg)))
+        is_rectangular = _filter_grouplen(is_rectangular, minsize=5)
 
         # we filter the lines which have a large altitude range
         fil_widths = _filter_for_altitude_range(widths, wlines, topo)
@@ -648,17 +648,15 @@ def catchment_width_geom(gdir, div_id=None):
             log.warning('({}) width filtering too strong.'.format(gdir.rgi_id))
             fil_widths = widths[np.int(len(widths) / 2.)]
 
-        # "Touches border" is a badly chosen name. In fact, it should be
-        # called "is_rectangular" since tidewater glaciers have a special
-        # treatment here
+        # Special treatment for tidewater glaciers
         if gdir.is_tidewater and fl.flows_to is None:
-            touches_border[-5:] = True
+            is_rectangular[-5:] = True
 
         # Write it in the objects attributes
         assert len(fil_widths) == n
         fl.widths = fil_widths
         fl.geometrical_widths = wlines
-        fl.touches_border = touches_border
+        fl.is_rectangular = is_rectangular
 
     # Overwrite pickle
     gdir.write_pickle(flowlines, 'inversion_flowlines', div_id=div_id)

--- a/oggm/core/preprocessing/inversion.py
+++ b/oggm/core/preprocessing/inversion.py
@@ -100,11 +100,11 @@ def prepare_for_inversion(gdir, div_id=None, add_debug_var=False,
             flux[-1] = 0.
 
         # Optimisation: we need to compute this term of a0 only once
-        flux_a0 = np.where(fl.touches_border, 1, 1.5)
+        flux_a0 = np.where(fl.is_rectangular, 1, 1.5)
         flux_a0 *= flux / widths
 
         # Shape
-        is_rectangular = fl.touches_border
+        is_rectangular = fl.is_rectangular
         if not invert_with_rectangular:
             is_rectangular[:] = False
         if invert_all_rectangular:

--- a/oggm/graphics.py
+++ b/oggm/graphics.py
@@ -378,7 +378,7 @@ def plot_catchment_width(gdir, ax=None, salemmap=None, corrected=False,
                                               linewidth=0.6, zorder=50)
 
             if add_touches:
-                pok = np.where(l.touches_border)
+                pok = np.where(l.is_rectangular)
                 xi, yi = l.line.xy
                 xis.append(np.asarray(xi)[pok])
                 yis.append(np.asarray(yi)[pok])

--- a/oggm/sandbox/gmd_paper/plot_inversion_sensi.py
+++ b/oggm/sandbox/gmd_paper/plot_inversion_sensi.py
@@ -41,7 +41,7 @@ for fl in model.fls:
     line = shpg.LineString([fl.line.coords[int(p)] for p in pg[0]])
     flo = Centerline(line, dx=fl.dx, surface_h=fl.surface_h[pg])
     flo.widths = fl.widths[pg]
-    flo.touches_border = np.ones(flo.nx).astype(np.bool)
+    flo.is_rectangular = np.ones(flo.nx).astype(np.bool)
     fls.append(flo)
 for did in [0, 1]:
     gdir.write_pickle(fls, 'inversion_flowlines', div_id=did)

--- a/oggm/sandbox/gmd_paper/plot_inversions.py
+++ b/oggm/sandbox/gmd_paper/plot_inversions.py
@@ -45,7 +45,7 @@ for fl in model.fls:
     line = shpg.LineString([fl.line.coords[int(p)] for p in pg[0]])
     flo = Centerline(line, dx=fl.dx, surface_h=fl.surface_h[pg])
     flo.widths = fl.widths[pg]
-    flo.touches_border = np.ones(flo.nx).astype(np.bool)
+    flo.is_rectangular = np.ones(flo.nx).astype(np.bool)
     fls.append(flo)
 for did in [0, 1]:
     gdir.write_pickle(fls, 'inversion_flowlines', div_id=did)
@@ -77,7 +77,7 @@ for fl in model.fls:
     line = shpg.LineString([fl.line.coords[int(p)] for p in pg[0]])
     flo = Centerline(line, dx=fl.dx, surface_h=fl.surface_h[pg])
     flo.widths = fl.widths[pg]
-    flo.touches_border = np.ones(flo.nx).astype(np.bool)
+    flo.is_rectangular = np.ones(flo.nx).astype(np.bool)
     fls.append(flo)
 for did in [0, 1]:
     gdir.write_pickle(fls, 'inversion_flowlines', div_id=did)
@@ -107,7 +107,7 @@ for fl in model.fls:
     line = shpg.LineString([fl.line.coords[int(p)] for p in pg[0]])
     flo = Centerline(line, dx=fl.dx, surface_h=fl.surface_h[pg])
     flo.widths = fl.widths[pg]
-    flo.touches_border = np.ones(flo.nx).astype(np.bool)
+    flo.is_rectangular = np.ones(flo.nx).astype(np.bool)
     fls.append(flo)
 for did in [0, 1]:
     gdir.write_pickle(fls, 'inversion_flowlines', div_id=did)
@@ -144,7 +144,7 @@ for fl in model.fls:
     sh = fl.surface_h[pg]
     flo = Centerline(line, dx=fl.dx, surface_h=sh)
     flo.widths = fl.widths[pg]
-    flo.touches_border = np.ones(flo.nx).astype(np.bool)
+    flo.is_rectangular = np.ones(flo.nx).astype(np.bool)
     fls.append(flo)
 for did in [0, 1]:
     gdir.write_pickle(fls, 'inversion_flowlines', div_id=did)

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -1235,7 +1235,7 @@ class TestIdealisedInversion(unittest.TestCase):
             flo = centerlines.Centerline(line, dx=fl.dx,
                                          surface_h=fl.surface_h[pg])
             flo.widths = fl.widths[pg]
-            flo.touches_border = np.ones(flo.nx).astype(np.bool)
+            flo.is_rectangular = np.ones(flo.nx).astype(np.bool)
             fls.append(flo)
         for did in [0, 1]:
             self.gdir.write_pickle(copy.deepcopy(fls), 'inversion_flowlines',
@@ -1264,7 +1264,7 @@ class TestIdealisedInversion(unittest.TestCase):
             flo = centerlines.Centerline(line, dx=fl.dx,
                                          surface_h=fl.surface_h[pg])
             flo.widths = fl.widths[pg]
-            flo.touches_border = np.zeros(flo.nx).astype(np.bool)
+            flo.is_rectangular = np.zeros(flo.nx).astype(np.bool)
             fls.append(flo)
         for did in [0, 1]:
             self.gdir.write_pickle(copy.deepcopy(fls), 'inversion_flowlines',
@@ -1305,7 +1305,7 @@ class TestIdealisedInversion(unittest.TestCase):
             flo = centerlines.Centerline(line, dx=fl.dx,
                                          surface_h=sh)
             flo.widths = fl.widths[pg]
-            flo.touches_border = fl.is_trapezoid[pg]
+            flo.is_rectangular = fl.is_trapezoid[pg]
             fls.append(flo)
         for did in [0, 1]:
             self.gdir.write_pickle(copy.deepcopy(fls), 'inversion_flowlines',
@@ -1337,7 +1337,7 @@ class TestIdealisedInversion(unittest.TestCase):
             flo = centerlines.Centerline(line, dx=fl.dx,
                                          surface_h=sh)
             flo.widths = fl.widths[pg]
-            flo.touches_border = np.ones(flo.nx).astype(np.bool)
+            flo.is_rectangular = np.ones(flo.nx).astype(np.bool)
             fls.append(flo)
         for did in [0, 1]:
             self.gdir.write_pickle(copy.deepcopy(fls), 'inversion_flowlines',
@@ -1367,7 +1367,7 @@ class TestIdealisedInversion(unittest.TestCase):
             flo = centerlines.Centerline(line, dx=fl.dx,
                                          surface_h=sh)
             flo.widths = fl.widths[pg]
-            flo.touches_border = np.ones(flo.nx).astype(np.bool)
+            flo.is_rectangular = np.ones(flo.nx).astype(np.bool)
             fls.append(flo)
         for did in [0, 1]:
             self.gdir.write_pickle(copy.deepcopy(fls), 'inversion_flowlines',
@@ -1398,7 +1398,7 @@ class TestIdealisedInversion(unittest.TestCase):
             flo = centerlines.Centerline(line, dx=fl.dx,
                                          surface_h=sh)
             flo.widths = fl.widths[pg]
-            flo.touches_border = np.ones(flo.nx).astype(np.bool)
+            flo.is_rectangular = np.ones(flo.nx).astype(np.bool)
             fls.append(flo)
 
         fls[0].set_flows_to(fls[1])
@@ -1435,7 +1435,7 @@ class TestIdealisedInversion(unittest.TestCase):
             flo = centerlines.Centerline(line, dx=fl.dx,
                                          surface_h=sh)
             flo.widths = fl.widths[pg]
-            flo.touches_border = np.ones(flo.nx).astype(np.bool)
+            flo.is_rectangular = np.ones(flo.nx).astype(np.bool)
             fls.append(flo)
         for did in [0, 1]:
             self.gdir.write_pickle(copy.deepcopy(fls), 'inversion_flowlines',
@@ -1468,7 +1468,7 @@ class TestIdealisedInversion(unittest.TestCase):
             flo = centerlines.Centerline(line, dx=fl.dx,
                                          surface_h=sh)
             flo.widths = fl.widths[pg]
-            flo.touches_border = np.zeros(flo.nx).astype(np.bool)
+            flo.is_rectangular = np.zeros(flo.nx).astype(np.bool)
             fls.append(flo)
         for did in [0, 1]:
             self.gdir.write_pickle(copy.deepcopy(fls), 'inversion_flowlines',

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -1921,7 +1921,7 @@ class TestGrindelInvert(unittest.TestCase):
         self.assertGreaterEqual(len(gdfc), len(fls)-1)
 
         # check touch borders qualitatively
-        self.assertGreaterEqual(np.sum(fls[-1].touches_border),  10)
+        self.assertGreaterEqual(np.sum(fls[-1].is_rectangular),  10)
 
 
 class TestGCMClimate(unittest.TestCase):

--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -2269,6 +2269,7 @@ class GlacierDirectory(object):
         self.is_tidewater = self.terminus_type in ['Marine-terminating',
                                                    'Lake-terminating']
         self.inversion_calving_rate = 0.
+        self.is_icecap = self.glacier_type == 'Ice cap'
 
         # convert the date
         try:


### PR DESCRIPTION
Most of the time, multiple flowlines don't make sense for ice-caps. This solves the problem simply by forbidding multiple flowlines for ice caps.

It also renames the "touches_border" flowline attribute to "is_rectangular"