### PR TITLE
Bug in glacier evolution numerical tests

### DIFF
--- a/oggm/__init__.py
+++ b/oggm/__init__.py
@@ -16,9 +16,9 @@ except ImportError:
                       'pip install -e .')
 
 # Spammers
-logging.getLogger("Fiona").setLevel(logging.ERROR)
-logging.getLogger("shapely").setLevel(logging.ERROR)
-logging.getLogger("rasterio").setLevel(logging.ERROR)
+logging.getLogger("Fiona").setLevel(logging.CRITICAL)
+logging.getLogger("shapely").setLevel(logging.CRITICAL)
+logging.getLogger("rasterio").setLevel(logging.CRITICAL)
 
 # Basic config
 logging.basicConfig(format='%(asctime)s: %(name)s: %(message)s',

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -763,11 +763,11 @@ class FluxBasedModel(FlowlineModel):
             max_dt = 10*SEC_IN_DAY
         elif time_stepping == 'conservative':
             cfl_number = 0.01
-            min_dt = 1*SEC_IN_HOUR
+            min_dt = SEC_IN_HOUR
             max_dt = 5*SEC_IN_DAY
         elif time_stepping == 'ultra-conservative':
             cfl_number = 0.01
-            min_dt = 0.5*SEC_IN_HOUR
+            min_dt = SEC_IN_HOUR / 10
             max_dt = 5*SEC_IN_DAY
         else:
             if time_stepping != 'user':
@@ -1627,11 +1627,13 @@ def _run_with_numerical_tests(gdir, filesuffix, mb, ys, ye, kwargs,
     for step in steps:
         log.info('(%s) trying %s time stepping scheme.', gdir.rgi_id, step)
         if model_fls is None:
-            model_fls = gdir.read_pickle('model_flowlines')
+            fls = gdir.read_pickle('model_flowlines')
+        else:
+            fls = model_fls
         if zero_initial_glacier:
-            for fl in model_fls:
+            for fl in fls:
                 fl.thick = fl.thick * 0.
-        model = FluxBasedModel(model_fls, mb_model=mb, y0=ys,
+        model = FluxBasedModel(fls, mb_model=mb, y0=ys,
                                time_stepping=step,
                                is_tidewater=gdir.is_tidewater,
                                **kwargs)

--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -941,7 +941,9 @@ def line_interpol(line, dx):
                     opbs.extend([shpg.Point(c) for c in p.coords])
             pbs = opbs
         else:
-            assert pbs.type == 'MultiPoint'
+            if pbs.type != 'MultiPoint':
+                raise RuntimeError('line_interpol: we expect a MultiPoint'
+                                    'but got a {}.'.format(pbs.type))
 
         # Out of the point(s) that we get, take the one farthest from the top
         refdis = line.project(pref)
@@ -1077,7 +1079,10 @@ def polygon_intersections(gdf):
             if isinstance(mult_intersect, shpg.linestring.LineString):
                 mult_intersect = [mult_intersect]
             for line in mult_intersect:
-                assert isinstance(line, shpg.linestring.LineString)
+                if not isinstance(line, shpg.linestring.LineString):
+                    raise RuntimeError('polygon_intersections: we expect'
+                                       'a LineString but got a '
+                                       '{}.'.format(line.type))
                 line = gpd.GeoDataFrame([[i, j, line]],
                                         columns=out_cols)
                 out = out.append(line)


### PR DESCRIPTION
This fixes an ugly bug in the glacier evolution operational runs.

The normal workflow for an operational run is to test an "adventurous"  time-stepping scheme and, if it doesn't work (i.e. runs unstable), a more conservative time stepping scheme is used. 

The bug caused the model flowlines to be re-used by the subsequent run *without* resetting them to their initial value, which had far reaching consequences:
- either their artifacts were so bad that the run would explode right away
- or it would still pass, in which case I would expect the results to be quite wrong.

I'm really curious to see what will be the implications for the global runs...