### PR TITLE
Move the 2D SIA model to the core modules

### DIFF
--- a/oggm/core/sia2d.py
+++ b/oggm/core/sia2d.py
@@ -355,11 +355,12 @@ class Upstream2D(Model2D):
         D_k_dn = self.gamma * H_k_dn ** (N + 1) * H_k_upstream_dn * s_k_grad_dn
 
         # --- Check the cfl condition
-        dt_cfl = (self.cfl * min(self.dx ** 2., self.dy ** 2.) /
-                  max(max(max(abs(D_k_up.flatten())),
-                          max(abs(D_k_dn.flatten()))),
-                      max(max(abs(D_l_up.flatten())),
-                          max(abs(D_l_dn.flatten())))))
+        divisor = max(max(np.max(np.abs(D_k_up)), np.max(np.abs(D_k_dn))),
+                      max(np.max(np.abs(D_l_up)), np.max(np.abs(D_l_dn))))
+        if divisor == 0:
+            dt_cfl = self.max_dt
+        else:
+            dt_cfl = (self.cfl * min(self.dx ** 2., self.dy ** 2.) / divisor)
 
         # --- Calculate Final diffusion term
         div_k = (D_k_up * (S[ix_(self.kp, self.l)] - S[ix_(self.k, self.l)]) /

--- a/oggm/sandbox/sia_2d/hef_dynamics.py
+++ b/oggm/sandbox/sia_2d/hef_dynamics.py
@@ -9,7 +9,7 @@ import oggm
 from oggm import cfg, tasks
 from oggm import utils, workflow
 from oggm.core.massbalance import (RandomMassBalance)
-from oggm.sandbox.sia_2d.models import Upstream2D, filter_ice_border
+from oggm.core.sia2d import Upstream2D, filter_ice_border
 from oggm.utils import get_demo_file
 
 cfg.initialize()

--- a/oggm/tests/test_numerics.py
+++ b/oggm/tests/test_numerics.py
@@ -846,8 +846,7 @@ class TestIdealisedCases(unittest.TestCase):
         assert 'exceeds domain boundaries' in str(excinfo.value)
 
 
-@pytest.mark.skip(reason='Currently not in OGGM')
-class TestSandbox(unittest.TestCase):
+class TestSia2d(unittest.TestCase):
 
     def setUp(self):
         pass
@@ -855,6 +854,7 @@ class TestSandbox(unittest.TestCase):
     def tearDown(self):
         pass
 
+    @is_slow
     def test_constant_bed(self):
 
         map_dx = 100.
@@ -885,7 +885,7 @@ class TestSandbox(unittest.TestCase):
         # Make a 2D bed out of the 1D
         bed_2d = np.repeat(fls[-1].bed_h, 3).reshape((fls[-1].nx, 3))
 
-        from oggm.sandbox.sia_2d.models import Upstream2D
+        from oggm.core.sia2d import Upstream2D
         sdmodel = Upstream2D(bed_2d, dx=map_dx, mb_model=mb, y0=0.,
                              glen_a=cfg.A, ice_thick_filter=None)
 


### PR DESCRIPTION
This is to encourage future developments/benchmarks and avoid regressions on the previously untested 2D code.