### PR TITLE
Print more useful error messages in case of exceptions in tasks

### DIFF
--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -2449,9 +2449,9 @@ class entity_task(object):
                 gdir.log(task_name, err=err)
                 pipe_log(gdir, task_name, err=err)
                 if print_log:
-                    self.log.error('%s occurred during task %s on %s!',
+                    self.log.error('%s occurred during task %s on %s: %s',
                                    type(err).__name__, task_name,
-                                   gdir.rgi_id)
+                                   gdir.rgi_id, str(err))
                 if not cfg.PARAMS['continue_on_error']:
                     raise
             return out

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -87,7 +87,7 @@ class _pickle_copier(object):
         except Exception as e:
             try:
                 err_msg = '({0}) exception occured while processing task ' \
-                          '{1}'.format(gdir.rgi_id, self.call_func.__name__)
+                          '{1}: {2}'.format(gdir.rgi_id, self.call_func.__name__, str(e))
                 raise RuntimeError(err_msg) from e
             except AttributeError:
                 pass


### PR DESCRIPTION
Saves you from opening a debugger just to look at the Exception.