### PR TITLE
DOCS: update install instructions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -401,7 +401,7 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3.5/', None),
+    'python': ('https://docs.python.org/3.6/', None),
     'pandas': ('http://pandas.pydata.org/pandas-docs/stable/', None),
     'numpy': ('http://docs.scipy.org/doc/numpy/', None),
 }

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -2,7 +2,7 @@ name: oggm
 channels:
   - conda-forge
 dependencies:
-  - python=3.5
+  - python=3.6
   - numpy=1.12.0
   - scipy=0.18.1
   - gdal=2.1.0

--- a/docs/installing-oggm.rst
+++ b/docs/installing-oggm.rst
@@ -17,10 +17,15 @@ purposes only). OGGM doesn't work with python version 2.7.
    ecosystem before trying to install and run OGGM.
 
 For most users we recommend to install python and the package dependencies
-withs the conda_ package manager:
+with the conda_ package manager:
 `Install with conda (all platforms)`_. Linux users and people
 with experience with `pip`_ can follow the specific instructions
 `Install with virtualenv (linux/debian)`_.
+
+.. warning::
+
+   If you are using a **Linux Mint** distribution you may want to test if you are
+   affected by the pyproj bug `described here <https://github.com/conda-forge/pyproj-feedstock/issues/10>`_
 
 
 .. _tested: https://travis-ci.org/OGGM/oggm
@@ -99,9 +104,10 @@ Conda environment
 We recommend to create a specific `environment`_ for OGGM. In a terminal
 window, type::
 
-    conda create --name oggm_env python=3.5
+    conda create --name oggm_env python=3.X
 
 
+where ``3.X`` is the python version shipped with conda (currently 3.6).
 You can of course use any other name for your environment.
 
 Don't forget to activate it before going on::

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -864,3 +864,26 @@ class TestDataFiles(unittest.TestCase):
         self.assertEqual(len(fdem), 3)
         for fp in fdem:
             self.assertTrue(os.path.exists(fp))
+
+
+class TestSkyIsFalling(unittest.TestCase):
+
+    def test_projplot(self):
+
+        # this caused many problems on Linux Mint distributions
+        # this is just to be sure that on your system, everything is fine
+        import pyproj
+        import matplotlib.pyplot as plt
+
+        wgs84 = pyproj.Proj(proj='latlong', datum='WGS84')
+        fig = plt.figure()
+        plt.close()
+
+        srs = ('+units=m +proj=lcc +lat_1=29.0 +lat_2=29.0 '
+               '+lat_0=29.0 +lon_0=89.8')
+
+        proj_out = pyproj.Proj("+init=EPSG:4326", preserve_units=True)
+        proj_in = pyproj.Proj(srs, preserve_units=True)
+
+        lon, lat = pyproj.transform(proj_in, proj_out, -2235000, -2235000)
+        np.testing.assert_allclose(lon, 70.75731, atol=1e-5)


### PR DESCRIPTION
Removes an outdated reference to 3.5 and adds a warning for Mint users
