### PR TITLE
Add new "external contribution" page to the docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,13 +3,13 @@
 |
 
 
-Extending `Marzeion et al., (2012)`_, the model accounts for glacier geometry 
-(including contributory branches) and includes an explicit ice dynamics module.
-It can simulate past and future mass-balance, volume and geometry of (almost)
-any glacier in the world in a fully automated workflow. We rely exclusively on
-publicly available data for calibration and validation.
+**OGGM is a modular open source model for glacier dynamics**
 
-.. _Marzeion et al., (2012): http://www.the-cryosphere.net/6/1295/2012/tc-6-1295-2012.html
+The model accounts for glacier geometry (including contributory branches) and
+includes an explicit ice dynamics module. It can simulate past and
+future mass-balance, volume and geometry of (almost) any glacier in the world
+in a fully automated and extensible workflow. We rely exclusively on publicly
+available data for calibration and validation.
 
 
 .. image:: docs/_static/ex_tasman.jpg

--- a/docs/add-module.rst
+++ b/docs/add-module.rst
@@ -1,0 +1,57 @@
+.. _add-module:
+
+*********************************
+Adding an external module to OGGM
+*********************************
+
+Thanks for helping us to make the model better!
+
+There are two ways to add a functionality to OGGM:
+
+1. The easiest (and recommended) way for small bugfixes or simple functionalities
+   is to add it directly to the main OGGM codebase. In this case, refer to
+   the :ref:`contributing` page for how to do that.
+2. If your endeavor is a larger project (i.e. a fundamental change in the model
+   physics or a new workflow), you can still use option 1 above. However,
+   there might be reasons (explained below) to use a different approach. This
+   is what this page is for.
+
+Why would I add my model to the OGGM set of tools?
+==================================================
+
+We envision OGGM as a **modular tool** to model glacier behavior. We do not
+want to force anyone towards a certain set-up or paramaterization that we chose.
+However, we believe that the OGGM capabilities could be useful to a
+wide range of applications, and also to you.
+
+Finally, we strongly believe in **model intercomparisons**. Agreeing on a
+common set of boundary conditions is the first step towards meaningful
+comparisons: this is where OGGM can help.
+
+Can I use my own repository/website and my own code style to do this?
+=====================================================================
+
+Yes you can!
+
+Ideally, we would have your module added to the main codebase: this ensures
+consistency of the code and continuous testing. However, there are several
+reasons why making your own repository could be useful:
+
+- complying to OGGM's strict testing rules can be annoying, especially in the
+  early stages of development of a model
+- with you own repository you have full control on it's development while
+  still being able to use the OGGM workflow and multiprocessing capabilities
+- with an external module the users who will use your model *will* have
+  to download it from here and you can make sure that correct attribution
+  is made to your work, i.e. by specifying that using this module requires a
+  reference to a specific scientific publication
+- if your funding agency requires you to have your own public website
+- etc.
+
+
+To help you in this project we have set-up a
+`template repository <https://github.com/OGGM/dummy-module>`_ from which you can
+build upon.
+
+Before writing your own module we recommend to contact us to discuss
+the best path to follow in your specific case.

--- a/docs/templates/index.txt
+++ b/docs/templates/index.txt
@@ -1,20 +1,18 @@
 
-An open source glacier model in Python
---------------------------------------
+An modular open source glacier model in Python
+----------------------------------------------
 
-Extending `Marzeion et al., (2012)`_, the model accounts for glacier geometry
-(including contributory branches) and includes an explicit ice dynamics module.
-It can simulate past and future mass-balance, volume and geometry of (almost)
-any glacier in the world in a fully automated workflow. We rely exclusively on
-publicly available data for calibration and validation.
+The model accounts for glacier geometry (including contributory branches) and
+includes an explicit ice dynamics module. It can simulate past and
+future mass-balance, volume and geometry of (almost) any glacier in the world
+in a fully automated and extensible workflow. We rely exclusively on publicly
+available data for calibration and validation.
 
 [version-specific-text]
 
 
 **For more information about the OGGM project and for the latest news, visit**
 `oggm.org <http://oggm.org>`_.
-
-.. _Marzeion et al., (2012): http://www.the-cryosphere.net/6/1295/2012/tc-6-1295-2012.html
 
 
 Index
@@ -70,6 +68,7 @@ Contributing
 ^^^^^^^^^^^^
 
 * :doc:`citing-oggm`
+* :doc:`add-module`
 * :doc:`contributing`
 
 .. toctree::
@@ -78,6 +77,7 @@ Contributing
     :caption: Contributing
 
     citing-oggm.rst
+    add-module.rst
     contributing.rst
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,0 @@
-[bdist_wheel]
-# This flag says that the code is written to work on both Python 2 and Python 3
-universal=1


### PR DESCRIPTION
This change is motivated by several discussions I had with David Rounce and @nchampollion at EGU.

This opens the way to a much more flexible way to add modules to OGGM. I believe this will more people to use the OGGM workflow while still having control on their code and who uses their model.