### PR TITLE
Enhance/Fix tests to work distributed with pytest-xdist

### DIFF
--- a/oggm/tests/__init__.py
+++ b/oggm/tests/__init__.py
@@ -47,6 +47,7 @@ RUN_WORKFLOW_TESTS = True
 RUN_GRAPHIC_TESTS = True
 RUN_BENCHMARK_TESTS = True
 RUN_PERFORMANCE_TESTS = False
+RUN_CREDENTIAL_TESTS = False
 if os.environ.get('TRAVIS') is not None:
     # specific to travis to reduce global test time
     ON_TRAVIS = True
@@ -118,6 +119,8 @@ if os.environ.get('OGGM_SLOW_TESTS') is not None:
     RUN_SLOW_TESTS = True
 if os.environ.get('OGGM_DOWNLOAD_TESTS') is not None:
     RUN_DOWNLOAD_TESTS = True
+if os.environ.get('OGGM_CREDENTIAL_TESTS') is not None:
+    RUN_CREDENTIAL_TESTS = True
 
 # quick n dirty method to see if internet is on
 try:
@@ -163,3 +166,9 @@ def is_performance_test(test):
     # Test decorator
     msg = "requires explicit environment for performance tests"
     return test if RUN_PERFORMANCE_TESTS else unittest.skip(msg)(test)
+
+
+def is_download_cred(test):
+    # Test decorator
+    msg = "requires explicit environment for download and credential tests (AWS)"
+    return test if RUN_CREDENTIAL_TESTS and RUN_DOWNLOAD_TESTS else unittest.skip(msg)(test)

--- a/oggm/tests/conftest.py
+++ b/oggm/tests/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+import logging
+import multiprocessing as mp
+from oggm import cfg, utils
+import pickle
+
+logger = logging.getLogger(__name__)
+
+def pytest_configure(config):
+    if config.pluginmanager.hasplugin('xdist'):
+        try:
+            from ilock import ILock
+            utils.lock = ILock("oggm_xdist_download_lock")
+            logger.info("ilock locking setup successfully for xdist tests")
+        except:
+            logger.warning("could not setup ilock locking for distributed tests")
+

--- a/oggm/tests/funcs.py
+++ b/oggm/tests/funcs.py
@@ -236,6 +236,8 @@ def get_test_dir():
 
     s = get_ident()
     out = os.path.join(cfg.PATHS['test_dir'], s)
+    if 'PYTEST_XDIST_WORKER' in os.environ:
+        out = os.path.join(out, os.environ.get('PYTEST_XDIST_WORKER'))
     mkdir(out)
 
     # If new ident, remove all other dirs so spare space

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -15,7 +15,7 @@ from numpy.testing import assert_array_equal, assert_allclose
 import oggm
 from oggm import utils
 from oggm import cfg
-from oggm.tests import is_download
+from oggm.tests import is_download, is_download_cred
 from oggm.tests.funcs import get_test_dir, patch_url_retrieve_github, init_hef
 from oggm.utils import shape_factor_adhikari
 _url_retrieve = None
@@ -760,7 +760,7 @@ class TestDataFiles(unittest.TestCase):
         zone = '41_20'
         self.assertTrue(utils._download_srtm_file(zone) is None)
 
-    @is_download
+    @is_download_cred
     def test_asterdownload(self):
 
         # this zone does exist and file should be small enough for download
@@ -780,7 +780,7 @@ class TestDataFiles(unittest.TestCase):
         fp, z = utils.get_topo_file([-20, -20], [65, 65])
         self.assertTrue(os.path.exists(fp[0]))
 
-    @is_download
+    @is_download_cred
     def test_asterdownloadfails(self):
 
         # this zone does not exist

--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -334,6 +334,8 @@ class TestWorkflow(unittest.TestCase):
     def test_random(self):
 
         # Fake Reset (all these tests are horribly coded)
+        if not os.path.exists(TEST_DIR):
+            os.makedirs(TEST_DIR)
         with open(CLI_LOGF, 'wb') as f:
             pickle.dump('none', f)
         gdirs = up_to_inversion()


### PR DESCRIPTION
With this, the cluster can run the tests in parallel on 56 Threads, completing all tests, including slow tests, in around one minute.