### PR TITLE
Relax constraint on RGI area conservation with new parameter

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -66,6 +66,10 @@ Enhancements
   outlines or DEM errors (:pull:`445`). This will be used to report to the
   RGI authors.
   By `Fabien Maussion <https://github.com/fmaussion>`_.
+- Added a new parameter (``PARAMS['use_rgi_area']``), which specifies whether
+  OGGM should use the reference area provided by RGI or the one computed
+  from the local map and reprojected outlines  (:pull:`458`, default: True).
+  By `Matthias Dusch <https://github.com/matthiasdusch>`_.
 
 
 Bug fixes

--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -259,6 +259,7 @@ def initialize(file=None):
     PARAMS['rgi_version'] = cp['rgi_version']
     PARAMS['hydro_month_nh'] = cp.as_int('hydro_month_nh')
     PARAMS['hydro_month_sh'] = cp.as_int('hydro_month_sh')
+    PARAMS['use_rgi_area'] = cp.as_bool('use_rgi_area')
 
     # Climate
     PARAMS['temp_use_local_gradient'] = cp.as_bool('temp_use_local_gradient')
@@ -303,7 +304,7 @@ def initialize(file=None):
            'prcp_scaling_factor', 'use_intersects', 'filter_min_slope',
            'auto_skip_task', 'correct_for_neg_flux', 'filter_for_neg_flux',
            'rgi_version', 'allow_negative_mustar',
-           'use_shape_factor_for_inversion',
+           'use_shape_factor_for_inversion', 'use_rgi_area',
            'use_shape_factor_for_fluxbasedmodel']
     for k in ltr:
         cp.pop(k, None)

--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -73,6 +73,9 @@ topo_interp = cubic
 # Make it large if you want to do past simulations.
 border = 20
 
+# Use the RGI area as reference or the one from the geometry?
+use_rgi_area = True
+
 # Head determination: (approx) size in meters of the half-size window
 # where to look for maximas
 localmax_window = 500.

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -110,6 +110,16 @@ class TestGIS(unittest.TestCase):
         # This is not guaranteed to be equal because of projection issues
         np.testing.assert_allclose(extent, gdir.extent_ll, atol=1e-5)
 
+        # Change area
+        prev_area = gdir.rgi_area_km2
+        cfg.PARAMS['use_rgi_area'] = False
+        entity = gpd.GeoDataFrame.from_file(hef_file).iloc[0]
+        gdir = oggm.GlacierDirectory(entity, base_dir=self.testdir,
+                                     reset=True)
+        gis.define_glacier_region(gdir, entity=entity)
+        np.testing.assert_allclose(gdir.rgi_area_km2, prev_area, atol=0.01)
+
+
     def test_divides_as_glaciers(self):
 
         hef_rgi = gpd.GeoDataFrame.from_file(get_demo_file('divides_alps.shp'))

--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -2812,7 +2812,7 @@ class GlacierDirectory(object):
         """A ``salem.Grid`` handling the georeferencing of the local grid"""
         return salem.Grid.from_json(self.get_filepath('glacier_grid'))
 
-    @lazy_property
+    @property
     def rgi_area_m2(self):
         """The glacier's RGI area (m2)."""
         return self.rgi_area_km2 * 10**6


### PR DESCRIPTION
 - [x] Tests added/passed
 - [x] Fully documented, including `whats-new.rst` for all changes

with ``PARAMS['use_rgi_area'] = False``, OGGM will use the geometry's area instead of the one provided by the RGI shapefile.
