### PR TITLE
Diagnostic variables are now stored at a yearly timestep during run

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -40,6 +40,12 @@ Breaking changes
   are better, but not backwards compatible. Aside of me I don't think
   anybody was using them (:pull:`465`).
   By `Fabien Maussion <https://github.com/fmaussion>`_.
+- Diagnostic variables (length, area, volume, ELA) are now stored at annual
+  steps instead of montly steps (:pull:`488`). The old behavior can still be
+  used with the ``store_monthly_step`` kwarg. Most users should not notice
+  this change because the regionaly compiled files were stored yearly
+  anyways.
+  By `Fabien Maussion <https://github.com/fmaussion>`_.
 
 Enhancements
 ~~~~~~~~~~~~

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -130,7 +130,7 @@ class MassBalanceModel(object, metaclass=SuperclassMeta):
         def to_minimize(x):
             o = self.get_annual_mb([x], year=year)[0] * SEC_IN_YEAR * cfg.RHO
             return o
-        return optimization.brentq(to_minimize, *self.valid_bounds, xtol=1)
+        return optimization.brentq(to_minimize, *self.valid_bounds, xtol=0.1)
 
 
 class LinearMassBalance(MassBalanceModel):

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -130,7 +130,7 @@ class MassBalanceModel(object, metaclass=SuperclassMeta):
         def to_minimize(x):
             o = self.get_annual_mb([x], year=year)[0] * SEC_IN_YEAR * cfg.RHO
             return o
-        return optimization.brentq(to_minimize, *self.valid_bounds, xtol=0.1)
+        return optimization.brentq(to_minimize, *self.valid_bounds, xtol=1)
 
 
 class LinearMassBalance(MassBalanceModel):

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -1091,7 +1091,7 @@ class TestIO(unittest.TestCase):
         fls = dummy_constant_bed()
         model = flowline.FluxBasedModel(fls, mb_model=mb, y0=0.,
                                         glen_a=self.glen_a)
-        ds, ds_diag = model.run_until_and_store(500, use_monthly_step=True)
+        ds, ds_diag = model.run_until_and_store(500, store_monthly_step=True)
         ds = ds[0]
 
         fls = dummy_constant_bed()
@@ -1138,7 +1138,7 @@ class TestIO(unittest.TestCase):
                                         glen_a=self.glen_a)
         model.run_until_and_store(500, run_path=run_path,
                                   diag_path=diag_path,
-                                  use_monthly_step=True)
+                                  store_monthly_step=True)
 
         ds_ = xr.open_dataset(diag_path)
         # the identical (i.e. attrs + names) doesn't work because of date

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -1091,7 +1091,7 @@ class TestIO(unittest.TestCase):
         fls = dummy_constant_bed()
         model = flowline.FluxBasedModel(fls, mb_model=mb, y0=0.,
                                         glen_a=self.glen_a)
-        ds, ds_diag = model.run_until_and_store(500)
+        ds, ds_diag = model.run_until_and_store(500, use_monthly_step=True)
         ds = ds[0]
 
         fls = dummy_constant_bed()
@@ -1118,6 +1118,95 @@ class TestIO(unittest.TestCase):
                 l_ref.append(model.length_m)
                 if int(yr) == 500:
                     secfortest = model.fls[0].section
+
+        np.testing.assert_allclose(ds.ts_section.isel(time=-1),
+                                   secfortest)
+
+        np.testing.assert_allclose(ds_diag.volume_m3, vol_diag)
+        np.testing.assert_allclose(ds_diag.area_m2, a_diag)
+        np.testing.assert_allclose(ds_diag.length_m, l_diag)
+        np.testing.assert_allclose(ds_diag.ela_m, ela_diag)
+
+        fls = dummy_constant_bed()
+        run_path = os.path.join(self.test_dir, 'ts_ideal.nc')
+        diag_path = os.path.join(self.test_dir, 'ts_diag.nc')
+        if os.path.exists(run_path):
+            os.remove(run_path)
+        if os.path.exists(diag_path):
+            os.remove(diag_path)
+        model = flowline.FluxBasedModel(fls, mb_model=mb, y0=0.,
+                                        glen_a=self.glen_a)
+        model.run_until_and_store(500, run_path=run_path,
+                                  diag_path=diag_path,
+                                  use_monthly_step=True)
+
+        ds_ = xr.open_dataset(diag_path)
+        # the identical (i.e. attrs + names) doesn't work because of date
+        del ds_diag.attrs['creation_date']
+        del ds_.attrs['creation_date']
+        xr.testing.assert_identical(ds_diag, ds_)
+
+        fmodel = flowline.FileModel(run_path)
+        assert fmodel.last_yr == 500
+        fls = dummy_constant_bed()
+        model = flowline.FluxBasedModel(fls, mb_model=mb, y0=0.,
+                                        glen_a=self.glen_a)
+        for yr in years:
+            model.run_until(yr)
+            if yr in [100, 300, 500]:
+                # this is sloooooow so we test a little bit only
+                fmodel.run_until(yr)
+                np.testing.assert_allclose(model.fls[0].section,
+                                           fmodel.fls[0].section)
+                np.testing.assert_allclose(model.fls[0].widths_m,
+                                           fmodel.fls[0].widths_m)
+
+        np.testing.assert_allclose(fmodel.volume_m3_ts(), vol_ref)
+        np.testing.assert_allclose(fmodel.area_m2_ts(), a_ref)
+        np.testing.assert_allclose(fmodel.length_m_ts(), l_ref)
+
+        # Can we start a run from the middle?
+        fmodel.run_until(300)
+        model = flowline.FluxBasedModel(fmodel.fls, mb_model=mb, y0=300,
+                                        glen_a=self.glen_a)
+        model.run_until(500)
+        fmodel.run_until(500)
+        np.testing.assert_allclose(model.fls[0].section,
+                                   fmodel.fls[0].section)
+
+    @is_slow
+    def test_run_annual_step(self):
+        mb = LinearMassBalance(2600.)
+
+        fls = dummy_constant_bed()
+        model = flowline.FluxBasedModel(fls, mb_model=mb, y0=0.,
+                                        glen_a=self.glen_a)
+        ds, ds_diag = model.run_until_and_store(500)
+        ds = ds[0]
+
+        fls = dummy_constant_bed()
+        model = flowline.FluxBasedModel(fls, mb_model=mb, y0=0.,
+                                        glen_a=self.glen_a)
+
+        years = np.arange(0, 501)
+        vol_ref = []
+        a_ref = []
+        l_ref = []
+        vol_diag = []
+        a_diag = []
+        l_diag = []
+        ela_diag = []
+        for yr in years:
+            model.run_until(yr)
+            vol_diag.append(model.volume_m3)
+            a_diag.append(model.area_m2)
+            l_diag.append(model.length_m)
+            ela_diag.append(model.mb_model.get_ela(year=yr))
+            vol_ref.append(model.volume_m3)
+            a_ref.append(model.area_m2)
+            l_ref.append(model.length_m)
+            if int(yr) == 500:
+                secfortest = model.fls[0].section
 
         np.testing.assert_allclose(ds.ts_section.isel(time=-1),
                                    secfortest)
@@ -2306,7 +2395,6 @@ class TestHEF(unittest.TestCase):
         assert (ds1.volume.isel(rgi_id=0, time=-1) <
                 0.7*ds3.volume.isel(rgi_id=0, time=-1))
 
-
     @is_slow
     def test_elevation_feedback(self):
 
@@ -2318,7 +2406,8 @@ class TestHEF(unittest.TestCase):
         for feedback in feedbacks:
             tasks.append((flowline.run_random_climate,
                           dict(nyears=200, seed=5, mb_elev_feedback=feedback,
-                               output_filesuffix=feedback)))
+                               output_filesuffix=feedback,
+                               store_monthly_step=True)))
         workflow.execute_parallel_tasks(self.gdir, tasks)
 
         out = []

--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -343,6 +343,7 @@ class TestWorkflow(unittest.TestCase):
         workflow.execute_entity_task(flowline.init_present_time_glacier, gdirs)
         workflow.execute_entity_task(flowline.run_random_climate, gdirs,
                                      nyears=200, seed=0,
+                                     store_monthly_step=True,
                                      output_filesuffix='_test')
 
         for gd in gdirs:
@@ -371,7 +372,7 @@ class TestWorkflow(unittest.TestCase):
             assert_allclose(df.RUN, df.DIAG)
 
         # Test output
-        ds = utils.compile_run_output(gdirs, filesuffix='_test', monthly=True)
+        ds = utils.compile_run_output(gdirs, filesuffix='_test')
         assert_allclose(ds_diag.volume_m3, ds.volume.sel(rgi_id=gd.rgi_id))
         assert_allclose(ds_diag.area_m2, ds.area.sel(rgi_id=gd.rgi_id))
         assert_allclose(ds_diag.length_m, ds.length.sel(rgi_id=gd.rgi_id))

--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -2056,7 +2056,7 @@ def get_ref_mb_glaciers(gdirs):
     return ref_gdirs
 
 
-def compile_run_output(gdirs, path=True, monthly=False, filesuffix=''):
+def compile_run_output(gdirs, path=True, filesuffix=''):
     """Merge the output of the model runs of several gdirs into one file.
 
     Parameters
@@ -2065,8 +2065,6 @@ def compile_run_output(gdirs, path=True, monthly=False, filesuffix=''):
         the list of GlacierDir to process.
     path : str
         where to store (default is on the working dir).
-    monthly : bool
-        whether to store monthly values (default is yearly)
     filesuffix : str
         the filesuffix of the run
     """
@@ -2096,17 +2094,6 @@ def compile_run_output(gdirs, path=True, monthly=False, filesuffix=''):
         months = ds_diag.hydro_month.values
         cyrs = ds_diag.calendar_year.values
         cmonths = ds_diag.calendar_month.values
-
-        # Monthly or not
-        if monthly:
-            pkeep = np.ones(len(time), dtype=np.bool)
-        else:
-            pkeep = np.where(months == 1)
-        time = time[pkeep]
-        yrs = yrs[pkeep]
-        months = months[pkeep]
-        cyrs = cyrs[pkeep]
-        cmonths = cmonths[pkeep]
 
         # Prepare output
         ds = xr.Dataset()
@@ -2141,10 +2128,10 @@ def compile_run_output(gdirs, path=True, monthly=False, filesuffix=''):
             ppath = gdir.get_filepath('model_diagnostics',
                                       filesuffix=filesuffix)
             with xr.open_dataset(ppath) as ds_diag:
-                vol[:, i] = ds_diag.volume_m3.values[pkeep]
-                area[:, i] = ds_diag.area_m2.values[pkeep]
-                length[:, i] = ds_diag.length_m.values[pkeep]
-                ela[:, i] = ds_diag.ela_m.values[pkeep]
+                vol[:, i] = ds_diag.volume_m3.values
+                area[:, i] = ds_diag.area_m2.values
+                length[:, i] = ds_diag.length_m.values
+                ela[:, i] = ds_diag.ela_m.values
         except:
             vol[:, i] = np.NaN
             area[:, i] = np.NaN


### PR DESCRIPTION
… per default

 - [x] Tests added/passed
 - [x] Fully documented, including `whats-new.rst` for all changes 