### PR TITLE
adds missing package to the getting started documentation

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -31,6 +31,7 @@ The following imports are necessary for all of the examples:
 
     import geopandas as gpd
     import oggm
+    import os
     from oggm import cfg, tasks, graphics
     from oggm.utils import get_demo_file
 


### PR DESCRIPTION
This pull request adds `import os` to the getting starting documentation. Not importing that package results in an error message when doing step 19 on that page. 