### PR TITLE
Changed SRTM download urls

### DIFF
--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -484,7 +484,8 @@ class TestFakeDownloads(unittest.TestCase):
                               fakefile='srtm_39_03.tif')
 
         def down_check(url, cache_name=None, reset=False):
-            expected = 'http://droppr.org/srtm/v4.1/6_5x5_TIFs/srtm_39_03.zip'
+            expected = 'http://srtm.csi.cgiar.org/SRT-ZIP/SRTM_V41/' + \
+              'SRTM_Data_GeoTiff/srtm_39_03.zip'
             self.assertEqual(url, expected)
             return tf
 

--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -600,7 +600,8 @@ def _download_srtm_file_unlocked(zone):
         return outpath
 
     # Did we download it yet?
-    wwwfile = 'http://droppr.org/srtm/v4.1/6_5x5_TIFs/srtm_' + zone + '.zip'
+    wwwfile = 'http://srtm.csi.cgiar.org/SRT-ZIP/SRTM_V41/' +\
+        'SRTM_Data_GeoTiff/srtm_' + zone + '.zip'
     dest_file = file_downloader(wwwfile)
 
     # None means we tried hard but we couldn't find it
@@ -2292,7 +2293,7 @@ def compile_climate_input(gdirs, path=True, filename='climate_monthly',
 def compile_task_log(gdirs, task_names=[], filesuffix='', path=True,
                      append=True):
     """Gathers the log output for the selected task(s)
-    
+
     Parameters
     ----------
     gdirs: the list of GlacierDir to process.
@@ -2335,11 +2336,11 @@ def glacier_characteristics(gdirs, filesuffix='', path=True,
                             inversion_only=False):
     """Gathers as many statistics as possible about a list of glacier
     directories.
-    
+
     It can be used to do result diagnostics and other stuffs. If the data
     necessary for a statistic is not available (e.g.: flowlines length) it
     will simply be ignored.
-    
+
     Parameters
     ----------
     gdirs: the list of GlacierDir to process.


### PR DESCRIPTION
 - [X] Closes #504 
 - [X] Tests already exist

Changes the dead 'droppr.org' url to 'http://srtm.csi.cgiar.org/SRT-ZIP/SRTM_V41/SRTM_Data_GeoTiff/' as proposed by @DavidParkes. 

A test to download a SRTM file already exists (`test_srtmdownload`).
But this test will not download the file if it still exits in the cache. This should probably be adapted.