### PR TITLE
defined rgi_area_km2 as (lazy) property and changed how it is determined

### DIFF
--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -2906,8 +2906,8 @@ class GlacierDirectory(object):
     @lazy_property
     def rgi_area_km2(self):
         """The glacier's RGI area (km2)."""
-        _area = gpd.read_file(self.get_filepath('outlines'))['Area'].values[0]
-        return float(_area.round(decimals=3))
+        _area = gpd.read_file(self.get_filepath('outlines'))['Area']
+        return np.round(float(_area), decimals=3)
 
     @property
     def rgi_area_m2(self):

--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -2673,6 +2673,7 @@ def idealized_gdir(surface_h, widths_m, map_dx, flowline_dx=1,
     entity.O1Region = '00'
     entity.O2Region = '0'
     gdir = GlacierDirectory(entity, base_dir=base_dir, reset=reset)
+    gpd.GeoDataFrame([entity]).to_file(gdir.get_filepath('outlines'))
 
     # Idealized flowline
     coords = np.arange(0, len(surface_h)-0.5, 1)

--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -2907,7 +2907,7 @@ class GlacierDirectory(object):
     def rgi_area_km2(self):
         """The glacier's RGI area (km2)."""
         _area = gpd.read_file(self.get_filepath('outlines'))['Area'].values[0]
-        return _area.round(decimals=3)
+        return float(_area.round(decimals=3))
 
     @property
     def rgi_area_m2(self):

--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -2784,7 +2784,6 @@ class GlacierDirectory(object):
         # Should be V5
         self.rgi_id = rgi_entity.RGIId
         self.glims_id = rgi_entity.GLIMSId
-        self.rgi_area_km2 = float(rgi_entity.Area)
         self.cenlon = float(rgi_entity.CenLon)
         self.cenlat = float(rgi_entity.CenLat)
         self.rgi_region = '{:02d}'.format(int(rgi_entity.O1Region))
@@ -2903,6 +2902,12 @@ class GlacierDirectory(object):
     def grid(self):
         """A ``salem.Grid`` handling the georeferencing of the local grid"""
         return salem.Grid.from_json(self.get_filepath('glacier_grid'))
+
+    @lazy_property
+    def rgi_area_km2(self):
+        """The glacier's RGI area (km2)."""
+        _area = gpd.read_file(self.get_filepath('outlines'))['Area'].values[0]
+        return _area.round(decimals=3)
 
     @property
     def rgi_area_m2(self):


### PR DESCRIPTION
This change should only effect you if `cfg.PARAMS['use_rgi_area'] == False` (where `True` is the default setting).

Previously if a none-rgi-area was used, it was not correctly set in the GlacierDirectory.

- If `cfg.PARAMS['use_rgi_area'] == False`: The glacier area will be calculated from the polygon geometry within `gis.define_glacier_region`.
- If `cfg.PARAMS['use_rgi_area'] == True`: The area will not be calculated, instead the RGI database value will be used. This was also the default behavior up till now.

In both cases the glacier area will be written to the glaciers outline shapefile. And now `rgi_area_km2` is a (lazy) property of a GlacierDirectory and will open the shapefile and read the area.

 - [x] Tests did already exist