### PR TITLE
Additional modifs to length change notebook

### DIFF
--- a/docs/notebooks/dynamics_and_length_changes.ipynb
+++ b/docs/notebooks/dynamics_and_length_changes.ipynb
@@ -20,7 +20,7 @@
    "source": [
     "This code was used to make the analyses shown in this blog post: http://oggm.org/2017/10/23/length-changes/\n",
     "\n",
-    "Date: 25.10.2017, updated 24.09.2018"
+    "Date: 25.10.2017, updated 26.09.2018"
    ]
   },
   {
@@ -66,7 +66,7 @@
     "cfg.PARAMS['ye'] = 2003  # This is the actual date of RGI\n",
     "cfg.PARAMS['border'] = 160\n",
     "cfg.PARAMS['use_intersects'] = False\n",
-    "cfg.PARAMS['baseline_climate']= 'HISTALP'"
+    "cfg.PARAMS['baseline_climate']= 'CUSTOM'"
    ]
   },
   {
@@ -121,7 +121,7 @@
    "source": [
     "odf = pd.DataFrame()\n",
     "for seed in [0, 1, 2, 3, 4]:\n",
-    "    suff = 'rdn_mustar_seed{}'.format(seed)\n",
+    "    suff = '_rdn_mustar_seed{}'.format(seed)\n",
     "    # bias=0 to ensure equibilbrium climate at t*. Needed for t* only!\n",
     "    tasks.run_random_climate(gdir, bias=0, nyears=400, output_filesuffix=suff, seed=seed);\n",
     "    ds = xr.open_dataset(gdir.get_filepath('model_diagnostics', filesuffix=suff))\n",
@@ -147,8 +147,8 @@
    "outputs": [],
    "source": [
     "# Plot 1\n",
-    "# We do the running average over 36 months for nice looking plots but this isn't necessary \n",
-    "ax = (odf.rolling(36, center=True).mean() - len_0).plot();\n",
+    "# We do the running average over 7 years for nice looking plots but this isn't necessary \n",
+    "ax = (odf.rolling(7, center=True).mean() - len_0).plot();\n",
     "ax.set_ylabel('Glacier Length Change [m]');\n",
     "ax.set_ylim([-1500, 1500])\n",
     "plt.title('Hintereisferner length changes in a random climate')\n",
@@ -179,7 +179,7 @@
    "outputs": [],
    "source": [
     "ds = xr.open_dataset(gdir.get_filepath('model_diagnostics', filesuffix='hist_from_current'))\n",
-    "s = ds.length_m.to_series().rolling(36, center=True).mean()\n",
+    "s = ds.length_m.to_series().rolling(7, center=True).mean()\n",
     "s = s - len_0\n",
     "ax = df.plot(c='k', label='Observations');\n",
     "s.plot(c='C0', label='OGGM');\n",
@@ -215,7 +215,7 @@
    "outputs": [],
    "source": [
     "ds = xr.open_dataset(gdir.get_filepath('model_diagnostics', filesuffix=suff))\n",
-    "s = ds.length_m.to_series().rolling(36, center=True).mean()\n",
+    "s = ds.length_m.to_series().rolling(7, center=True).mean()\n",
     "s = s - len_0\n",
     "s.plot();\n",
     "plt.title('Glacier length in a colder, random climate');"
@@ -250,7 +250,7 @@
    "outputs": [],
    "source": [
     "ds = xr.open_dataset(gdir.get_filepath('model_diagnostics', filesuffix='hist_from_bias'))\n",
-    "s = ds.length_m.to_series().rolling(36, center=True).mean()\n",
+    "s = ds.length_m.to_series().rolling(7, center=True).mean()\n",
     "s = s - len_0\n",
     "ax = df.plot(c='k', label='Observations');\n",
     "s.plot(c='C0', label='OGGM');\n",
@@ -265,7 +265,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Historical run from a liquid glacier"
+    "## Historical run from a \"more liquid\" glacier"
    ]
   },
   {
@@ -287,7 +287,7 @@
    "outputs": [],
    "source": [
     "ds = xr.open_dataset(gdir.get_filepath('model_diagnostics', filesuffix=suff))\n",
-    "s = ds.length_m.to_series().rolling(36, center=True).mean()\n",
+    "s = ds.length_m.to_series().rolling(7, center=True).mean()\n",
     "s = s - len_0\n",
     "s.plot();\n",
     "plt.title('Glacier length in a colder, random climate');"
@@ -311,7 +311,7 @@
    "outputs": [],
    "source": [
     "ds = xr.open_dataset(gdir.get_filepath('model_diagnostics', filesuffix='hist_from_bias_a'))\n",
-    "s = ds.length_m.to_series().rolling(36, center=True).mean()\n",
+    "s = ds.length_m.to_series().rolling(7, center=True).mean()\n",
     "s = s - len_0\n",
     "ax = df.plot(c='k', label='Observations');\n",
     "s.plot(c='C0', label='OGGM');\n",
@@ -371,16 +371,16 @@
     "tmp_mod = FileModel(gdir.get_filepath('model_run', filesuffix=suff))\n",
     "tmp_mod.run_until(0)\n",
     "tasks.run_from_climate_data(gdir, ys=1601, ye=2003, init_model_fls=tmp_mod.fls,\n",
-    "                            climate_filename='cesm_data', output_filesuffix='cesm_from_bias');\n",
+    "                            climate_filename='cesm_data', output_filesuffix='_cesm_from_bias');\n",
     "tmp_mod.run_until(100)\n",
     "tasks.run_from_climate_data(gdir, ys=1601, ye=2003, init_model_fls=tmp_mod.fls,\n",
-    "                            climate_filename='cesm_data', output_filesuffix='cesm_from_bias_100');\n",
+    "                            climate_filename='cesm_data', output_filesuffix='_cesm_from_bias_100');\n",
     "tmp_mod.run_until(200)\n",
     "tasks.run_from_climate_data(gdir, ys=1601, ye=2003, init_model_fls=tmp_mod.fls,\n",
-    "                            climate_filename='cesm_data', output_filesuffix='cesm_from_bias_200');\n",
+    "                            climate_filename='cesm_data', output_filesuffix='_cesm_from_bias_200');\n",
     "tmp_mod.run_until(300)\n",
     "tasks.run_from_climate_data(gdir, ys=1601, ye=2003, init_model_fls=tmp_mod.fls,\n",
-    "                            climate_filename='cesm_data', output_filesuffix='cesm_from_bias_300');"
+    "                            climate_filename='cesm_data', output_filesuffix='_cesm_from_bias_300');"
    ]
   },
   {
@@ -390,17 +390,17 @@
    "outputs": [],
    "source": [
     "pdf = pd.DataFrame()\n",
-    "ds = xr.open_dataset(gdir.get_filepath('model_diagnostics', filesuffix='cesm_from_bias'))\n",
-    "s = ds.length_m.to_series().rolling(36, center=True).mean()\n",
+    "ds = xr.open_dataset(gdir.get_filepath('model_diagnostics', filesuffix='_cesm_from_bias'))\n",
+    "s = ds.length_m.to_series().rolling(7, center=True).mean()\n",
     "pdf['Init HEF'] = s - len_0\n",
-    "ds = xr.open_dataset(gdir.get_filepath('model_diagnostics', filesuffix='cesm_from_bias_100'))\n",
-    "s = ds.length_m.to_series().rolling(36, center=True).mean()\n",
+    "ds = xr.open_dataset(gdir.get_filepath('model_diagnostics', filesuffix='_cesm_from_bias_100'))\n",
+    "s = ds.length_m.to_series().rolling(7, center=True).mean()\n",
     "pdf['Large HEF'] = s - len_0\n",
-    "ds = xr.open_dataset(gdir.get_filepath('model_diagnostics', filesuffix='cesm_from_bias_200'))\n",
-    "s = ds.length_m.to_series().rolling(36, center=True).mean()\n",
+    "ds = xr.open_dataset(gdir.get_filepath('model_diagnostics', filesuffix='_cesm_from_bias_200'))\n",
+    "s = ds.length_m.to_series().rolling(7, center=True).mean()\n",
     "pdf['Larger HEF'] = s - len_0\n",
-    "ds = xr.open_dataset(gdir.get_filepath('model_diagnostics', filesuffix='cesm_from_bias_300'))\n",
-    "s = ds.length_m.to_series().rolling(36, center=True).mean()\n",
+    "ds = xr.open_dataset(gdir.get_filepath('model_diagnostics', filesuffix='_cesm_from_bias_300'))\n",
+    "s = ds.length_m.to_series().rolling(7, center=True).mean()\n",
     "pdf['Even larger HEF'] = s - len_0\n",
     "\n",
     "ax = pdf.plot();\n",
@@ -438,6 +438,19 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.5.2"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": false,
+   "sideBar": true,
+   "skip_h1_title": true,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
   }
  },
  "nbformat": 4,

--- a/oggm/core/climate.py
+++ b/oggm/core/climate.py
@@ -260,6 +260,11 @@ def process_cru_data(gdir):
     (provided with OGGM) and writes everything to a NetCDF file.
     """
 
+    if cfg.PATHS.get('climate_file', None):
+        raise warnings.warn("You seem to have set a custom climate file for "
+                            "this run, but are using the default CRU climate "
+                            "file.")
+
     if cfg.PARAMS['baseline_climate'] != 'CRU':
         raise ValueError("cfg.PARAMS['baseline_climate'] should be set to CRU")
 
@@ -456,6 +461,11 @@ def process_histalp_data(gdir):
 
     Extracts the nearest timeseries and writes everything to a NetCDF file.
     """
+
+    if cfg.PATHS.get('climate_file', None):
+        raise warnings.warn("You seem to have set a custom climate file for "
+                            "this run, but are using the default HISTALP "
+                            "climate file.")
 
     if cfg.PARAMS['baseline_climate'] != 'HISTALP':
         raise ValueError("cfg.PARAMS['baseline_climate'] should be set to "

--- a/oggm/core/climate.py
+++ b/oggm/core/climate.py
@@ -261,9 +261,9 @@ def process_cru_data(gdir):
     """
 
     if cfg.PATHS.get('climate_file', None):
-        raise warnings.warn("You seem to have set a custom climate file for "
-                            "this run, but are using the default CRU climate "
-                            "file.")
+        warnings.warn("You seem to have set a custom climate file for this "
+                      "run, but are using the default CRU climate "
+                      "file instead.")
 
     if cfg.PARAMS['baseline_climate'] != 'CRU':
         raise ValueError("cfg.PARAMS['baseline_climate'] should be set to CRU")
@@ -463,9 +463,9 @@ def process_histalp_data(gdir):
     """
 
     if cfg.PATHS.get('climate_file', None):
-        raise warnings.warn("You seem to have set a custom climate file for "
-                            "this run, but are using the default HISTALP "
-                            "climate file.")
+        warnings.warn("You seem to have set a custom climate file for this "
+                      "run, but are using the default HISTALP climate file "
+                      "instead.")
 
     if cfg.PARAMS['baseline_climate'] != 'HISTALP':
         raise ValueError("cfg.PARAMS['baseline_climate'] should be set to "

--- a/oggm/tests/test_benchmarks.py
+++ b/oggm/tests/test_benchmarks.py
@@ -14,14 +14,23 @@ from scipy import optimize as optimization
 import oggm.cfg as cfg
 from oggm import tasks, utils, workflow
 from oggm.workflow import execute_entity_task
-from oggm.tests.funcs import get_test_dir
+from oggm.tests.funcs import get_test_dir, patch_url_retrieve_github
 from oggm.utils import get_demo_file
 from oggm.core import gis, centerlines
 from oggm.core.massbalance import ConstantMassBalance
 
 pytestmark = pytest.mark.test_env("benchmark")
 do_plot = False
+_url_retrieve = None
 
+
+def setup_module(module):
+    module._url_retrieve = utils._urlretrieve
+    utils._urlretrieve = patch_url_retrieve_github
+
+
+def teardown_module(module):
+    utils._urlretrieve = module._url_retrieve
 
 class TestSouthGlacier(unittest.TestCase):
 

--- a/oggm/tests/test_graphics.py
+++ b/oggm/tests/test_graphics.py
@@ -10,7 +10,7 @@ import matplotlib.pyplot as plt
 # Local imports
 import oggm.utils
 from oggm.tests import mpl_image_compare
-from oggm.tests.funcs import init_hef, get_test_dir
+from oggm.tests.funcs import init_hef, get_test_dir, patch_url_retrieve_github
 from oggm import graphics
 from oggm.core import (gis, inversion, climate, centerlines, flowline,
                        massbalance)
@@ -25,6 +25,16 @@ warnings.filterwarnings("ignore", category=UserWarning,
 
 # Globals
 pytestmark = pytest.mark.test_env("graphics")
+_url_retrieve = None
+
+
+def setup_module(module):
+    module._url_retrieve = utils._urlretrieve
+    utils._urlretrieve = patch_url_retrieve_github
+
+
+def teardown_module(module):
+    utils._urlretrieve = module._url_retrieve
 
 # ----------------------------------------------------------
 # Lets go

--- a/oggm/tests/test_numerics.py
+++ b/oggm/tests/test_numerics.py
@@ -25,7 +25,8 @@ from oggm.tests.funcs import (dummy_bumpy_bed, dummy_constant_bed,
                               dummy_mixed_bed, dummy_constant_bed_obstacle,
                               dummy_noisy_bed, dummy_parabolic_bed,
                               dummy_trapezoidal_bed, dummy_width_bed,
-                              dummy_width_bed_tributary)
+                              dummy_width_bed_tributary,
+                              patch_url_retrieve_github)
 
 # after oggm.test
 import matplotlib.pyplot as plt
@@ -39,6 +40,16 @@ MUSCLSuperBeeModel = partial(MUSCLSuperBeeModel, inplace=True)
 
 pytestmark = pytest.mark.test_env("numerics")
 do_plot = False
+_url_retrieve = None
+
+
+def setup_module(module):
+    module._url_retrieve = utils._urlretrieve
+    utils._urlretrieve = patch_url_retrieve_github
+
+
+def teardown_module(module):
+    utils._urlretrieve = module._url_retrieve
 
 
 class TestIdealisedCases(unittest.TestCase):

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -24,6 +24,7 @@ _url_retrieve = None
 
 
 pytestmark = pytest.mark.test_env("utils")
+_url_retrieve = None
 
 
 def setup_module(module):

--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -68,7 +68,7 @@ logger = logging.getLogger(__name__)
 # The given commit will be downloaded from github and used as source for
 # all sample data
 SAMPLE_DATA_GH_REPO = 'OGGM/oggm-sample-data'
-SAMPLE_DATA_COMMIT = 'c5602a25073bb5ea0064f5e41b041751384f7582'
+SAMPLE_DATA_COMMIT = 'e6e01e9b9a25ddf8938aa63726ef2be38449533c'
 
 CRU_SERVER = ('https://crudata.uea.ac.uk/cru/data/hrg/cru_ts_4.01/cruts'
               '.1709081022.v4.01/')


### PR DESCRIPTION
Yesterday's change by @matthiasdusch worked fine, but it used the default HISTALP file instead of the user provided one. The general solution is actually better, but for this notebook I would avoid to download any big dataset. 

Since https://github.com/OGGM/oggm/pull/519 , the climate selection is now more explicit. The three valid options are:

``cfg.PARAMS['baseline_climate']= 'CUSTOM'``

``cfg.PARAMS['baseline_climate']= 'HISTALP'``

``cfg.PARAMS['baseline_climate']= 'CRU'``

I will add a warning when people set a custom file and still use the default one for a clearer behavior.


