### PR TITLE
Do not force Agg backend in conftest

### DIFF
--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,2 +1,0 @@
-import matplotlib
-matplotlib.use('Agg')

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,3 @@
-import matplotlib
-matplotlib.use('Agg')  # noqa: E402
-
 import pytest
 import logging
 import getpass


### PR DESCRIPTION
@TimoRoth any reason why this was added? This just drove me crazy as I was looking for a reason as why my plots didn't show up while developing tests. If needed it has to be hidden behind a "if on machine" block. Also, we can't do this silently, this is too intrusive.

I've seen there are a couple of other ``matplotlib.use('Agg')`` in the codebase: in doc and benchmark builds. Leaving them here for now
