### PR TITLE
splits process_cesm_data() into 2 functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,21 +33,21 @@ matrix:
     - env: TEST_CONTAINER=py37 OGGM_TEST_ENV=workflow MPL=--mpl OGGM_TEST_MULTIPROC=False
     - env: TEST_CONTAINER=py37 OGGM_TEST_ENV=graphics MPL=--mpl
   include:
-    - env: TEST_CONTAINER=20181112 OGGM_TEST_ENV=prepro MPL=
+    - env: TEST_CONTAINER=20181123 OGGM_TEST_ENV=prepro MPL=
       os: linux
-    - env: TEST_CONTAINER=20181112 OGGM_TEST_ENV=numerics MPL=
+    - env: TEST_CONTAINER=20181123 OGGM_TEST_ENV=numerics MPL=
       os: linux
-    - env: TEST_CONTAINER=20181112 OGGM_TEST_ENV=models MPL=
+    - env: TEST_CONTAINER=20181123 OGGM_TEST_ENV=models MPL=
       os: linux
-    - env: TEST_CONTAINER=20181112 OGGM_TEST_ENV=benchmark MPL=
+    - env: TEST_CONTAINER=20181123 OGGM_TEST_ENV=benchmark MPL=
       os: linux
-    - env: TEST_CONTAINER=20181112 OGGM_TEST_ENV=utils MPL=
+    - env: TEST_CONTAINER=20181123 OGGM_TEST_ENV=utils MPL=
       os: linux
-    - env: TEST_CONTAINER=20181112 OGGM_TEST_ENV=workflow MPL=--mpl OGGM_TEST_MULTIPROC=True
+    - env: TEST_CONTAINER=20181123 OGGM_TEST_ENV=workflow MPL=--mpl OGGM_TEST_MULTIPROC=True
       os: linux
-    - env: TEST_CONTAINER=20181112 OGGM_TEST_ENV=workflow MPL=--mpl OGGM_TEST_MULTIPROC=False
+    - env: TEST_CONTAINER=20181123 OGGM_TEST_ENV=workflow MPL=--mpl OGGM_TEST_MULTIPROC=False
       os: linux
-    - env: TEST_CONTAINER=20181112 OGGM_TEST_ENV=graphics MPL=--mpl
+    - env: TEST_CONTAINER=20181123 OGGM_TEST_ENV=graphics MPL=--mpl
       os: linux
     - env: TEST_CONTAINER=py37 OGGM_TEST_ENV=prepro MPL=
       os: linux

--- a/ci/mk_travis_yaml.sh
+++ b/ci/mk_travis_yaml.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-MAIN_TEST_CONTAINER_TAG="20181112"
+MAIN_TEST_CONTAINER_TAG="20181123"
 
 for os in linux; do
 	for test_container in $MAIN_TEST_CONTAINER_TAG py37; do

--- a/docs/notebooks/dynamics_and_length_changes.ipynb
+++ b/docs/notebooks/dynamics_and_length_changes.ipynb
@@ -371,16 +371,16 @@
     "tmp_mod = FileModel(gdir.get_filepath('model_run', filesuffix=suff))\n",
     "tmp_mod.run_until(0)\n",
     "tasks.run_from_climate_data(gdir, ys=1601, ye=2003, init_model_fls=tmp_mod.fls,\n",
-    "                            climate_filename='cesm_data', output_filesuffix='_cesm_from_bias');\n",
+    "                            climate_filename='gcm_data', output_filesuffix='_cesm_from_bias');\n",
     "tmp_mod.run_until(100)\n",
     "tasks.run_from_climate_data(gdir, ys=1601, ye=2003, init_model_fls=tmp_mod.fls,\n",
-    "                            climate_filename='cesm_data', output_filesuffix='_cesm_from_bias_100');\n",
+    "                            climate_filename='gcm_data', output_filesuffix='_cesm_from_bias_100');\n",
     "tmp_mod.run_until(200)\n",
     "tasks.run_from_climate_data(gdir, ys=1601, ye=2003, init_model_fls=tmp_mod.fls,\n",
-    "                            climate_filename='cesm_data', output_filesuffix='_cesm_from_bias_200');\n",
+    "                            climate_filename='gcm_data', output_filesuffix='_cesm_from_bias_200');\n",
     "tmp_mod.run_until(300)\n",
     "tasks.run_from_climate_data(gdir, ys=1601, ye=2003, init_model_fls=tmp_mod.fls,\n",
-    "                            climate_filename='cesm_data', output_filesuffix='_cesm_from_bias_300');"
+    "                            climate_filename='gcm_data', output_filesuffix='_cesm_from_bias_300');"
    ]
   },
   {
@@ -437,7 +437,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.5"
   },
   "toc": {
    "base_numbering": 1,

--- a/docs/run_examples/_code/run_with_spinup.py
+++ b/docs/run_examples/_code/run_with_spinup.py
@@ -83,7 +83,7 @@ cfg.PATHS['gcm_precc_file'] = get_demo_file('cesm.PRECC.160001-200512'
                                             '.selection.nc')
 cfg.PATHS['gcm_precl_file'] = get_demo_file('cesm.PRECL.160001-200512'
                                             '.selection.nc')
-execute_entity_task(tasks.process_cesm_data, gdirs)
+execute_entity_task(tasks.prepro_cesm_data, gdirs)
 
 # Inversion tasks
 execute_entity_task(tasks.prepare_for_inversion, gdirs)
@@ -97,7 +97,7 @@ execute_entity_task(tasks.init_present_time_glacier, gdirs)
 # Run the last 200 years with the default starting point (current glacier)
 # and CESM data as input
 execute_entity_task(tasks.run_from_climate_data, gdirs,
-                    climate_filename='cesm_data',
+                    climate_filename='gcm_data',
                     ys=1801, ye=2000,
                     output_filesuffix='_no_spinup')
 
@@ -107,7 +107,7 @@ execute_entity_task(tasks.run_constant_climate, gdirs,
                     output_filesuffix='_spinup')
 # Run a past climate run based on this spinup
 execute_entity_task(tasks.run_from_climate_data, gdirs,
-                    climate_filename='cesm_data',
+                    climate_filename='gcm_data',
                     ys=1801, ye=2000,
                     init_model_filesuffix='_spinup',
                     output_filesuffix='_with_spinup')

--- a/docs/run_examples/_code/run_with_spinup.py
+++ b/docs/run_examples/_code/run_with_spinup.py
@@ -83,7 +83,7 @@ cfg.PATHS['gcm_precc_file'] = get_demo_file('cesm.PRECC.160001-200512'
                                             '.selection.nc')
 cfg.PATHS['gcm_precl_file'] = get_demo_file('cesm.PRECL.160001-200512'
                                             '.selection.nc')
-execute_entity_task(tasks.prepro_cesm_data, gdirs)
+execute_entity_task(tasks.process_cesm_data, gdirs)
 
 # Inversion tasks
 execute_entity_task(tasks.prepare_for_inversion, gdirs)

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -83,7 +83,7 @@ Breaking changes
   `compile_glacier_statistics` (:pull:`571`).
   By `Fabien Maussion <https://github.com/fmaussion>`_.
 - The ``process_cesm_data`` task has been been moved to climate_prepro.py
-  adressing: :issue:`469` & :pull:`xxx`.
+  adressing: :issue:`469` & :pull:`582`.
   By `Anouk Vlug <https://github.com/anoukvlug>`_.
 
 Enhancements

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -18,7 +18,7 @@ Breaking changes
 ~~~~~~~~~~~~~~~~
 
 - The utils.copy_to_basedir() function is changed to being an entity task. In
-  addition cesm_data files, when present, will from now on always be copied
+  addition gcm_data files, when present, will from now on always be copied
   when using this task (:issue:`467` & :pull:`468`).
   By `Anouk Vlug <https://github.com/anoukvlug>`_.
 - Accumulation Area Ratio (AAR) is now correctly computed (:issue:`361`).
@@ -146,7 +146,7 @@ Enhancements
   will replace ``process_cesm_data``. ``process_gcm_data`` can also be used
   when running oggm with another GCM for the climate. ``process_cesm_data`` can
   be used as an example when you plan make a function for running OGGM with
-  another GCM (:issue:`469` & :pull:`xxx`).
+  another GCM (:issue:`469` & :pull:`582`).
   `Anouk Vlug <https://github.com/anoukvlug>`_.
 
 

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -82,7 +82,9 @@ Breaking changes
 - The global task `glacier_characteristics` has been renamed to
   `compile_glacier_statistics` (:pull:`571`).
   By `Fabien Maussion <https://github.com/fmaussion>`_.
-
+- The ``process_cesm_data`` task has been been moved to climate_prepro.py
+  adressing: :issue:`469` & :pull:`xxx`.
+  By `Anouk Vlug <https://github.com/anoukvlug>`_.
 
 Enhancements
 ~~~~~~~~~~~~
@@ -139,6 +141,13 @@ Enhancements
   also adds some safety checks at the calibration and computation of the
   mass-balance to make sure there is no misused parameters (:pull:`493`).
   By `Fabien Maussion <https://github.com/fmaussion>`_.
+- The ``process_cesm_data`` function has been split into two functions, to make
+  it easier to run oggm with the climate of other GCM's. ``prepro_cesm_data``
+  will replace ``process_cesm_data``. ``process_gcm_data`` can also be used
+  when running oggm with another GCM for the climate. ``process_cesm_data`` can
+  be used as an example when you plan make a function for running OGGM with
+  another GCM (:issue:`469` & :pull:`xxx`).
+  `Anouk Vlug <https://github.com/anoukvlug>`_.
 
 
 Bug fixes

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -142,11 +142,11 @@ Enhancements
   mass-balance to make sure there is no misused parameters (:pull:`493`).
   By `Fabien Maussion <https://github.com/fmaussion>`_.
 - The ``process_cesm_data`` function has been split into two functions, to make
-  it easier to run oggm with the climate of other GCM's. ``prepro_cesm_data``
-  will replace ``process_cesm_data``. ``process_gcm_data`` can also be used
-  when running oggm with another GCM for the climate. ``process_cesm_data`` can
-  be used as an example when you plan make a function for running OGGM with
-  another GCM (:issue:`469` & :pull:`582`).
+  it easier to run oggm with the climate of other GCM's: ``process_cesm_data``
+  reads the CESM files and handles the CESM specific file logic.
+  ``process_gcm_data`` is the general task able to handle all kind of data.
+  ``process_cesm_data`` can also be used as an example when you plan make a
+  function for running OGGM with another GCM (:issue:`469` & :pull:`582`).
   `Anouk Vlug <https://github.com/anoukvlug>`_.
 
 

--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -169,7 +169,7 @@ _doc = ('Some information (dictionary) about the climate data and the mass '
 BASENAMES['climate_info'] = ('climate_info.pkl', _doc)
 
 _doc = 'The monthly GCM climate timeseries stored in a netCDF file.'
-BASENAMES['cesm_data'] = ('cesm_data.nc', _doc)
+BASENAMES['gcm_data'] = ('gcm_data.nc', _doc)
 
 _doc = "A dict containing the glacier's t*, bias, and the flowlines' mu*"
 BASENAMES['local_mustar'] = ('local_mustar.json', _doc)

--- a/oggm/core/climate.py
+++ b/oggm/core/climate.py
@@ -110,87 +110,39 @@ def process_custom_climate_data(gdir):
     gdir.write_pickle(out, 'climate_info')
 
 
-@entity_task(log, writes=['cesm_data'])
-def process_cesm_data(gdir, filesuffix='', fpath_temp=None, fpath_precc=None,
-                      fpath_precl=None):
-    """Processes and writes the climate data for this glacier.
+@entity_task(log, writes=['gcm_data'])
+def process_gcm_data(gdir, filesuffix='', precp=None, temp=None,
+                     time_unit=None, time2=None):
+    ''' Applies the anomaly method to the climate data and stores the data in a
+    format that can be used by the OGGM mass balance model.
 
-    This function is made for interpolating the Community
-    Earth System Model Last Millenial Ensemble (CESM-LME) climate simulations,
-    from Otto-Bliesner et al. (2016), to the high-resolution CL2 climatologies
-    (provided with OGGM) and writes everything to a NetCDF file.
-
-    Parameters
+        Parameters
     ----------
     filesuffix : str
         append a suffix to the filename (useful for ensemble experiments).
-    fpath_temp : str
-        path to the temp file (default: cfg.PATHS['gcm_temp_file'])
-    fpath_precc : str
-        path to the precc file (default: cfg.PATHS['gcm_precc_file'])
-    fpath_precl : str
-        path to the precl file (default: cfg.PATHS['gcm_precl_file'])
-    """
+    prcp    : xarray.DataArray - format:
+        monthly total precipitation [mm]
+            Coordinates:
+            lat      float64
+            lon      float64
+            time     (time) object
+            month    (time) int64
+            year     (time) int64
+    temp : xarray.DataArray
+        monthly temperature [K]
+            Coordinates:
+            lat      float64
+            lon      float64
+            time     (time) object
+            month    (time) int64
+            year     (time) int64
+    time_unit : str
+            format: days since e.g.: days since 0850-01-01 00:00:00
+    time2 : numpy.ndarray
 
-    # GCM temperature and precipitation data
-    if fpath_temp is None:
-        if not ('gcm_temp_file' in cfg.PATHS):
-            raise ValueError("Need to set cfg.PATHS['gcm_temp_file']")
-        fpath_temp = cfg.PATHS['gcm_temp_file']
-    if fpath_precc is None:
-        if not ('gcm_precc_file' in cfg.PATHS):
-            raise ValueError("Need to set cfg.PATHS['gcm_precc_file']")
-        fpath_precc = cfg.PATHS['gcm_precc_file']
-    if fpath_precl is None:
-        if not ('gcm_precl_file' in cfg.PATHS):
-            raise ValueError("Need to set cfg.PATHS['gcm_precl_file']")
-        fpath_precl = cfg.PATHS['gcm_precl_file']
+    for an example see: climate_prepro.process_cesm_data()
 
-    # read the files
-    with warnings.catch_warnings():
-        # Long time series are currently a pain pandas
-        warnings.filterwarnings("ignore", message='Unable to decode time axis')
-        tempds = xr.open_dataset(fpath_temp)
-    precpcds = xr.open_dataset(fpath_precc, decode_times=False)
-    preclpds = xr.open_dataset(fpath_precl, decode_times=False)
-
-    # select for location
-    lon = gdir.cenlon
-    lat = gdir.cenlat
-
-    # CESM files are in 0-360
-    if lon <= 0:
-        lon += 360
-
-    # take the closest
-    # TODO: consider GCM interpolation?
-    temp = tempds.TREFHT.sel(lat=lat, lon=lon, method='nearest')
-    precp = (precpcds.PRECC.sel(lat=lat, lon=lon, method='nearest') +
-             preclpds.PRECL.sel(lat=lat, lon=lon, method='nearest'))
-
-    # from normal years to hydrological years
-    sm = cfg.PARAMS['hydro_month_' + gdir.hemisphere]
-    em = sm - 1 if (sm > 1) else 12
-    # TODO: we don't check if the files actually start in January but we should
-    precp = precp[sm-1:sm-13].load()
-    temp = temp[sm-1:sm-13].load()
-    y0 = int(temp.time.values[0].strftime('%Y'))
-    y1 = int(temp.time.values[-1].strftime('%Y'))
-    time = pd.period_range('{}-{:02d}'.format(y0, sm),
-                           '{}-{:02d}'.format(y1, em), freq='M')
-    temp['time'] = time
-    precp['time'] = time
-    # Workaround for https://github.com/pydata/xarray/issues/1565
-    temp['month'] = ('time', time.month)
-    precp['month'] = ('time', time.month)
-    temp['year'] = ('time', time.year)
-    precp['year'] = ('time', time.year)
-    ny, r = divmod(len(time), 12)
-    assert r == 0
-
-    # Convert m s-1 to mm mth-1
-    ndays = np.tile(np.roll(cfg.DAYS_IN_MONTH, 13-sm), y1 - y0)
-    precp = precp * ndays * (60 * 60 * 24 * 1000)
+    '''
 
     # compute monthly anomalies
     # of temp
@@ -227,29 +179,16 @@ def process_cesm_data(gdir, filesuffix='', fpath_temp=None, fpath_precc=None,
     # The last step might create negative values (unlikely). Clip them
     ts_pre.values = ts_pre.values.clip(0)
 
-    # load dates in right format to save
-    dsindex = salem.GeoNetcdf(fpath_temp, monthbegin=True)
-    time1 = dsindex.variables['time']
-    time2 = time1[sm-1:sm-13] - ndays  # to hydrological years
-    time2 = netCDF4.num2date(time2, time1.units, calendar='noleap')
-
     assert np.all(np.isfinite(ts_pre.values))
     assert np.all(np.isfinite(ts_tmp.values))
 
-    # back to -180 - 180
-    loc_lon = precp.lon if precp.lon <= 180 else precp.lon - 360
-
     gdir.write_monthly_climate_file(time2, ts_pre.values, ts_tmp.values,
                                     float(dscru.ref_hgt),
-                                    loc_lon, precp.lat.values,
-                                    time_unit=time1.units,
-                                    file_name='cesm_data',
+                                    precp.lon.values, precp.lat.values,
+                                    time_unit=time_unit,
+                                    file_name='gcm_data',
                                     filesuffix=filesuffix)
 
-    dsindex._nc.close()
-    tempds.close()
-    precpcds.close()
-    preclpds.close()
     ds_cru.close()
 
 

--- a/oggm/core/climate.py
+++ b/oggm/core/climate.py
@@ -111,12 +111,12 @@ def process_custom_climate_data(gdir):
 
 
 @entity_task(log, writes=['gcm_data'])
-def process_gcm_data(gdir, filesuffix='', precp=None, temp=None,
+def process_gcm_data(gdir, filesuffix='', prcp=None, temp=None,
                      time_unit=None, time2=None):
-    ''' Applies the anomaly method to the climate data and stores the data in a
+    """ Applies the anomaly method to the climate data and stores the data in a
     format that can be used by the OGGM mass balance model.
 
-        Parameters
+    Parameters
     ----------
     filesuffix : str
         append a suffix to the filename (useful for ensemble experiments).
@@ -142,7 +142,7 @@ def process_gcm_data(gdir, filesuffix='', precp=None, temp=None,
 
     for an example see: climate_prepro.process_cesm_data()
 
-    '''
+    """
 
     # compute monthly anomalies
     # of temp
@@ -150,12 +150,12 @@ def process_gcm_data(gdir, filesuffix='', precp=None, temp=None,
     ts_tmp_avg = ts_tmp_avg.groupby(ts_tmp_avg.month).mean(dim='time')
     ts_tmp = temp.groupby(temp.month) - ts_tmp_avg
     # of precip -- scaled anomalies
-    ts_pre_avg = precp.isel(time=(precp.year >= 1961) & (precp.year <= 1990))
+    ts_pre_avg = prcp.isel(time=(prcp.year >= 1961) & (prcp.year <= 1990))
     ts_pre_avg = ts_pre_avg.groupby(ts_pre_avg.month).mean(dim='time')
-    ts_pre_ano = precp.groupby(precp.month) - ts_pre_avg
+    ts_pre_ano = prcp.groupby(prcp.month) - ts_pre_avg
     # scaled anomalies is the default. Standard anomalies above
     # are used later for where ts_pre_avg == 0
-    ts_pre = precp.groupby(precp.month) / ts_pre_avg
+    ts_pre = prcp.groupby(prcp.month) / ts_pre_avg
 
     # Get CRU to apply the anomaly to
     fpath = gdir.get_filepath('climate_monthly')
@@ -184,7 +184,7 @@ def process_gcm_data(gdir, filesuffix='', precp=None, temp=None,
 
     gdir.write_monthly_climate_file(time2, ts_pre.values, ts_tmp.values,
                                     float(dscru.ref_hgt),
-                                    precp.lon.values, precp.lat.values,
+                                    prcp.lon.values, prcp.lat.values,
                                     time_unit=time_unit,
                                     file_name='gcm_data',
                                     filesuffix=filesuffix)

--- a/oggm/core/climate.py
+++ b/oggm/core/climate.py
@@ -128,6 +128,7 @@ def process_gcm_data(gdir, filesuffix='', prcp=None, temp=None,
             time     (time) object
             month    (time) int64
             year     (time) int64
+            dates    (time) object format YYYY-MM-DD hh:mm:ss
     temp : xarray.DataArray
         monthly temperature [K]
             Coordinates:
@@ -136,9 +137,9 @@ def process_gcm_data(gdir, filesuffix='', prcp=None, temp=None,
             time     (time) object
             month    (time) int64
             year     (time) int64
+            dates    (time) object format YYYY-MM-DD hh:mm:ss
     time_unit : str
             format: days since e.g.: days since 0850-01-01 00:00:00
-    time2 : numpy.ndarray
 
     for an example see: climate_prepro.process_cesm_data()
 
@@ -182,7 +183,8 @@ def process_gcm_data(gdir, filesuffix='', prcp=None, temp=None,
     assert np.all(np.isfinite(ts_pre.values))
     assert np.all(np.isfinite(ts_tmp.values))
 
-    gdir.write_monthly_climate_file(time2, ts_pre.values, ts_tmp.values,
+    gdir.write_monthly_climate_file(temp.time.dates.values,
+                                    ts_pre.values, ts_tmp.values,
                                     float(dscru.ref_hgt),
                                     prcp.lon.values, prcp.lat.values,
                                     time_unit=time_unit,

--- a/oggm/core/climate_prepro.py
+++ b/oggm/core/climate_prepro.py
@@ -113,10 +113,13 @@ def prepro_cesm_data(gdir, filesuffix='', fpath_temp=None, fpath_precc=None,
     time2 = netCDF4.num2date(time2, time1.units, calendar='noleap')
     time_unit = time1.units
 
+    prcp['dates'] = ('time', time2)
+    temp['dates'] = ('time', time2)
+
     dsindex._nc.close()
     tempds.close()
     precpcds.close()
     preclpds.close()
 
-    process_gcm_data(gdir, filesuffix=filesuffix, prcp=prcp,
-                     temp=temp, time_unit=time_unit, time2=time2)
+    process_gcm_data(gdir, filesuffix=filesuffix, prcp=prcp, temp=temp,
+                     time_unit=time_unit)

--- a/oggm/core/climate_prepro.py
+++ b/oggm/core/climate_prepro.py
@@ -1,0 +1,123 @@
+"""Climate data and mass-balance computations"""
+# Built ins
+import logging
+import os
+import datetime
+import warnings
+# External libs
+import numpy as np
+import netCDF4
+import pandas as pd
+import xarray as xr
+from scipy import stats
+import salem
+from scipy import optimize as optimization
+# Locals
+from oggm import cfg
+from oggm import entity_task
+from oggm.core.climate import process_gcm_data
+# Module logger
+log = logging.getLogger(__name__)
+
+
+@entity_task(log, writes=['gcm_data'])
+def prepro_cesm_data(gdir, filesuffix='', fpath_temp=None, fpath_precc=None,
+                      fpath_precl=None):
+    """Processes and writes the climate data for this glacier.
+
+    This function is made for interpolating the Community
+    Earth System Model Last Millennium Ensemble (CESM-LME) climate simulations,
+    from Otto-Bliesner et al. (2016), to the high-resolution CL2 climatologies
+    (provided with OGGM) and writes everything to a NetCDF file.
+
+    Parameters
+    ----------
+    filesuffix : str
+        append a suffix to the filename (useful for ensemble experiments).
+    fpath_temp : str
+        path to the temp file (default: cfg.PATHS['gcm_temp_file'])
+    fpath_precc : str
+        path to the precc file (default: cfg.PATHS['gcm_precc_file'])
+    fpath_precl : str
+        path to the precl file (default: cfg.PATHS['gcm_precl_file'])
+    """
+
+    # GCM temperature and precipitation data
+    if fpath_temp is None:
+        if not ('gcm_temp_file' in cfg.PATHS):
+            raise ValueError("Need to set cfg.PATHS['gcm_temp_file']")
+        fpath_temp = cfg.PATHS['gcm_temp_file']
+    if fpath_precc is None:
+        if not ('gcm_precc_file' in cfg.PATHS):
+            raise ValueError("Need to set cfg.PATHS['gcm_precc_file']")
+        fpath_precc = cfg.PATHS['gcm_precc_file']
+    if fpath_precl is None:
+        if not ('gcm_precl_file' in cfg.PATHS):
+            raise ValueError("Need to set cfg.PATHS['gcm_precl_file']")
+        fpath_precl = cfg.PATHS['gcm_precl_file']
+
+    # read the files
+    with warnings.catch_warnings():
+        # Long time series are currently a pain pandas
+        warnings.filterwarnings("ignore", message='Unable to decode time axis')
+        tempds = xr.open_dataset(fpath_temp)
+    precpcds = xr.open_dataset(fpath_precc, decode_times=False)
+    preclpds = xr.open_dataset(fpath_precl, decode_times=False)
+
+    # select for location
+    lon = gdir.cenlon
+    lat = gdir.cenlat
+
+    # CESM files are in 0-360
+    if lon <= 0:
+        lon += 360
+
+    # take the closest
+    # TODO: consider GCM interpolation?
+    temp = tempds.TREFHT.sel(lat=lat, lon=lon, method='nearest')
+    precp = (precpcds.PRECC.sel(lat=lat, lon=lon, method='nearest') +
+             preclpds.PRECL.sel(lat=lat, lon=lon, method='nearest'))
+
+    temp.lon.values = temp.lon if temp.lon <= 180 else temp.lon - 360
+    precp.lon.values = precp.lon if precp.lon <= 180 else precp.lon - 360
+
+    # from normal years to hydrological years
+    sm = cfg.PARAMS['hydro_month_' + gdir.hemisphere]
+    em = sm - 1 if (sm > 1) else 12
+    # TODO: we don't check if the files actually start in January but we should
+    precp = precp[sm-1:sm-13].load()
+    temp = temp[sm-1:sm-13].load()
+    y0 = int(temp.time.values[0].strftime('%Y'))
+    y1 = int(temp.time.values[-1].strftime('%Y'))
+    time = pd.period_range('{}-{:02d}'.format(y0, sm),
+                           '{}-{:02d}'.format(y1, em), freq='M')
+
+    temp['time'] = time
+    precp['time'] = time
+    # Workaround for https://github.com/pydata/xarray/issues/1565
+    temp['month'] = ('time', time.month)
+    precp['month'] = ('time', time.month)
+    temp['year'] = ('time', time.year)
+    precp['year'] = ('time', time.year)
+    ny, r = divmod(len(time), 12)
+    assert r == 0
+
+    # Convert m s-1 to mm mth-1
+    ndays = np.tile(np.roll(cfg.DAYS_IN_MONTH, 13-sm), y1 - y0)
+    precp = precp * ndays * (60 * 60 * 24 * 1000)
+
+    # load dates in right format to save
+    dsindex = salem.GeoNetcdf(fpath_temp, monthbegin=True)
+    time1 = dsindex.variables['time']
+    time2 = time1[sm-1:sm-13] - ndays  # to hydrological years
+    time2 = netCDF4.num2date(time2, time1.units, calendar='noleap')
+    time_unit = time1.units
+
+    return process_gcm_data(gdir, filesuffix=filesuffix, precp=precp,
+                            temp=temp, time_unit=time_unit, time2=time2)
+
+    dsindex._nc.close()
+    tempds.close()
+    precpcds.close()
+    preclpds.close()
+

--- a/oggm/core/climate_prepro.py
+++ b/oggm/core/climate_prepro.py
@@ -53,9 +53,6 @@ def prepro_cesm_data(gdir, filesuffix='', fpath_temp=None, fpath_precc=None,
         fpath_precl = cfg.PATHS['cesm_precl_file']
 
     # read the files
-    if LooseVersion(xr.__version__) < LooseVersion('0.11'):
-        raise ImportError('This task needs xarray v0.11 or newer to run.')
-
     tempds = xr.open_dataset(fpath_temp)
     precpcds = xr.open_dataset(fpath_precc)
     preclpds = xr.open_dataset(fpath_precl)

--- a/oggm/core/climate_prepro.py
+++ b/oggm/core/climate_prepro.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 
 @entity_task(log, writes=['gcm_data'])
 def prepro_cesm_data(gdir, filesuffix='', fpath_temp=None, fpath_precc=None,
-                      fpath_precl=None):
+                     fpath_precl=None):
     """Processes and writes the climate data for this glacier.
 
     This function is made for interpolating the Community
@@ -120,4 +120,3 @@ def prepro_cesm_data(gdir, filesuffix='', fpath_temp=None, fpath_precc=None,
     tempds.close()
     precpcds.close()
     preclpds.close()
-

--- a/oggm/core/climate_prepro.py
+++ b/oggm/core/climate_prepro.py
@@ -53,6 +53,9 @@ def prepro_cesm_data(gdir, filesuffix='', fpath_temp=None, fpath_precc=None,
         fpath_precl = cfg.PATHS['cesm_precl_file']
 
     # read the files
+    if LooseVersion(xr.__version__) < LooseVersion('0.10.9'):
+        raise ImportError('This task needs xarray v0.10.9 or newer to run.')
+
     tempds = xr.open_dataset(fpath_temp)
     precpcds = xr.open_dataset(fpath_precc)
     preclpds = xr.open_dataset(fpath_precl)

--- a/oggm/core/climate_prepro.py
+++ b/oggm/core/climate_prepro.py
@@ -17,8 +17,8 @@ log = logging.getLogger(__name__)
 
 
 @entity_task(log, writes=['gcm_data'])
-def prepro_cesm_data(gdir, filesuffix='', fpath_temp=None, fpath_precc=None,
-                     fpath_precl=None):
+def process_cesm_data(gdir, filesuffix='', fpath_temp=None, fpath_precc=None,
+                      fpath_precl=None):
     """Processes and writes GCM climate data for this glacier.
 
     This function is made for interpolating the Community
@@ -53,8 +53,8 @@ def prepro_cesm_data(gdir, filesuffix='', fpath_temp=None, fpath_precc=None,
         fpath_precl = cfg.PATHS['cesm_precl_file']
 
     # read the files
-    if LooseVersion(xr.__version__) < LooseVersion('0.10.9'):
-        raise ImportError('This task needs xarray v0.10.9 or newer to run.')
+    if LooseVersion(xr.__version__) < LooseVersion('0.11'):
+        raise ImportError('This task needs xarray v0.11 or newer to run.')
 
     tempds = xr.open_dataset(fpath_temp)
     precpcds = xr.open_dataset(fpath_precc)

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -1631,7 +1631,7 @@ def run_random_climate(gdir, nyears=1000, y0=None, halfsize=15,
         (default is yearly)
     climate_filename : str
         name of the climate file, e.g. 'climate_monthly' (default) or
-        'cesm_data'
+        'gcm_data'
     climate_input_filesuffix: str
         filesuffix for the input climate file
     output_filesuffix : str
@@ -1702,7 +1702,7 @@ def run_constant_climate(gdir, nyears=1000, y0=None, halfsize=15,
         (default is yearly)
     climate_filename : str
         name of the climate file, e.g. 'climate_monthly' (default) or
-        'cesm_data'
+        'gcm_data'
     climate_input_filesuffix: str
         filesuffix for the input climate file
     output_filesuffix : str
@@ -1754,7 +1754,7 @@ def run_from_climate_data(gdir, ys=None, ye=None,
         (default is yearly)
     climate_filename : str
         name of the climate file, e.g. 'climate_monthly' (default) or
-        'cesm_data'
+        'gcm_data'
     climate_input_filesuffix: str
         filesuffix for the input climate file
     output_filesuffix : str

--- a/oggm/tasks.py
+++ b/oggm/tasks.py
@@ -22,6 +22,7 @@ from oggm.core.climate import process_cru_data
 from oggm.core.climate import process_histalp_data
 from oggm.core.climate import process_custom_climate_data
 from oggm.core.climate import process_gcm_data
+from oggm.core.climate_prepro import prepro_cesm_data
 from oggm.core.climate import local_t_star
 from oggm.core.climate import mu_star_calibration
 from oggm.core.climate import apparent_mb_from_linear_mb

--- a/oggm/tasks.py
+++ b/oggm/tasks.py
@@ -22,7 +22,7 @@ from oggm.core.climate import process_cru_data
 from oggm.core.climate import process_histalp_data
 from oggm.core.climate import process_custom_climate_data
 from oggm.core.climate import process_gcm_data
-from oggm.core.climate_prepro import prepro_cesm_data
+from oggm.core.climate_prepro import process_cesm_data
 from oggm.core.climate import local_t_star
 from oggm.core.climate import mu_star_calibration
 from oggm.core.climate import apparent_mb_from_linear_mb

--- a/oggm/tasks.py
+++ b/oggm/tasks.py
@@ -21,7 +21,7 @@ from oggm.core.climate import glacier_mu_candidates
 from oggm.core.climate import process_cru_data
 from oggm.core.climate import process_histalp_data
 from oggm.core.climate import process_custom_climate_data
-from oggm.core.climate import process_cesm_data
+from oggm.core.climate import process_gcm_data
 from oggm.core.climate import local_t_star
 from oggm.core.climate import mu_star_calibration
 from oggm.core.climate import apparent_mb_from_linear_mb

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -2539,7 +2539,7 @@ class TestHEF(unittest.TestCase):
         cfg.PATHS['cesm_precc_file'] = f
         f = get_demo_file('cesm.PRECL.160001-200512.selection.nc')
         cfg.PATHS['cesm_precl_file'] = f
-        climate_prepro.prepro_cesm_data(self.gdir)
+        climate_prepro.process_cesm_data(self.gdir)
 
         # Climate data
         fh = gdir.get_filepath('climate_monthly')

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -2534,11 +2534,11 @@ class TestHEF(unittest.TestCase):
 
         # init
         f = get_demo_file('cesm.TREFHT.160001-200512.selection.nc')
-        cfg.PATHS['gcm_temp_file'] = f
+        cfg.PATHS['cesm_temp_file'] = f
         f = get_demo_file('cesm.PRECC.160001-200512.selection.nc')
-        cfg.PATHS['gcm_precc_file'] = f
+        cfg.PATHS['cesm_precc_file'] = f
         f = get_demo_file('cesm.PRECL.160001-200512.selection.nc')
-        cfg.PATHS['gcm_precl_file'] = f
+        cfg.PATHS['cesm_precl_file'] = f
         climate_prepro.prepro_cesm_data(self.gdir)
 
         # Climate data

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -23,7 +23,7 @@ from oggm.core import massbalance
 from oggm.core.massbalance import LinearMassBalance
 import xarray as xr
 from oggm import utils, workflow, tasks, cfg
-from oggm.core import climate, inversion, centerlines
+from oggm.core import climate_prepro, climate, inversion, centerlines
 from oggm.cfg import SEC_IN_DAY, SEC_IN_YEAR, SEC_IN_MONTH
 from oggm.utils import get_demo_file
 
@@ -2539,7 +2539,7 @@ class TestHEF(unittest.TestCase):
         cfg.PATHS['gcm_precc_file'] = f
         f = get_demo_file('cesm.PRECL.160001-200512.selection.nc')
         cfg.PATHS['gcm_precl_file'] = f
-        climate.process_cesm_data(self.gdir)
+        climate_prepro.prepro_cesm_data(self.gdir)
 
         # Climate data
         with warnings.catch_warnings():
@@ -2547,7 +2547,7 @@ class TestHEF(unittest.TestCase):
             warnings.filterwarnings("ignore",
                                     message='Unable to decode time axis')
             fh = gdir.get_filepath('climate_monthly')
-            fcesm = gdir.get_filepath('cesm_data')
+            fcesm = gdir.get_filepath('gcm_data')
             with xr.open_dataset(fh) as hist, xr.open_dataset(fcesm) as cesm:
 
                 tv = cesm.time.values
@@ -2578,7 +2578,7 @@ class TestHEF(unittest.TestCase):
         # Mass balance models
         mb_cru = massbalance.PastMassBalance(self.gdir)
         mb_cesm = massbalance.PastMassBalance(self.gdir,
-                                              filename='cesm_data')
+                                              filename='gcm_data')
 
         # Average over 1961-1990
         h, w = self.gdir.get_inversion_flowline_hw()
@@ -2617,7 +2617,7 @@ class TestHEF(unittest.TestCase):
         run_from_climate_data(gdir, ys=1961, ye=1990,
                               output_filesuffix='_hist')
         run_from_climate_data(gdir, ys=1961, ye=1990,
-                              climate_filename='cesm_data',
+                              climate_filename='gcm_data',
                               output_filesuffix='_cesm')
 
         ds1 = utils.compile_run_output([gdir], path=False, filesuffix='_hist')

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -2242,13 +2242,13 @@ class TestGCMClimate(unittest.TestCase):
         cfg.PATHS['gcm_precc_file'] = f
         f = get_demo_file('cesm.PRECL.160001-200512.selection.nc')
         cfg.PATHS['gcm_precl_file'] = f
-        climate.process_cesm_data(gdir)
+        oggm.core.climate_prepro.prepro_cesm_data(gdir)
         with warnings.catch_warnings():
             # Long time series are currently a pain pandas
             warnings.filterwarnings("ignore",
                                     message='Unable to decode time axis')
             fh = gdir.get_filepath('climate_monthly')
-            fcesm = gdir.get_filepath('cesm_data')
+            fcesm = gdir.get_filepath('gcm_data')
             with xr.open_dataset(fh) as cru, xr.open_dataset(fcesm) as cesm:
 
                 tv = cesm.time.values
@@ -2291,7 +2291,7 @@ class TestGCMClimate(unittest.TestCase):
 
     def test_compile_climate_input(self):
 
-        filename = 'cesm_data'
+        filename = 'gcm_data'
         filesuffix = '_cesm'
 
         hef_file = get_demo_file('Hintereisferner_RGI5.shp')
@@ -2309,7 +2309,7 @@ class TestGCMClimate(unittest.TestCase):
         cfg.PATHS['gcm_precc_file'] = f
         f = get_demo_file('cesm.PRECL.160001-200512.selection.nc')
         cfg.PATHS['gcm_precl_file'] = f
-        climate.process_cesm_data(gdir, filesuffix=filesuffix)
+        oggm.core.climate_prepro.prepro_cesm_data(gdir, filesuffix=filesuffix)
         utils.compile_climate_input([gdir], filename=filename,
                                     filesuffix=filesuffix)
 

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -19,8 +19,8 @@ import xarray as xr
 import rasterio
 
 # Local imports
-from oggm.core import (gis, inversion, climate, centerlines, flowline,
-                       massbalance)
+from oggm.core import (gis, inversion, climate_prepro, climate, centerlines,
+                       flowline, massbalance)
 import oggm.cfg as cfg
 from oggm import utils
 from oggm.utils import get_demo_file, tuple2int
@@ -2237,12 +2237,12 @@ class TestGCMClimate(unittest.TestCase):
         self.assertEqual(ci['baseline_hydro_yr_1'], 2014)
 
         f = get_demo_file('cesm.TREFHT.160001-200512.selection.nc')
-        cfg.PATHS['gcm_temp_file'] = f
+        cfg.PATHS['cesm_temp_file'] = f
         f = get_demo_file('cesm.PRECC.160001-200512.selection.nc')
-        cfg.PATHS['gcm_precc_file'] = f
+        cfg.PATHS['cesm_precc_file'] = f
         f = get_demo_file('cesm.PRECL.160001-200512.selection.nc')
-        cfg.PATHS['gcm_precl_file'] = f
-        oggm.core.climate_prepro.prepro_cesm_data(gdir)
+        cfg.PATHS['cesm_precl_file'] = f
+        climate_prepro.prepro_cesm_data(gdir)
         with warnings.catch_warnings():
             # Long time series are currently a pain pandas
             warnings.filterwarnings("ignore",
@@ -2304,12 +2304,12 @@ class TestGCMClimate(unittest.TestCase):
         utils.compile_climate_input([gdir])
 
         f = get_demo_file('cesm.TREFHT.160001-200512.selection.nc')
-        cfg.PATHS['gcm_temp_file'] = f
+        cfg.PATHS['cesm_temp_file'] = f
         f = get_demo_file('cesm.PRECC.160001-200512.selection.nc')
-        cfg.PATHS['gcm_precc_file'] = f
+        cfg.PATHS['cesm_precc_file'] = f
         f = get_demo_file('cesm.PRECL.160001-200512.selection.nc')
-        cfg.PATHS['gcm_precl_file'] = f
-        oggm.core.climate_prepro.prepro_cesm_data(gdir, filesuffix=filesuffix)
+        cfg.PATHS['cesm_precl_file'] = f
+        climate_prepro.prepro_cesm_data(gdir, filesuffix=filesuffix)
         utils.compile_climate_input([gdir], filename=filename,
                                     filesuffix=filesuffix)
 

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -2242,7 +2242,7 @@ class TestGCMClimate(unittest.TestCase):
         cfg.PATHS['cesm_precc_file'] = f
         f = get_demo_file('cesm.PRECL.160001-200512.selection.nc')
         cfg.PATHS['cesm_precl_file'] = f
-        climate_prepro.prepro_cesm_data(gdir)
+        climate_prepro.process_cesm_data(gdir)
 
         fh = gdir.get_filepath('climate_monthly')
         fcesm = gdir.get_filepath('gcm_data')
@@ -2298,7 +2298,7 @@ class TestGCMClimate(unittest.TestCase):
         cfg.PATHS['cesm_precc_file'] = f
         f = get_demo_file('cesm.PRECL.160001-200512.selection.nc')
         cfg.PATHS['cesm_precl_file'] = f
-        climate_prepro.prepro_cesm_data(gdir, filesuffix=filesuffix)
+        climate_prepro.process_cesm_data(gdir, filesuffix=filesuffix)
         utils.compile_climate_input([gdir], filename=filename,
                                     filesuffix=filesuffix)
 

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -2243,51 +2243,40 @@ class TestGCMClimate(unittest.TestCase):
         f = get_demo_file('cesm.PRECL.160001-200512.selection.nc')
         cfg.PATHS['cesm_precl_file'] = f
         climate_prepro.prepro_cesm_data(gdir)
-        with warnings.catch_warnings():
-            # Long time series are currently a pain pandas
-            warnings.filterwarnings("ignore",
-                                    message='Unable to decode time axis')
-            fh = gdir.get_filepath('climate_monthly')
-            fcesm = gdir.get_filepath('gcm_data')
-            with xr.open_dataset(fh) as cru, xr.open_dataset(fcesm) as cesm:
 
-                tv = cesm.time.values
-                time = pd.period_range(tv[0].strftime('%Y-%m-%d'),
-                                       tv[-1].strftime('%Y-%m-%d'),
-                                       freq='M')
-                cesm['time'] = time
-                cesm.coords['year'] = ('time', time.year)
-                cesm.coords['month'] = ('time', time.month)
+        fh = gdir.get_filepath('climate_monthly')
+        fcesm = gdir.get_filepath('gcm_data')
+        with xr.open_dataset(fh) as cru, xr.open_dataset(fcesm) as cesm:
 
-                # Let's do some basic checks
-                scru = cru.sel(time=slice('1961', '1990'))
-                scesm = cesm.load().isel(time=((cesm.year >= 1961) &
-                                               (cesm.year <= 1990)))
-                # Climate during the chosen period should be the same
-                np.testing.assert_allclose(scru.temp.mean(),
-                                           scesm.temp.mean(),
-                                           rtol=1e-3)
-                np.testing.assert_allclose(scru.prcp.mean(),
-                                           scesm.prcp.mean(),
-                                           rtol=1e-3)
+            # Let's do some basic checks
+            scru = cru.sel(time=slice('1961', '1990'))
+            scesm = cesm.load().isel(time=((cesm['time.year'] >= 1961) &
+                                           (cesm['time.year'] <= 1990)))
+            # Climate during the chosen period should be the same
+            np.testing.assert_allclose(scru.temp.mean(),
+                                       scesm.temp.mean(),
+                                       rtol=1e-3)
+            np.testing.assert_allclose(scru.prcp.mean(),
+                                       scesm.prcp.mean(),
+                                       rtol=1e-3)
 
-                # And also the anual cycle
-                scru = scru.groupby('time.month').mean()
-                scesm = scesm.groupby(scesm.month).mean()
-                np.testing.assert_allclose(scru.temp, scesm.temp, rtol=1e-3)
-                np.testing.assert_allclose(scru.prcp, scesm.prcp, rtol=1e-3)
+            # And also the annual cycle
+            scru = scru.groupby('time.month').mean(dim='time')
+            scesm = scesm.groupby('time.month').mean(dim='time')
+            np.testing.assert_allclose(scru.temp, scesm.temp, rtol=1e-3)
+            np.testing.assert_allclose(scru.prcp, scesm.prcp, rtol=1e-3)
 
-                # How did the annua cycle change with time?
-                scesm1 = cesm.isel(time=((cesm.year >= 1961) &
-                                         (cesm.year <= 1990)))
-                scesm2 = cesm.isel(time=((cesm.year >= 1661) &
-                                         (cesm.year <= 1690)))
-                scesm1 = scesm1.groupby(scesm1.month).mean()
-                scesm2 = scesm2.groupby(scesm2.month).mean()
-                # No more than one degree? (silly test)
-                np.testing.assert_allclose(scesm1.temp, scesm2.temp, atol=1)
-                # N more than 30%? (silly test)
-                np.testing.assert_allclose(scesm1.prcp, scesm2.prcp, rtol=0.3)
+            # How did the annua cycle change with time?
+            scesm1 = cesm.isel(time=((cesm['time.year'] >= 1961) &
+                                     (cesm['time.year'] <= 1990)))
+            scesm2 = cesm.isel(time=((cesm['time.year'] >= 1661) &
+                                     (cesm['time.year'] <= 1690)))
+            scesm1 = scesm1.groupby('time.month').mean(dim='time')
+            scesm2 = scesm2.groupby('time.month').mean(dim='time')
+            # No more than one degree? (silly test)
+            np.testing.assert_allclose(scesm1.temp, scesm2.temp, atol=1)
+            # N more than 30%? (silly test)
+            np.testing.assert_allclose(scesm1.prcp, scesm2.prcp, rtol=0.3)
 
     def test_compile_climate_input(self):
 
@@ -2313,48 +2302,44 @@ class TestGCMClimate(unittest.TestCase):
         utils.compile_climate_input([gdir], filename=filename,
                                     filesuffix=filesuffix)
 
-        with warnings.catch_warnings():
-            # Long time series are currently a pain pandas
-            warnings.filterwarnings("ignore", message='Unable to decode')
+        # CRU
+        f1 = os.path.join(cfg.PATHS['working_dir'], 'climate_input.nc')
+        f2 = gdir.get_filepath(filename='climate_monthly')
+        with xr.open_dataset(f1) as clim_cru1, \
+                xr.open_dataset(f2) as clim_cru2:
+            np.testing.assert_allclose(np.squeeze(clim_cru1.prcp),
+                                       clim_cru2.prcp)
+            np.testing.assert_allclose(np.squeeze(clim_cru1.temp),
+                                       clim_cru2.temp)
+            np.testing.assert_allclose(np.squeeze(clim_cru1.ref_hgt),
+                                       clim_cru2.ref_hgt)
+            np.testing.assert_allclose(np.squeeze(clim_cru1.ref_pix_lat),
+                                       clim_cru2.ref_pix_lat)
+            np.testing.assert_allclose(np.squeeze(clim_cru1.ref_pix_lon),
+                                       clim_cru2.ref_pix_lon)
+            np.testing.assert_allclose(clim_cru1.calendar_month,
+                                       clim_cru2['time.month'])
+            np.testing.assert_allclose(clim_cru1.calendar_year,
+                                       clim_cru2['time.year'])
+            np.testing.assert_allclose(clim_cru1.hydro_month[[0, -1]],
+                                       [1, 12])
 
-            # CRU
-            f1 = os.path.join(cfg.PATHS['working_dir'], 'climate_input.nc')
-            f2 = gdir.get_filepath(filename='climate_monthly')
-            with xr.open_dataset(f1) as clim_cru1, \
-                    xr.open_dataset(f2) as clim_cru2:
-                np.testing.assert_allclose(np.squeeze(clim_cru1.prcp),
-                                           clim_cru2.prcp)
-                np.testing.assert_allclose(np.squeeze(clim_cru1.temp),
-                                           clim_cru2.temp)
-                np.testing.assert_allclose(np.squeeze(clim_cru1.ref_hgt),
-                                           clim_cru2.ref_hgt)
-                np.testing.assert_allclose(np.squeeze(clim_cru1.ref_pix_lat),
-                                           clim_cru2.ref_pix_lat)
-                np.testing.assert_allclose(np.squeeze(clim_cru1.ref_pix_lon),
-                                           clim_cru2.ref_pix_lon)
-                np.testing.assert_allclose(clim_cru1.calendar_month,
-                                           clim_cru2['time.month'])
-                np.testing.assert_allclose(clim_cru1.calendar_year,
-                                           clim_cru2['time.year'])
-                np.testing.assert_allclose(clim_cru1.hydro_month[[0, -1]],
-                                           [1, 12])
-
-            # CESM
-            f1 = os.path.join(cfg.PATHS['working_dir'],
-                              'climate_input_cesm.nc')
-            f2 = gdir.get_filepath(filename=filename, filesuffix=filesuffix)
-            with xr.open_dataset(f1) as clim_cesm1, \
-                    xr.open_dataset(f2) as clim_cesm2:
-                np.testing.assert_allclose(np.squeeze(clim_cesm1.prcp),
-                                           clim_cesm2.prcp)
-                np.testing.assert_allclose(np.squeeze(clim_cesm1.temp),
-                                           clim_cesm2.temp)
-                np.testing.assert_allclose(np.squeeze(clim_cesm1.ref_hgt),
-                                           clim_cesm2.ref_hgt)
-                np.testing.assert_allclose(np.squeeze(clim_cesm1.ref_pix_lat),
-                                           clim_cesm2.ref_pix_lat)
-                np.testing.assert_allclose(np.squeeze(clim_cesm1.ref_pix_lon),
-                                           clim_cesm2.ref_pix_lon)
+        # CESM
+        f1 = os.path.join(cfg.PATHS['working_dir'],
+                          'climate_input_cesm.nc')
+        f2 = gdir.get_filepath(filename=filename, filesuffix=filesuffix)
+        with xr.open_dataset(f1) as clim_cesm1, \
+                xr.open_dataset(f2) as clim_cesm2:
+            np.testing.assert_allclose(np.squeeze(clim_cesm1.prcp),
+                                       clim_cesm2.prcp)
+            np.testing.assert_allclose(np.squeeze(clim_cesm1.temp),
+                                       clim_cesm2.temp)
+            np.testing.assert_allclose(np.squeeze(clim_cesm1.ref_hgt),
+                                       clim_cesm2.ref_hgt)
+            np.testing.assert_allclose(np.squeeze(clim_cesm1.ref_pix_lat),
+                                       clim_cesm2.ref_pix_lat)
+            np.testing.assert_allclose(np.squeeze(clim_cesm1.ref_pix_lon),
+                                       clim_cesm2.ref_pix_lon)
 
 
 class TestIdealizedGdir(unittest.TestCase):

--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -3623,7 +3623,7 @@ def copy_to_basedir(gdir, base_dir, setup='run'):
     if setup == 'run':
         paths = ['model_flowlines', 'inversion_params', 'outlines',
                  'local_mustar', 'climate_monthly', 'gridded_data',
-                 'cesm_data', 'climate_info']
+                 'gcm_data', 'climate_info']
         paths = ('*' + p + '*' for p in paths)
         shutil.copytree(gdir.dir, new_dir,
                         ignore=include_patterns(*paths))
@@ -3631,7 +3631,7 @@ def copy_to_basedir(gdir, base_dir, setup='run'):
         paths = ['inversion_params', 'downstream_line', 'outlines',
                  'inversion_flowlines', 'glacier_grid',
                  'local_mustar', 'climate_monthly', 'gridded_data',
-                 'cesm_data', 'climate_info']
+                 'gcm_data', 'climate_info']
         paths = ('*' + p + '*' for p in paths)
         shutil.copytree(gdir.dir, new_dir,
                         ignore=include_patterns(*paths))

--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -2286,31 +2286,17 @@ def compile_climate_input(gdirs, path=True, filename='climate_monthly',
         try:
             ppath = gdirs[i].get_filepath(filename=filename,
                                           filesuffix=filesuffix)
-            with warnings.catch_warnings():
-                # Long time series are currently a pain pandas
-                warnings.filterwarnings("ignore", message='Unable to decode')
-                with xr.open_dataset(ppath) as ds_clim:
-                    ds_clim.time.values
+            with xr.open_dataset(ppath) as ds_clim:
+                ds_clim.time.values
             break
         except BaseException:
             i += 1
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", message='Unable to decode time axis')
+    with xr.open_dataset(ppath) as ds_clim:
+        cyrs = ds_clim['time.year']
+        cmonths = ds_clim['time.month']
+        has_grad = 'gradient' in ds_clim.variables
 
-        with xr.open_dataset(ppath) as ds_clim:
-            try:
-                y0 = ds_clim.temp.time.values[0].astype('datetime64[Y]')
-                y1 = ds_clim.temp.time.values[-1].astype('datetime64[Y]')
-            except AttributeError:
-                y0 = ds_clim.temp.time.values[0].strftime('%Y')
-                y1 = ds_clim.temp.time.values[-1].strftime('%Y')
-            has_grad = 'gradient' in ds_clim.variables
-
-    # We know the file is structured like this
-    ctime = pd.period_range('{}-10'.format(y0), '{}-9'.format(y1), freq='M')
-    cyrs = ctime.year
-    cmonths = ctime.month
     yrs, months = calendardate_to_hydrodate(cyrs, cmonths)
     time = date_to_floatyear(yrs, months)
 
@@ -2350,16 +2336,14 @@ def compile_climate_input(gdirs, path=True, filename='climate_monthly',
         try:
             ppath = gdir.get_filepath(filename=filename,
                                       filesuffix=filesuffix)
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore", message='Unable to decode')
-                with xr.open_dataset(ppath) as ds_clim:
-                    prcp[:, i] = ds_clim.prcp.values
-                    temp[:, i] = ds_clim.temp.values
-                    if has_grad:
-                        grad[:, i] = ds_clim.gradient
-                    ref_hgt[i] = ds_clim.ref_hgt
-                    ref_pix_lon[i] = ds_clim.ref_pix_lon
-                    ref_pix_lat[i] = ds_clim.ref_pix_lat
+            with xr.open_dataset(ppath) as ds_clim:
+                prcp[:, i] = ds_clim.prcp.values
+                temp[:, i] = ds_clim.temp.values
+                if has_grad:
+                    grad[:, i] = ds_clim.gradient
+                ref_hgt[i] = ds_clim.ref_hgt
+                ref_pix_lon[i] = ds_clim.ref_pix_lon
+                ref_pix_lat[i] = ds_clim.ref_pix_lat
         except BaseException:
             pass
 
@@ -3285,6 +3269,7 @@ class GlacierDirectory(object):
                                    ref_pix_hgt, ref_pix_lon, ref_pix_lat, *,
                                    gradient=None,
                                    time_unit='days since 1801-01-01 00:00:00',
+                                   calendar=None,
                                    file_name='climate_monthly',
                                    filesuffix=''):
         """Creates a netCDF4 file with climate data timeseries.
@@ -3327,8 +3312,16 @@ class GlacierDirectory(object):
             nc.author_info = 'Open Global Glacier Model'
 
             timev = nc.createVariable('time', 'i4', ('time',))
-            timev.setncatts({'units': time_unit})
-            timev[:] = netCDF4.date2num([t for t in time], time_unit)
+            tatts = {'units': time_unit}
+            if calendar is not None:
+                tatts['calendar'] = calendar
+                numdate = netCDF4.date2num([t for t in time], time_unit,
+                                           calendar=calendar)
+            else:
+                numdate = netCDF4.date2num([t for t in time], time_unit)
+
+            timev.setncatts(tatts)
+            timev[:] = numdate
 
             v = nc.createVariable('prcp', 'f4', ('time',), zlib=zlib)
             v.units = 'kg m-2'


### PR DESCRIPTION
This PR is a result of the OGGM hack day. It is meant to contribute to issue https://github.com/OGGM/oggm/issues/469. This PR is not meant as a final solution, but more as first step and as food to continue the discussion. So don't hesitate to comment on it @fmaussion @nchampollion @sumnonpuella  

- [x] Tests added/passed
- [ ] Fully documented
- [x] Entry in `whats-new.rst` 

With this PR `process_cesm_data()` is split into 2 functions. `prepro_cesm_data` and `process_gcm_data()`. `process_gcm_data` is meant to make it easier to run OGGM with the climate of other GCM's. `prepro_cesm_data` replaces `process_cesm_data()`. `prepro_cesm_data` uses the `process_gcm_data()` to generate the climate files for OGGM. It also can be used as an example on how to use other GCM's as input.

- `prepro_cesm_data` is placed is a new file. I am not sure what the best name and location for this file would be.
