### PR TITLE
Try to fix some tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -120,4 +120,6 @@ matrix:
       os: windows
 
 script:
+  - export -f travis_wait
+  - export -f travis_jigger
   - ./ci/travis_stage_script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
   fast_finish: true
   allow_failures:
     - os: windows
+    - os: osx
   include:
     - env: OGGM_TEST_ENV=prepro PYTHON_VERSION=3.6 MPL=
       os: linux

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -13,7 +13,7 @@
     "environment_type": "oggm_virtualenv",
     "install_timeout": 1800,
 
-    "pythons": ["3.5", "3.6"],
+    "pythons": ["3.5", "3.6", "3.7"],
 
     // The matrix of dependencies to test.  Each key is the name of a
     // package (in PyPI) and the values are version numbers.  An empty

--- a/ci/travis_stage_script.sh
+++ b/ci/travis_stage_script.sh
@@ -24,7 +24,7 @@ fi
 if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
 	wget -q https://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe -O miniconda.exe
 	chmod +x miniconda.exe
-	./miniconda.exe "/S" "/D=$(cygpath -w -a $HOME/miniconda)"
+	travis_wait 40 ./miniconda.exe "/S" "/D=$(cygpath -w -a $HOME/miniconda)"
 	rm miniconda.exe
 elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
 	rvm get head || true

--- a/ci/travis_stage_script.sh
+++ b/ci/travis_stage_script.sh
@@ -24,7 +24,7 @@ fi
 if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
 	wget -q https://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe -O miniconda.exe
 	chmod +x miniconda.exe
-	./miniconda.exe "/InstallationType=JustMe" "/AddToPath=0" "/RegisterPython=0" "/NoRegistry=1" "/S" "/D=$(cygpath -w -a $HOME/miniconda)"
+	./miniconda.exe "/S" "/D=$(cygpath -w -a $HOME/miniconda)"
 	rm miniconda.exe
 elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
 	rvm get head || true

--- a/oggm/tests/test_graphics.py
+++ b/oggm/tests/test_graphics.py
@@ -257,7 +257,7 @@ def test_thick_alt():
 
 
 @pytest.mark.graphic
-@mpl_image_compare()
+@mpl_image_compare(multi=True)
 def test_thick_interp():
     fig, ax = plt.subplots()
     gdir = init_hef()
@@ -352,7 +352,7 @@ def test_ice_cap():
 
 
 @pytest.mark.graphic
-@mpl_image_compare()
+@mpl_image_compare(multi=True)
 def test_coxe():
 
     testdir = os.path.join(get_test_dir(), 'tmp_coxe')

--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -68,7 +68,7 @@ logger = logging.getLogger(__name__)
 # The given commit will be downloaded from github and used as source for
 # all sample data
 SAMPLE_DATA_GH_REPO = 'OGGM/oggm-sample-data'
-SAMPLE_DATA_COMMIT = '999ebbf0a48d8892058b3e2323bd975eed8a56b5'
+SAMPLE_DATA_COMMIT = '657ecfd463fbd5e43c5d138085a484947a464649'
 
 CRU_SERVER = ('https://crudata.uea.ac.uk/cru/data/hrg/cru_ts_4.01/cruts'
               '.1709081022.v4.01/')


### PR DESCRIPTION
Re-Generated all the baseline images for now, will try to fix everything else that comes up.
Something weird is going on with salem/pandas, where it complains

```
______________________________________________________________________________________ TestFilterNegFlux.test_correct _______________________________________________________________________________________

self = <oggm.tests.test_prepro.TestFilterNegFlux testMethod=test_correct>

    def test_correct(self):

        entity = gpd.read_file(get_demo_file('rgi_oetztal.shp'))
        entity = entity.loc[entity.RGIId == 'RGI50-11.00666'].iloc[0]

        cfg.PARAMS['correct_for_neg_flux'] = False

        gdir = oggm.GlacierDirectory(entity, base_dir=self.testdir)
        gis.define_glacier_region(gdir, entity=entity)
        gis.glacier_masks(gdir)
        centerlines.compute_centerlines(gdir)
        centerlines.initialize_flowlines(gdir)
        centerlines.catchment_area(gdir)
        centerlines.catchment_width_geom(gdir)
        centerlines.catchment_width_correction(gdir)
>       climate.process_custom_climate_data(gdir)

oggm/tests/test_prepro.py:1498:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
oggm/utils.py:2730: in _entity_task
    out = task_func(gdir, **kwargs)
oggm/core/climate.py:49: in process_custom_climate_data
    nc_ts = salem.GeoNetcdf(fpath)
../../oggm_venv/lib/python3.7/site-packages/salem/datasets.py:396: in __init__
    GeoDataset.__init__(self, grid, time=time)
../../oggm_venv/lib/python3.7/site-packages/salem/datasets.py:95: in __init__
    time = pd.Series(np.arange(len(time)), index=time)
../../oggm_venv/lib/python3.7/site-packages/pandas/core/series.py:183: in __init__
    index = _ensure_index(index)
../../oggm_venv/lib/python3.7/site-packages/pandas/core/indexes/base.py:4974: in _ensure_index
    return Index(index_like)
../../oggm_venv/lib/python3.7/site-packages/pandas/core/indexes/base.py:417: in __new__
    name=name, **kwargs)
../../oggm_venv/lib/python3.7/site-packages/pandas/core/indexes/datetimes.py:399: in __new__
    yearfirst=yearfirst)
../../oggm_venv/lib/python3.7/site-packages/pandas/core/tools/datetimes.py:467: in to_datetime
    result = _convert_listlike(arg, box, format)
../../oggm_venv/lib/python3.7/site-packages/pandas/core/tools/datetimes.py:368: in _convert_listlike
    require_iso8601=require_iso8601
pandas/_libs/tslib.pyx:492: in pandas._libs.tslib.array_to_datetime
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>   ???
E   AttributeError: 'real_datetime' object has no attribute 'nanosecond'
```

Not sure if that's an issue in oggm, salem or pandas.