### PR TITLE
Change order in which MultipleFlowlineMassBalance reads flowlines

### DIFF
--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -893,14 +893,15 @@ class MultipleFlowlineMassBalance(MassBalanceModel):
 
         # Read in the flowlines
         if fls is None:
-            for fn in ['model_flowlines', 'inversion_flowlines']:
+            try:
+                fls = gdir.read_pickle('model_flowlines')
+            except FileNotFoundError:
                 try:
-                    fls = gdir.read_pickle(fn)
+                    fls = gdir.read_pickle('inversion_flowlines')
                 except FileNotFoundError:
-                    pass
-            if fls is None:
-                raise RuntimeError('Need a valid `model_flowlines` or '
-                                   '`inversion_flowlines` to continue!')
+                    raise RuntimeError('Need a valid `model_flowlines` or '
+                                       '`inversion_flowlines` to continue!')\
+                        from None
 
         self.fls = fls
 

--- a/oggm/graphics.py
+++ b/oggm/graphics.py
@@ -245,11 +245,6 @@ def plot_centerlines(gdirs, ax=None, smap=None, use_flowlines=False,
     if add_downstream and not use_flowlines:
         raise ValueError('Downstream lines can be plotted with flowlines only')
 
-    # Files
-    filename = 'centerlines'
-    if use_flowlines:
-        filename = 'inversion_flowlines'
-
     gdir = gdirs[0]
     with utils.ncDataset(gdir.get_filepath('gridded_data')) as nc:
         topo = nc.variables['topo'][:]
@@ -272,7 +267,18 @@ def plot_centerlines(gdirs, ax=None, smap=None, use_flowlines=False,
                               color='black', linewidth=0.5)
 
         # plot Centerlines
-        cls = gdir.read_pickle(filename)
+        if use_flowlines:
+            try:
+                cls = gdir.read_pickle('model_flowlines')
+            except FileNotFoundError:
+                try:
+                    cls = gdir.read_pickle('inversion_flowlines')
+                except FileNotFoundError:
+                    raise RuntimeError('Need a valid `model_flowlines` or '
+                                       '`inversion_flowlines` to continue!')\
+                        from None
+        else:
+            cls = gdir.read_pickle('centerlines')
 
         # Go in reverse order for red always being the longuest
         cls = cls[::-1]


### PR DESCRIPTION
If a `MultipleFlowlineMassBalance` is initialized without explicit Flowline objects, it tries to read the `model_flowlines` and `inversion_flowlines` from the GlacierDirectory. 
But till now, if both files were available, it used `inversion_flowlines` instead of the desired `model_flowlines`.
This is now changed.

This PR also applies the same logic used in the Massbalance-Model to `graphics.plot_centerlines`: If called with `use_flowlines=True`, it uses `model_flowlines` if they exists and falls back to `inversion_flowlines` if not.
