### PR TITLE
Remove implicit fallback to inversion_flowlines in MultipleFlowlineMassBalance

### DIFF
--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -871,7 +871,8 @@ class MultipleFlowlineMassBalance(MassBalanceModel):
     """
 
     def __init__(self, gdir, fls=None, mu_star=None,
-                 mb_model_class=PastMassBalance, **kwargs):
+                 mb_model_class=PastMassBalance, use_inversion_flowlines=False,
+                 **kwargs):
         """Initialize.
 
         Parameters
@@ -888,20 +889,24 @@ class MultipleFlowlineMassBalance(MassBalanceModel):
         mb_model_class : class, optional
             the mass-balance model to use (e.g. PastMassBalance,
             ConstantMassBalance...)
+        use_inversion_flowlines: bool, optional
+            if True 'inversion_flowlines' instead of 'model_flowlines' will be
+            used.
         kwargs : kwargs to pass to mb_model_class
         """
 
         # Read in the flowlines
+        if use_inversion_flowlines:
+            fls = gdir.read_pickle('inversion_flowlines')
+
         if fls is None:
             try:
                 fls = gdir.read_pickle('model_flowlines')
             except FileNotFoundError:
-                try:
-                    fls = gdir.read_pickle('inversion_flowlines')
-                except FileNotFoundError:
-                    raise RuntimeError('Need a valid `model_flowlines` or '
-                                       '`inversion_flowlines` to continue!')\
-                        from None
+                raise RuntimeError('Need a valid `model_flowlines` file. '
+                                   'If you explicitly want to use '
+                                   '`inversion_flowlines`, set '
+                                   'use_inversion_flowlines=True.') from None
 
         self.fls = fls
 


### PR DESCRIPTION
If a MultipleFlowlineMassBalance-model was initialised without explicitly passing a list of flowlines, `model_flowlines` were loaded. If they were not available the model implicitly used `inversion_flowlines` as fallback.

As discussed with @fmaussion this is unpythonic and a possible source of unintentional model behavior which would be hard to trace back.

Reading the `model_flowlines` at initialisation if no flowlines are passed is wanted for convenience and fits into the general model handling.
This commit introduces a new keyword `use_inversion_flowlines` (default==False). When set to True the `inversion_flowlines` will be read from the GlacierDirectory.