### PR TITLE
Add rgi_id to flowlines and pass them to the massbalance models

### DIFF
--- a/oggm/core/centerlines.py
+++ b/oggm/core/centerlines.py
@@ -87,6 +87,7 @@ class Centerline(object):
         self.mu_star_is_valid = False  # if mu* leeds to good flux, keep it
         self.flux = None  # Flux (kg m-2)
         self.flux_needs_correction = False  # whether this branch was baaad
+        self.rgi_id = None  # Usefull if this line is used with another glacier
 
     def set_flows_to(self, other, check_tail=True, last_point=False):
         """Find the closest point in "other" and sets all the corresponding

--- a/oggm/core/centerlines.py
+++ b/oggm/core/centerlines.py
@@ -56,7 +56,8 @@ class Centerline(object):
     It is instanciated and updated by _join_lines() exclusively
     """
 
-    def __init__(self, line, dx=None, surface_h=None, orig_head=None):
+    def __init__(self, line, dx=None, surface_h=None, orig_head=None,
+                 rgi_id=None):
         """ Instantiate."""
 
         self.line = None  # Shapely LineString
@@ -87,7 +88,7 @@ class Centerline(object):
         self.mu_star_is_valid = False  # if mu* leeds to good flux, keep it
         self.flux = None  # Flux (kg m-2)
         self.flux_needs_correction = False  # whether this branch was baaad
-        self.rgi_id = None  # Usefull if this line is used with another glacier
+        self.rgi_id = rgi_id  # Usefull if line is used with another glacier
 
     def set_flows_to(self, other, check_tail=True, last_point=False):
         """Find the closest point in "other" and sets all the corresponding
@@ -1599,7 +1600,7 @@ def initialize_flowlines(gdir):
             new_line = shpg.LineString(points[sp:])
 
         sl = Centerline(new_line, dx=dx, surface_h=hgts,
-                        orig_head=cl.orig_head)
+                        orig_head=cl.orig_head, rgi_id=gdir.rgi_id)
         sl.order = cl.order
         fls.append(sl)
 

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -37,7 +37,7 @@ class Flowline(Centerline):
     """The is the input flowline for the model."""
 
     def __init__(self, line=None, dx=1, map_dx=None,
-                 surface_h=None, bed_h=None):
+                 surface_h=None, bed_h=None, rgi_id=None):
         """ Instanciate.
 
         #TODO: documentation
@@ -57,6 +57,7 @@ class Flowline(Centerline):
         self.map_dx = map_dx
         self.dx_meter = map_dx * self.dx
         self.bed_h = bed_h
+        self.rgi_id = rgi_id
 
     @Centerline.widths.getter
     def widths(self):
@@ -128,7 +129,7 @@ class ParabolicBedFlowline(Flowline):
     """A more advanced Flowline."""
 
     def __init__(self, line=None, dx=None, map_dx=None,
-                 surface_h=None, bed_h=None, bed_shape=None):
+                 surface_h=None, bed_h=None, bed_shape=None, rgi_id=None):
         """ Instanciate.
 
         Parameters
@@ -140,7 +141,8 @@ class ParabolicBedFlowline(Flowline):
         #TODO: document properties
         """
         super(ParabolicBedFlowline, self).__init__(line, dx, map_dx,
-                                                   surface_h, bed_h)
+                                                   surface_h, bed_h,
+                                                   rgi_id=rgi_id)
 
         assert np.all(np.isfinite(bed_shape))
         self.bed_shape = bed_shape
@@ -167,7 +169,7 @@ class RectangularBedFlowline(Flowline):
     """A more advanced Flowline."""
 
     def __init__(self, line=None, dx=None, map_dx=None,
-                 surface_h=None, bed_h=None, widths=None):
+                 surface_h=None, bed_h=None, widths=None, rgi_id=None):
         """ Instanciate.
 
         Parameters
@@ -179,7 +181,8 @@ class RectangularBedFlowline(Flowline):
         #TODO: document properties
         """
         super(RectangularBedFlowline, self).__init__(line, dx, map_dx,
-                                                     surface_h, bed_h)
+                                                     surface_h, bed_h,
+                                                     rgi_id=rgi_id)
 
         self._widths = widths
 
@@ -210,7 +213,7 @@ class TrapezoidalBedFlowline(Flowline):
     """A more advanced Flowline."""
 
     def __init__(self, line=None, dx=None, map_dx=None, surface_h=None,
-                 bed_h=None, widths=None, lambdas=None):
+                 bed_h=None, widths=None, lambdas=None, rgi_id=None):
         """ Instanciate.
 
         Parameters
@@ -222,7 +225,8 @@ class TrapezoidalBedFlowline(Flowline):
         #TODO: document properties
         """
         super(TrapezoidalBedFlowline, self).__init__(line, dx, map_dx,
-                                                     surface_h, bed_h)
+                                                     surface_h, bed_h,
+                                                     rgi_id=rgi_id)
 
         self._w0_m = widths * self.map_dx - lambdas * self.thick
 
@@ -267,7 +271,7 @@ class MixedBedFlowline(Flowline):
 
     def __init__(self, *, line=None, dx=None, map_dx=None, surface_h=None,
                  bed_h=None, section=None, bed_shape=None,
-                 is_trapezoid=None, lambdas=None, widths_m=None):
+                 is_trapezoid=None, lambdas=None, widths_m=None, rgi_id=None):
         """ Instanciate.
 
         Parameters
@@ -282,7 +286,8 @@ class MixedBedFlowline(Flowline):
 
         super(MixedBedFlowline, self).__init__(line=line, dx=dx, map_dx=map_dx,
                                                surface_h=surface_h.copy(),
-                                               bed_h=bed_h.copy())
+                                               bed_h=bed_h.copy(),
+                                               rgi_id=rgi_id)
 
         # To speedup calculations if no trapezoid bed is present
         self._do_trapeze = np.any(is_trapezoid)
@@ -1507,7 +1512,8 @@ def init_present_time_glacier(gdir):
                                section=section, bed_shape=bed_shape,
                                is_trapezoid=np.isfinite(lambdas),
                                lambdas=lambdas,
-                               widths_m=widths_m)
+                               widths_m=widths_m,
+                               rgi_id=cl.rgi_id)
 
         # Update attrs
         nfl.mu_star = cl.mu_star

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -214,7 +214,8 @@ class PastMassBalance(MassBalanceModel):
 
     def __init__(self, gdir, mu_star=None, bias=None,
                  filename='climate_monthly', input_filesuffix='',
-                 repeat=False, ys=None, ye=None, check_calib_params=True):
+                 repeat=False, ys=None, ye=None, check_calib_params=True,
+                 rgi_id=None):
         """Initialize.
 
         Parameters
@@ -248,6 +249,9 @@ class PastMassBalance(MassBalanceModel):
             the parameters used during calibration and the ones you are
             using at run time. If they don't match, it will raise an error.
             Set to False to suppress this check.
+        rgi_id: str
+            When a glacier is merged from several glaciers, the rgi_id will
+            allow to load the correct climate file.
 
         Attributes
         ----------
@@ -306,7 +310,8 @@ class PastMassBalance(MassBalanceModel):
         self.repeat = repeat
 
         # Read file
-        fpath = gdir.get_filepath(filename, filesuffix=input_filesuffix)
+        fpath = gdir.get_filepath(filename, filesuffix=input_filesuffix,
+                                  rgi_id=rgi_id)
         with ncDataset(fpath, mode='r') as nc:
             # time
             time = nc.variables['time']
@@ -446,7 +451,7 @@ class ConstantMassBalance(MassBalanceModel):
 
     def __init__(self, gdir, mu_star=None, bias=None,
                  y0=None, halfsize=15, filename='climate_monthly',
-                 input_filesuffix=''):
+                 input_filesuffix='', rgi_id=None):
         """Initialize
 
         Parameters
@@ -474,7 +479,8 @@ class ConstantMassBalance(MassBalanceModel):
         super(ConstantMassBalance, self).__init__()
         self.mbmod = PastMassBalance(gdir, mu_star=mu_star, bias=bias,
                                      filename=filename,
-                                     input_filesuffix=input_filesuffix)
+                                     input_filesuffix=input_filesuffix,
+                                     rgi_id=rgi_id)
 
         if y0 is None:
             df = gdir.read_json('local_mustar')
@@ -609,7 +615,7 @@ class RandomMassBalance(MassBalanceModel):
     def __init__(self, gdir, mu_star=None, bias=None,
                  y0=None, halfsize=15, seed=None, filename='climate_monthly',
                  input_filesuffix='', all_years=False,
-                 unique_samples=False):
+                 unique_samples=False, rgi_id=None):
         """Initialize.
 
         Parameters
@@ -650,7 +656,8 @@ class RandomMassBalance(MassBalanceModel):
         self.valid_bounds = [-1e4, 2e4]  # in m
         self.mbmod = PastMassBalance(gdir, mu_star=mu_star, bias=bias,
                                      filename=filename,
-                                     input_filesuffix=input_filesuffix)
+                                     input_filesuffix=input_filesuffix,
+                                     rgi_id=rgi_id)
 
         # Climate period
         if all_years:
@@ -917,7 +924,7 @@ class MultipleFlowlineMassBalance(MassBalanceModel):
 
         # Initialise the mb models
         self.flowline_mb_models = [mb_model_class(gdir, mu_star=fl.mu_star,
-                                                  **kwargs)
+                                                  rgi_id=fl.rgi_id, **kwargs)
                                    for fl in self.fls]
 
         self.valid_bounds = self.flowline_mb_models[-1].valid_bounds

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -214,8 +214,7 @@ class PastMassBalance(MassBalanceModel):
 
     def __init__(self, gdir, mu_star=None, bias=None,
                  filename='climate_monthly', input_filesuffix='',
-                 repeat=False, ys=None, ye=None, check_calib_params=True,
-                 rgi_id=None):
+                 repeat=False, ys=None, ye=None, check_calib_params=True):
         """Initialize.
 
         Parameters
@@ -249,9 +248,6 @@ class PastMassBalance(MassBalanceModel):
             the parameters used during calibration and the ones you are
             using at run time. If they don't match, it will raise an error.
             Set to False to suppress this check.
-        rgi_id: str
-            When a glacier is merged from several glaciers, the rgi_id will
-            allow to load the correct climate file.
 
         Attributes
         ----------
@@ -310,8 +306,7 @@ class PastMassBalance(MassBalanceModel):
         self.repeat = repeat
 
         # Read file
-        fpath = gdir.get_filepath(filename, filesuffix=input_filesuffix,
-                                  rgi_id=rgi_id)
+        fpath = gdir.get_filepath(filename, filesuffix=input_filesuffix)
         with ncDataset(fpath, mode='r') as nc:
             # time
             time = nc.variables['time']
@@ -451,7 +446,7 @@ class ConstantMassBalance(MassBalanceModel):
 
     def __init__(self, gdir, mu_star=None, bias=None,
                  y0=None, halfsize=15, filename='climate_monthly',
-                 input_filesuffix='', rgi_id=None):
+                 input_filesuffix=''):
         """Initialize
 
         Parameters
@@ -479,8 +474,7 @@ class ConstantMassBalance(MassBalanceModel):
         super(ConstantMassBalance, self).__init__()
         self.mbmod = PastMassBalance(gdir, mu_star=mu_star, bias=bias,
                                      filename=filename,
-                                     input_filesuffix=input_filesuffix,
-                                     rgi_id=rgi_id)
+                                     input_filesuffix=input_filesuffix)
 
         if y0 is None:
             df = gdir.read_json('local_mustar')
@@ -615,7 +609,7 @@ class RandomMassBalance(MassBalanceModel):
     def __init__(self, gdir, mu_star=None, bias=None,
                  y0=None, halfsize=15, seed=None, filename='climate_monthly',
                  input_filesuffix='', all_years=False,
-                 unique_samples=False, rgi_id=None):
+                 unique_samples=False):
         """Initialize.
 
         Parameters
@@ -656,8 +650,7 @@ class RandomMassBalance(MassBalanceModel):
         self.valid_bounds = [-1e4, 2e4]  # in m
         self.mbmod = PastMassBalance(gdir, mu_star=mu_star, bias=bias,
                                      filename=filename,
-                                     input_filesuffix=input_filesuffix,
-                                     rgi_id=rgi_id)
+                                     input_filesuffix=input_filesuffix)
 
         # Climate period
         if all_years:
@@ -878,7 +871,7 @@ class MultipleFlowlineMassBalance(MassBalanceModel):
 
     def __init__(self, gdir, fls=None, mu_star=None,
                  mb_model_class=PastMassBalance, use_inversion_flowlines=False,
-                 **kwargs):
+                 input_filesuffix='', **kwargs):
         """Initialize.
 
         Parameters
@@ -898,6 +891,8 @@ class MultipleFlowlineMassBalance(MassBalanceModel):
         use_inversion_flowlines: bool, optional
             if True 'inversion_flowlines' instead of 'model_flowlines' will be
             used.
+        input_filesuffix : str
+            the file suffix of the input climate file
         kwargs : kwargs to pass to mb_model_class
         """
 
@@ -923,9 +918,15 @@ class MultipleFlowlineMassBalance(MassBalanceModel):
                 fl.mu_star = mu
 
         # Initialise the mb models
-        self.flowline_mb_models = [mb_model_class(gdir, mu_star=fl.mu_star,
-                                                  rgi_id=fl.rgi_id, **kwargs)
-                                   for fl in self.fls]
+        self.flowline_mb_models = []
+        for fl in self.fls:
+            # Merged glaciers will need different climate files, use filesuffix
+            if (fl.rgi_id is not None) and (fl.rgi_id != gdir.rgi_id):
+                input_filesuffix = '_' + fl.rgi_id + input_filesuffix
+
+            self.flowline_mb_models.append(
+                mb_model_class(gdir, mu_star=fl.mu_star,
+                               input_filesuffix=input_filesuffix, **kwargs))
 
         self.valid_bounds = self.flowline_mb_models[-1].valid_bounds
 

--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -3046,7 +3046,7 @@ class GlacierDirectory(object):
         """The glacier's RGI area (m2)."""
         return self.rgi_area_km2 * 10**6
 
-    def get_filepath(self, filename, delete=False, filesuffix=''):
+    def get_filepath(self, filename, delete=False, filesuffix='', rgi_id=None):
         """Absolute path to a specific file.
 
         Parameters
@@ -3058,6 +3058,10 @@ class GlacierDirectory(object):
         filesuffix : str
             append a suffix to the filename (useful for model runs). Note
             that the BASENAME remains same.
+        rgi_id: str
+            actual filename might include the RGI_id. In case of a merged
+            glacier the GDir might contain files like 'climate_monthly'
+            associated with different original glaciers.
 
         Returns
         -------
@@ -3068,6 +3072,12 @@ class GlacierDirectory(object):
             raise ValueError(filename + ' not in cfg.BASENAMES.')
 
         fname = cfg.BASENAMES[filename]
+
+        if rgi_id is not None:
+            fname = fname.split('.')
+            assert len(fname) == 2
+            fname = fname[0] + '_' + rgi_id + '.' + fname[1]
+
         if filesuffix:
             fname = fname.split('.')
             assert len(fname) == 2

--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -3046,7 +3046,7 @@ class GlacierDirectory(object):
         """The glacier's RGI area (m2)."""
         return self.rgi_area_km2 * 10**6
 
-    def get_filepath(self, filename, delete=False, filesuffix='', rgi_id=None):
+    def get_filepath(self, filename, delete=False, filesuffix=''):
         """Absolute path to a specific file.
 
         Parameters
@@ -3058,10 +3058,6 @@ class GlacierDirectory(object):
         filesuffix : str
             append a suffix to the filename (useful for model runs). Note
             that the BASENAME remains same.
-        rgi_id: str
-            actual filename might include the RGI_id. In case of a merged
-            glacier the GDir might contain files like 'climate_monthly'
-            associated with different original glaciers.
 
         Returns
         -------
@@ -3072,13 +3068,7 @@ class GlacierDirectory(object):
             raise ValueError(filename + ' not in cfg.BASENAMES.')
 
         fname = cfg.BASENAMES[filename]
-
-        if rgi_id is not None:
-            fname = fname.split('.')
-            assert len(fname) == 2
-            fname = fname[0] + '_' + rgi_id + filesuffix + '.' + fname[1]
-
-        elif (rgi_id is None) and filesuffix:
+        if filesuffix:
             fname = fname.split('.')
             assert len(fname) == 2
             fname = fname[0] + filesuffix + '.' + fname[1]

--- a/oggm/utils.py
+++ b/oggm/utils.py
@@ -3076,12 +3076,13 @@ class GlacierDirectory(object):
         if rgi_id is not None:
             fname = fname.split('.')
             assert len(fname) == 2
-            fname = fname[0] + '_' + rgi_id + '.' + fname[1]
+            fname = fname[0] + '_' + rgi_id + filesuffix + '.' + fname[1]
 
-        if filesuffix:
+        elif (rgi_id is None) and filesuffix:
             fname = fname.split('.')
             assert len(fname) == 2
             fname = fname[0] + filesuffix + '.' + fname[1]
+
         out = os.path.join(self.dir, fname)
         if delete and os.path.isfile(out):
             os.remove(out)


### PR DESCRIPTION
This commit ads a attribute `rgi_id` to Centerlines and Flowlines in order to associate them with their glacier.

The intention comes from merged glaciers where flowlines from several glaciers are merged to one new glaicer. See #600 for more details on that.

Here I add the `rgi_id` to the `input_filesuffix` of the massbalance model. This allows to load a climat file from a different glacier if flowlines of several glaciers are merged to one big glacier.

The `rgi_id` is added to the front of the filesuffix. A climatefile could now for example have the structure: `climate_monthly_RGI60-01.23456_suffix.nc`

`Centerline.rgi_id` is now set by default when initialized with `centerlines.initialize_flowlines`.