### PR TITLE
Allow traceback when using executing_entity_task

### DIFF
--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -81,22 +81,12 @@ class _pickle_copier(object):
             call_func = self.call_func
         else:
             call_func, gdir = arg
-        try:
-            if isinstance(gdir, Sequence):
-                gdir, gdir_kwargs = gdir
-                gdir_kwargs = _merge_dicts(self.out_kwargs, gdir_kwargs)
-                return call_func(gdir, **gdir_kwargs)
-            else:
-                return call_func(gdir, **self.out_kwargs)
-        except Exception as e:
-            try:
-                err_msg = ('({0}) exception occured while processing task '
-                           '{1}: {2}'.format(gdir.rgi_id, call_func.__name__,
-                                             str(e)))
-                raise RuntimeError(err_msg) from e
-            except AttributeError:
-                pass
-            raise
+        if isinstance(gdir, Sequence):
+            gdir, gdir_kwargs = gdir
+            gdir_kwargs = _merge_dicts(self.out_kwargs, gdir_kwargs)
+            return call_func(gdir, **gdir_kwargs)
+        else:
+            return call_func(gdir, **self.out_kwargs)
 
 
 def reset_multiprocessing():


### PR DESCRIPTION
For debugging, raising this way was hidding the traceback and it was not possible to trace  the origin of the error.

With this change, the traceback is now correctly showing when multiprocessing is set to False 

(multiproc = True is not good for debugging, maybe I should add this to the docs somewhere)

cc @TimoRoth - btw, do we still need this pickle_copier now that we are a python3 shop only?
