### PR TITLE
SRTM changed their download URL again

### DIFF
--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -519,8 +519,8 @@ class TestFakeDownloads(unittest.TestCase):
                               fakefile='srtm_39_03.tif')
 
         def down_check(url, cache_name=None, reset=False):
-            expected = ('http://srtm.csi.cgiar.org/SRT-ZIP/SRTM_V41/'
-                        'SRTM_Data_GeoTiff/srtm_39_03.zip')
+            expected = ('http://srtm.csi.cgiar.org/wp-content/uploads/files/'
+                        'srtm_5x5/TIFF/srtm_39_03.zip')
             self.assertEqual(url, expected)
             return tf
 

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -402,8 +402,8 @@ def _download_srtm_file_unlocked(zone):
         return outpath
 
     # Did we download it yet?
-    wwwfile = 'http://srtm.csi.cgiar.org/SRT-ZIP/SRTM_V41/' +\
-        'SRTM_Data_GeoTiff/srtm_' + zone + '.zip'
+    wwwfile = ('http://srtm.csi.cgiar.org/wp-content/uploads/files/srtm_5x5/'
+               'TIFF/srtm_' + zone + '.zip')
     dest_file = file_downloader(wwwfile)
 
     # None means we tried hard but we couldn't find it


### PR DESCRIPTION
<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->

This couldn't happen at a worse moment :roll_eyes: 

@TimoRoth I'm (quite) sure the data didn't change: can you please make a symlink on the cluster?

`srtm.csi.cgiar.org/wp-content/uploads/files/srtm_5x5/TIFF/`

should point to:

`srtm.csi.cgiar.org/SRT-ZIP/SRTM_V41/SRTM_Data_GeoTiff/`

Thanks!
 