### PR TITLE
Solve some more bugs in DEM handling

### DIFF
--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -326,6 +326,7 @@ def initialize(file=None, logging_level='INFO'):
     PARAMS['compress_climate_netcdf'] = cp.as_bool('compress_climate_netcdf')
     PARAMS['use_tar_shapefiles'] = cp.as_bool('use_tar_shapefiles')
     PARAMS['clip_mu_star'] = cp.as_bool('clip_mu_star')
+    PARAMS['clip_tidewater_border'] = cp.as_bool('clip_tidewater_border')
 
     # Climate
     PARAMS['baseline_climate'] = cp['baseline_climate'].strip().upper()
@@ -363,7 +364,7 @@ def initialize(file=None, logging_level='INFO'):
            'use_multiple_flowlines', 'tstar_search_glacierwide',
            'mpi_recv_buf_size', 'hydro_month_nh', 'clip_mu_star',
            'tstar_search_window', 'use_bias_for_run', 'hydro_month_sh',
-           'use_intersects', 'filter_min_slope',
+           'use_intersects', 'filter_min_slope', 'clip_tidewater_border',
            'auto_skip_task', 'correct_for_neg_flux', 'filter_for_neg_flux',
            'rgi_version',
            'use_shape_factor_for_inversion', 'use_rgi_area',

--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -77,6 +77,10 @@ topo_interp = cubic
 # Make it large if you want to do past simulations.
 border = 20
 
+# For tidewater glaciers it doesn't make sense to have large maps
+# if for some reason you still want this, set to false
+clip_tidewater_border = True
+
 # Use the RGI area as reference or the one from the geometry?
 use_rgi_area = True
 

--- a/oggm/tests/test_graphics.py
+++ b/oggm/tests/test_graphics.py
@@ -363,6 +363,7 @@ def test_coxe():
     cfg.PARAMS['use_intersects'] = False
     cfg.PATHS['dem_file'] = get_demo_file('dem_RGI50-01.10299.tif')
     cfg.PARAMS['border'] = 40
+    cfg.PARAMS['clip_tidewater_border'] = False
     cfg.PARAMS['use_multiple_flowlines'] = False
 
     hef_file = get_demo_file('rgi_RGI50-01.10299.shp')

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -56,9 +56,9 @@ _RGI_METADATA = dict()
 
 DEM3REG = {
     'ISL': [-25., -12., 63., 67.],  # Iceland
-    'SVALBARD': [10., 34., 76., 81.],
+    'SVALBARD': [9., 35.99, 75., 84.],
     'JANMAYEN': [-10., -7., 70., 72.],
-    'FJ': [36., 66., 79., 82.],  # Franz Josef Land
+    'FJ': [36., 68., 79., 90.],  # Franz Josef Land
     'FAR': [-8., -6., 61., 63.],  # Faroer
     'BEAR': [18., 20., 74., 75.],  # Bear Island
     'SHL': [-3., 0., 60., 61.],  # Shetland
@@ -321,7 +321,7 @@ def file_downloader(www_path, retry_max=5, cache_name=None, reset=False):
             break
         except HttpDownloadError as err:
             # This works well for py3
-            if err.code == 404:
+            if err.code == 404 or err.code == 300:
                 # Ok so this *should* be an ocean tile
                 return None
             elif err.code >= 500 and err.code < 600:
@@ -1452,8 +1452,10 @@ def get_topo_file(lon_ex, lat_ex, rgi_region=None, rgi_subregion=None,
         source_str = source
 
     # Anywhere else on Earth we check for DEM3, ASTER, or SRTM
+    # exceptional test for eastern russia:
+    east_max = np.min(lat_ex) > 59 and np.min(lon_ex) > 170
     if (np.min(lat_ex) < -60.) or (np.max(lat_ex) > 60.) or \
-            (source == 'DEM3') or (source == 'ASTER'):
+            (source == 'DEM3') or (source == 'ASTER') or east_max:
         # default is DEM3
         source = 'DEM3' if source is None else source
         if source == 'DEM3':


### PR DESCRIPTION
<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->

Also, this now automatically clips the size of the map for tidewater glaciers: it doesn't make sense at all to have large maps for them since we don't compute the downstream line for them.

@bearecinos you can go back to the previous behavior with `cfg.PARAMS['clip_tidewater_border'] = False`
