### PR TITLE
make download test more strict for Travis

### DIFF
--- a/oggm/tests/funcs.py
+++ b/oggm/tests/funcs.py
@@ -214,7 +214,8 @@ def patch_url_retrieve_github(url, *args, **kwargs):
     """A simple patch to OGGM's download function to make sure we don't
     download elsewhere than expected."""
 
-    assert 'github' in url or 'cluster.klima.uni-bremen' in url
+    assert 'github' in url
+    assert 'cluster.klima.uni-bremen.de/~fmaussion/gdirs/' in url
     return oggm_urlretrieve(url, *args, **kwargs)
 
 

--- a/oggm/tests/funcs.py
+++ b/oggm/tests/funcs.py
@@ -214,8 +214,8 @@ def patch_url_retrieve_github(url, *args, **kwargs):
     """A simple patch to OGGM's download function to make sure we don't
     download elsewhere than expected."""
 
-    assert 'github' in url
-    assert 'cluster.klima.uni-bremen.de/~fmaussion/gdirs/' in url
+    assert ('github' in url or
+            'cluster.klima.uni-bremen.de/~fmaussion/gdirs/' in url)
     return oggm_urlretrieve(url, *args, **kwargs)
 
 


### PR DESCRIPTION
<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->

There is a safety wall on tests, to make sure they don't go online unexpectedly. 

Recently I made the safety wall less strict for new kind of tests (start from online gdir), this PR makes it a bit more explicit even