### PR TITLE
Switch off multiproc in merge glacier tests

### DIFF
--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -2679,6 +2679,7 @@ class TestMergedHEF(unittest.TestCase):
         cfg.PARAMS['border'] = 100
         cfg.PARAMS['prcp_scaling_factor'] = 1.75
         cfg.PARAMS['temp_melt'] = -1.75
+        cfg.PARAMS['use_multiprocessing'] = False
 
     def tearDown(self):
         self.rm_dir()


### PR DESCRIPTION
<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->

I have the strong intuition that multiprocessing is the reason why code coverage is missing.

cc @matthiasdusch 