### PR TITLE
init_glacier_regions can now start from a list of ids as well

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -13,6 +13,8 @@ New contributors to the project:
   cross-validation tools and an associated website.
 - **Philipp Gregor** (Master student, University of Innsbruck), added options
   to switch on lateral bed stress in the flowline ice dynamics
+- **Nicolas Champollion** (PostDoc, University of Bremen), added GCM data
+  IO routines.
 - **Sadie Bartholomew** (Software Engineer, UK Met Office), added ability to
   replace colormaps in graphics with HCL-based colors using python-colorspace.
 
@@ -167,6 +169,9 @@ Enhancements
   By `Matthias Dusch <https://github.com/matthiasdusch>`_.
 - New ``oggm_prepro`` command line tool to run the OGGM preprocessing tasks
   and compress the directories (:pull:`648`).
+  By `Fabien Maussion <https://github.com/fmaussion>`_.
+- `init_glacier_regions` task now accepts RGI Ids strongs as input instead of
+  only Geodataframes previously (:pull:`656`).
   By `Fabien Maussion <https://github.com/fmaussion>`_.
 
 

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -420,10 +420,9 @@ class TestStartFromPrepro(unittest.TestCase):
 
         # Go - initialize working directories
         entitites = self.rgidf.iloc[:4].RGIId
+        cfg.PARAMS['border'] = 10
         gdirs = workflow.init_glacier_regions(entitites,
-                                              from_prepro_level=1,
-                                              prepro_rgi_version='61',
-                                              prepro_border=160)
+                                              from_prepro_level=1)
         n_intersects = 0
         for gdir in gdirs:
             assert gdir.has_file('dem')

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -1260,11 +1260,21 @@ class GlacierDirectory(object):
 
         # RGI IDs are also valid entries
         if isinstance(rgi_entity, str):
+            # Get the meta from the shape file directly
             if from_tar:
-                raise NotImplementedError('`from_tar` and a str entity is '
-                                          'not implemented yet!')
-            _shp = os.path.join(base_dir, rgi_entity[:8], rgi_entity[:11],
-                                rgi_entity, 'outlines.shp')
+                _dir = os.path.join(base_dir, rgi_entity[:8], rgi_entity[:11],
+                                    rgi_entity)
+                if not os.path.exists(str(from_tar)):
+                    from_tar = _dir + '.tar.gz'
+                with tarfile.open(from_tar, 'r') as tf:
+                    tf.extractall(os.path.dirname(_dir))
+                if delete_tar:
+                    os.remove(from_tar)
+                from_tar = False  # to not re-unpack later below
+                _shp = os.path.join(_dir, 'outlines.shp')
+            else:
+                _shp = os.path.join(base_dir, rgi_entity[:8], rgi_entity[:11],
+                                    rgi_entity, 'outlines.shp')
             rgi_entity = self._read_shapefile_from_path(_shp)
             crs = salem.check_crs(rgi_entity.crs)
             rgi_entity = rgi_entity.iloc[0]

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -194,7 +194,7 @@ def _gdirs_from_prepro(entity, from_prepro_level=None,
                        prepro_border=None, prepro_rgi_version=None):
 
     if prepro_border is None:
-        prepro_border = cfg.PARAMS['border']
+        prepro_border = int(cfg.PARAMS['border'])
     if prepro_rgi_version is None:
         prepro_rgi_version = cfg.PARAMS['rgi_version']
     try:

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -84,7 +84,7 @@ class _pickle_copier(object):
             call_func = self.call_func
         else:
             call_func, gdir = arg
-        if isinstance(gdir, Sequence):
+        if isinstance(gdir, Sequence) and not isinstance(gdir, str):
             gdir, gdir_kwargs = gdir
             gdir_kwargs = _merge_dicts(self.out_kwargs, gdir_kwargs)
             return call_func(gdir, **gdir_kwargs)
@@ -197,8 +197,12 @@ def _gdirs_from_prepro(entity, from_prepro_level=None,
         prepro_border = cfg.PARAMS['border']
     if prepro_rgi_version is None:
         prepro_rgi_version = cfg.PARAMS['rgi_version']
+    try:
+        rid = entity.RGIId
+    except AttributeError:
+        rid = entity
     tar_url = utils.prepro_gdir_url(prepro_rgi_version,
-                                    entity.RGIId,
+                                    rid,
                                     prepro_border,
                                     from_prepro_level)
     from_tar = utils.file_downloader(tar_url)
@@ -207,7 +211,7 @@ def _gdirs_from_prepro(entity, from_prepro_level=None,
     return oggm.GlacierDirectory(entity, from_tar=from_tar)
 
 
-def init_glacier_regions(rgidf=None, reset=False, force=False,
+def init_glacier_regions(rgidf=None, *, reset=False, force=False,
                          from_prepro_level=None, prepro_border=None,
                          prepro_rgi_version=None,
                          from_tar=False, delete_tar=False):
@@ -218,7 +222,7 @@ def init_glacier_regions(rgidf=None, reset=False, force=False,
 
     Parameters
     ----------
-    rgidf : GeoDataFrame, optional for pre-computed runs
+    rgidf : GeoDataFrame or list of ids, optional for pre-computed runs
         the RGI glacier outlines. If unavailable, OGGM will parse the
         information from the glacier directories found in the working
         directory. It is required for new runs.
@@ -261,26 +265,35 @@ def init_glacier_regions(rgidf=None, reset=False, force=False,
     new_gdirs = []
     if rgidf is None:
         if reset:
-            raise ValueError('Cannot use reset without a rgi file')
-        log.workflow('init_glacier_regions by parsing available folders.')
+            raise ValueError('Cannot use reset without setting rgidf')
+        log.workflow('init_glacier_regions by parsing available folders '
+                     '(can be slow).')
         # The dirs should be there already
         gl_dir = os.path.join(cfg.PATHS['working_dir'], 'per_glacier')
         for root, _, files in os.walk(gl_dir):
             if files and ('dem.tif' in files):
                 gdirs.append(oggm.GlacierDirectory(os.path.basename(root)))
     else:
+
+        # Check if dataframe or list of strs
+        try:
+            entities = []
+            for _, entity in rgidf.iterrows():
+                entities.append(entity)
+        except AttributeError:
+            entities = utils.tolist(rgidf)
+
         if from_prepro_level is not None:
             log.workflow('init_glacier_regions from prepro level {} on '
-                         '{} glaciers.'.format(from_prepro_level, len(rgidf)))
-            entitites = []
-            for _, entity in rgidf.iterrows():
-                entitites.append(entity)
-            gdirs = execute_entity_task(_gdirs_from_prepro, entitites,
+                         '{} glaciers.'.format(from_prepro_level,
+                                               len(entities)))
+            gdirs = execute_entity_task(_gdirs_from_prepro, entities,
                                         from_prepro_level=from_prepro_level,
                                         prepro_border=prepro_border,
                                         prepro_rgi_version=prepro_rgi_version)
         else:
-            for _, entity in rgidf.iterrows():
+            # TODO: if necessary this could use multiprocessing as well
+            for entity in entities:
                 gdir = oggm.GlacierDirectory(entity, reset=reset,
                                              from_tar=from_tar,
                                              delete_tar=delete_tar)


### PR DESCRIPTION
<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->

This is going to be useful for tutorials and such. Now one can do:

```python
gdirs = workflow.init_glacier_regions(['RGI60-00001], from_prepro_level=1)
```


