### PR TITLE
Allow fallbacks for failing entity tasks + fallback functions for 'local_t_star' and 'mu_star_calibration'

### DIFF
--- a/oggm/core/climate.py
+++ b/oggm/core/climate.py
@@ -977,7 +977,7 @@ def calving_mb(gdir):
     return gdir.inversion_calving_rate * 1e9 * rho / gdir.rgi_area_m2
 
 
-@entity_task(log, writes=['local_mustar'])
+@entity_task(log, writes=['local_mustar'], fallback=utils.fb_local_t_star)
 def local_t_star(gdir, *, ref_df=None, tstar=None, bias=None):
     """Compute the local t* and associated glacier-wide mu*.
 

--- a/oggm/utils/__init__.py
+++ b/oggm/utils/__init__.py
@@ -2,3 +2,4 @@
 from oggm.utils._downloads import *
 from oggm.utils._funcs import *
 from oggm.utils._workflow import *
+from oggm.utils._fallbacks import *

--- a/oggm/utils/_fallbacks.py
+++ b/oggm/utils/_fallbacks.py
@@ -1,0 +1,31 @@
+"""Fallback functions which can be passed to the entity decorator."""
+
+# External libs
+import numpy as np
+
+
+def fb_local_t_star(gdir):
+    """A Fallback function if climate.local_t_star raises an Error.
+
+    This function will still write a `local_mustar.json`, filled with NANs,
+    if climate.local_t_star fails and cfg.PARAMS['continue_on_error'] = True.
+
+    As `local_mustar.json` will be read, extended and rewritten by
+    climate.mu_star_calibration, those entries will be written here as well.
+
+    Parameters
+    ----------
+    gdir : :py:class:`oggm.GlacierDirectory`
+        the glacier directory to process
+
+    """
+    # Scalars in a small dict for later
+    df = dict()
+    df['rgi_id'] = gdir.rgi_id
+    df['t_star'] = np.nan
+    df['bias'] = np.nan
+    df['mu_star_glacierwide'] = np.nan
+    df['mu_star_per_flowline'] = [np.nan]
+    df['mu_star_flowline_avg'] = np.nan
+    df['mu_star_allsame'] = np.nan
+    gdir.write_json(df, 'local_mustar')

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -325,7 +325,7 @@ class entity_task(object):
     exceptions, logging, and (some day) database for job-controlling.
     """
 
-    def __init__(self, log, writes=[]):
+    def __init__(self, log, writes=[], fallback=None):
         """Decorator syntax: ``@oggm_task(writes=['dem', 'outlines'])``
 
         Parameters
@@ -333,9 +333,12 @@ class entity_task(object):
         writes: list
             list of files that the task will write down to disk (must be
             available in ``cfg.BASENAMES``)
+        fallback: python function
+            will be executed on gdir if entity_task fails
         """
         self.log = log
         self.writes = writes
+        self.fallback = fallback
 
         cnt = ['    Notes']
         cnt += ['    -----']
@@ -393,6 +396,9 @@ class entity_task(object):
                                    gdir.rgi_id, str(err))
                 if not cfg.PARAMS['continue_on_error']:
                     raise
+
+                if self.fallback is not None:
+                    self.fallback(gdir)
             return out
 
         _entity_task.__dict__['is_entity_task'] = True


### PR DESCRIPTION
- [ ] Tests added/passed
- [ ] Fully documented
- [ ] Entry in `whats-new.rst` 


This PR expands the `execute_entity_task` decorator with a fallback argument:
If a task fails and `cfg.PARAMS['continue_on_error']==True` a fallback-function will be executed.

I suggest storing these fallback functions in `utils/_fallbacks.py`.

Hera also two first fallback functions for climate.local_t_star and climate.mu_star_calibration are included.
`local_t_star` writes a `local_mustar.json`  to the glacier directory with information on tstar, mustar, and bias. If this task fails but `cfg.PARAMS['continue_on_error']==True` later tasks like 'mu_star_calibration' would read a possible preexisting json file (e.g. if the same glacier is run several times with different parameter settings).