### PR TITLE
Change in prepro_levels and gdir size reduction

### DIFF
--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -1768,18 +1768,6 @@ class GlacierDirectory(object):
         v.standard_name = 'projection_y_coordinate'
         v[:] = y
 
-        v = nc.createVariable('longitude', 'f4', ('y', 'x'), zlib=True)
-        v.units = 'degrees_east'
-        v.long_name = 'longitude coordinate'
-        v.standard_name = 'longitude'
-        v[:] = lon
-
-        v = nc.createVariable('latitude', 'f4', ('y', 'x'), zlib=True)
-        v.units = 'degrees_north'
-        v.long_name = 'latitude coordinate'
-        v.standard_name = 'latitude'
-        v[:] = lat
-
         return nc
 
     def write_monthly_climate_file(self, time, prcp, temp,


### PR DESCRIPTION
<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->

This should be transparent for the users. Still:
- prepro_levels now has 4 levels instead of 5 (I removed a useless one in between)
- climate is now level 2, making it much cheaper in terms of space

I will have to update the tests once the data is available on cluster.

I also removed useless variables from the gridded netcdf file, which will make the gdirs much smaller I think. 
