### PR TITLE
Add oggm_benchmark CLI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,7 @@ setup(
         'pytest11': ['pytest_oggm = oggm.pytest_plugin'],
         'console_scripts': [
             'oggm_prepro = oggm.cli.prepro_levels:main',
+            'oggm_benchmark = oggm.cli.benchmark:main',
         ],
     },
 )


### PR DESCRIPTION
This add an `oggm_benchmark` command. 

It works very much like `prepro_levels` and will write a csv file with some running time in it.

Typically you would like to run in on an RGI region and see how long it takes. If necessary we could add much more options to track memory usage and more, but this is a first step.