### PR TITLE
Add a simple way to do a CRU spinup

### DIFF
--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -22,6 +22,7 @@ from oggm import __version__
 import oggm.cfg as cfg
 from oggm import utils
 from oggm import entity_task
+from oggm.exceptions import InvalidParamsError
 from oggm.core.massbalance import (MultipleFlowlineMassBalance,
                                    ConstantMassBalance,
                                    PastMassBalance,
@@ -676,6 +677,11 @@ class FlowlineModel(object):
         if run_path is not None:
             self.to_netcdf(run_path)
         ny = len(yearly_time)
+        if ny == 1:
+            yrs = [yrs]
+            cyrs = [cyrs]
+            months = [months]
+            cmonths = [cmonths]
         nm = len(monthly_time)
         sects = [(np.zeros((ny, fl.nx)) * np.NaN) for fl in self.fls]
         widths = [(np.zeros((ny, fl.nx)) * np.NaN) for fl in self.fls]
@@ -1805,7 +1811,7 @@ def run_constant_climate(gdir, nyears=1000, y0=None, halfsize=15,
 
 
 @entity_task(log)
-def run_from_climate_data(gdir, ys=None, ye=None,
+def run_from_climate_data(gdir, ys=None, ye=None, min_ys=None,
                           store_monthly_step=False,
                           climate_filename='climate_monthly',
                           climate_input_filesuffix='', output_filesuffix='',
@@ -1823,9 +1829,13 @@ def run_from_climate_data(gdir, ys=None, ye=None,
     gdir : :py:class:`oggm.GlacierDirectory`
         the glacier directory to process
     ys : int
-        start year of the model run (default: from the config file)
+        start year of the model run (default: from the glacier geometry
+        date)
     ye : int
-        end year of the model run (default: from the config file)
+        end year of the model run (no default: needs to be set)
+    min_ys : int
+        if you want to impose a minimum start year, regardless if the glacier
+        inventory date is later.
     store_monthly_step : bool
         whether to store the diagnostic data at a monthly time step or not
         (default is yearly)
@@ -1853,9 +1863,14 @@ def run_from_climate_data(gdir, ys=None, ye=None,
     """
 
     if ys is None:
-        ys = cfg.PARAMS['ys']
+        try:
+            ys = gdir.rgi_date.year
+        except AttributeError:
+            ys = gdir.rgi_date
     if ye is None:
-        ye = cfg.PARAMS['ye']
+        raise InvalidParamsError('Need to set the `ye` kwarg!')
+    if min_ys is not None:
+        ys = ys if ys < min_ys else min_ys
 
     if init_model_filesuffix is not None:
         fp = gdir.get_filepath('model_run', filesuffix=init_model_filesuffix)

--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -246,8 +246,3 @@ use_shape_factor_for_fluxbasedmodel =
 # This value could need more tuning
 downstream_min_shape = 0.0001
 trapezoid_lambdas = 0.2
-# Which period you want to run?
-ys = 1990
-ye = 2003
-
-

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -525,7 +525,7 @@ class TestCenterlines(unittest.TestCase):
         entity['Area'] = entity['AREA']
         entity['CenLat'] = entity['CENLAT']
         entity['CenLon'] = entity['CENLON']
-        entity.BgnDate = 0
+        entity.BgnDate = '-999'
         entity.Name = 'Baltoro'
         entity.GlacType = '0000'
         entity.Status = '0'
@@ -538,6 +538,8 @@ class TestCenterlines(unittest.TestCase):
 
         my_mask = np.zeros((gdir.grid.ny, gdir.grid.nx), dtype=np.uint8)
         cls = gdir.read_pickle('centerlines')
+
+        assert gdir.rgi_date == 2009
 
         sub = centerlines.line_inflows(cls[-1])
         self.assertEqual(set(cls), set(sub))

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -44,6 +44,29 @@ from oggm.utils._downloads import (get_demo_file, get_wgms_files,
 from oggm import cfg
 from oggm.exceptions import InvalidParamsError
 
+
+# Default RGI date (median per region)
+RGI_DATE = {'01': 2009,
+            '02': 2004,
+            '03': 1999,
+            '04': 2001,
+            '05': 2001,
+            '06': 2000,
+            '07': 2008,
+            '08': 2002,
+            '09': 2001,
+            '10': 2011,
+            '11': 2003,
+            '12': 2001,
+            '13': 2006,
+            '14': 2001,
+            '15': 2001,
+            '16': 2000,
+            '17': 2000,
+            '18': 1978,
+            '19': 1989,
+            }
+
 # Module logger
 log = logging.getLogger('.'.join(__name__.split('.')[:-1]))
 
@@ -552,7 +575,6 @@ def compile_run_output(gdirs, path=True, filesuffix='', use_compression=True):
             i += 1
 
     # OK found it, open it and prepare the output
-
     with xr.open_dataset(ppath) as ds_diag:
         time = ds_diag.time.values
         yrs = ds_diag.hydro_year.values
@@ -1290,9 +1312,9 @@ class GlacierDirectory(object):
         The glacier's RGI area (km2)
     cenlon, cenlat : float
         The glacier centerpoint's lon/lat
-    rgi_date : datetime
-        The RGI's BGNDATE attribute if available. Otherwise, defaults to
-        2003-01-01
+    rgi_date : int
+        The RGI's BGNDATE year attribute if available. Otherwise, defaults to
+        the median year for the RGI region
     rgi_region : str
         The RGI region name
     name : str
@@ -1446,11 +1468,9 @@ class GlacierDirectory(object):
         self.hemisphere = 'sh' if self.cenlat < 0 else 'nh'
 
         # convert the date
-        try:
-            rgi_date = pd.to_datetime(rgi_datestr[0:4],
-                                      errors='raise', format='%Y')
-        except BaseException:
-            rgi_date = None
+        rgi_date = int(rgi_datestr[0:4])
+        if rgi_date < 0:
+            rgi_date = RGI_DATE[self.rgi_region]
         self.rgi_date = rgi_date
 
         # Root directory


### PR DESCRIPTION
<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->

This are simple minor tweaks to make the glacier mip runs possible.

Now one can do:

```python
# Go - initialize working directories
gdirs = workflow.init_glacier_regions(rgidf, from_prepro_level=4)

# Spinup for glaciers before 2006
workflow.execute_entity_task(tasks.run_from_climate_data, gdirs,
                             ye=2006, min_ys=2006,
                             output_filesuffix='_spinup')

# Add climate and run
rcps = ['rcp26', 'rcp85']
gcms = ['CCSM4', 'CNRM-CM5']
task_names = []
for rcp in rcps:
    for gcm in gcms:

        filesuffix = '_{}_{}'.format(gcm, rcp)
        fpath_temp = 'tas_mon{}_r1i1p1_g025.nc'.format(filesuffix)
        fpath_precip = 'pr_mon{}_r1i1p1_g025.nc'.format(filesuffix)

        log.workflow('Start experiment ' + filesuffix)
        workflow.execute_entity_task(tasks.process_cmip5_data, gdirs,
                                     filesuffix=filesuffix,
                                     fpath_temp=utils.get_cmip5_file(fpath_temp),
                                     fpath_precip=utils.get_cmip5_file(fpath_precip))

        # Run
        workflow.execute_entity_task(tasks.run_from_climate_data, gdirs,
                                     climate_filename='gcm_data',
                                     init_model_filesuffix='_spinup',  # <------------ this is new as well
                                     climate_input_filesuffix=filesuffix,
                                     ys=2006, ye=2100,
                                     output_filesuffix=filesuffix)

        log.workflow('Compiling output ' + filesuffix + ' ...')
        utils.compile_run_output(gdirs, filesuffix=filesuffix)
        task_names.append('run_random_climate' + filesuffix)
```

cc @nchampollion 
