### PR TITLE
Back to prepro gdirs on my www folder

### DIFF
--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -1666,6 +1666,28 @@ class TestDataFiles(unittest.TestCase):
         for fp in fdem:
             self.assertTrue(os.path.exists(fp))
 
+    @pytest.mark.download
+    def test_from_prepro(self):
+
+        # Read in the RGI file
+        rgi_file = utils.get_demo_file('rgi_oetztal.shp')
+        rgidf = gpd.read_file(rgi_file)
+        rgidf['RGIId'] = [rid.replace('RGI50', 'RGI60')
+                               for rid in rgidf.RGIId]
+
+        # Go - initialize working directories
+        gdirs = workflow.init_glacier_regions(rgidf.iloc[:2],
+                                              from_prepro_level=1,
+                                              prepro_rgi_version='61',
+                                              prepro_border=10,
+                                              use_demo_glaciers=False)
+        n_intersects = 0
+        for gdir in gdirs:
+            assert gdir.has_file('dem')
+            n_intersects += gdir.has_file('intersects')
+        assert n_intersects > 0
+        workflow.execute_entity_task(tasks.glacier_masks, gdirs)
+
 
 class TestSkyIsFalling(unittest.TestCase):
 

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -53,7 +53,7 @@ CRU_SERVER = ('https://crudata.uea.ac.uk/cru/data/hrg/cru_ts_4.01/cruts'
 
 HISTALP_SERVER = 'http://www.zamg.ac.at/histalp/download/grid5m/'
 
-GDIR_URL = 'https://cluster.klima.uni-bremen.de/data/gdirs/oggm_v1.1/'
+GDIR_URL = 'https://cluster.klima.uni-bremen.de/~fmaussion/gdirs/oggm_v1.1/'
 DEMO_GDIR_URL = 'https://cluster.klima.uni-bremen.de/~fmaussion/demo_gdirs/'
 
 CMIP5_URL = 'https://cluster.klima.uni-bremen.de/~nicolas/cmip5-ng/'


### PR DESCRIPTION
So yesterday I recreated the prepo gdirs with the current default docker file (not py7 anymore)

This tells OGGM to download from them again.

@TimoRoth : you can safely delete `www/data/gdirs` on cluster. Could you update the hash files from your current PR to include the following folders?

- https://cluster.klima.uni-bremen.de/~fmaussion/demo_gdirs/ 
- https://cluster.klima.uni-bremen.de/~fmaussion/gdirs/
- https://cluster.klima.uni-bremen.de/~fmaussion/test_gdirs/    
- https://cluster.klima.uni-bremen.de/~nicolas/cmip5-ng/

Thanks!