### PR TITLE
Downloading preprocessed GDirs with multiprocessing fails

### DIFF
--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -295,13 +295,6 @@ def _requests_urlretrieve(url, path, reporthook):
 
 
 def oggm_urlretrieve(url, cache_obj_name=None, reset=False, reporthook=None):
-    with _get_download_lock():
-        return _oggm_urlretrieve_unlocked(url, cache_obj_name, reset,
-                                          reporthook)
-
-
-def _oggm_urlretrieve_unlocked(url, cache_obj_name=None, reset=False,
-                               reporthook=None):
     """Wrapper around urlretrieve, to implement our caching logic.
 
     Instead of accepting a destination path, it decided where to store the file
@@ -755,15 +748,22 @@ def _get_centerline_lonlat(gdir):
     return olist
 
 
-def prepro_gdir_url(rgi_version, rgi_id, border, prepro_level, demo_url=False):
+def get_prepro_gdir(rgi_version, rgi_id, border, prepro_level, demo_url=False):
+    with _get_download_lock():
+        return _get_prepro_gdir_unlocked(rgi_version, rgi_id, border,
+                                         prepro_level, demo_url)
 
+
+def _get_prepro_gdir_unlocked(rgi_version, rgi_id, border, prepro_level,
+                              demo_url=False):
     # Prepro URL
     url = DEMO_GDIR_URL if demo_url else GDIR_URL
     url += 'RGI{}/'.format(rgi_version)
     url += 'b_{:03d}/'.format(border)
     url += 'L{:d}/'.format(prepro_level)
     url += '{}/{}.tar' .format(rgi_id[:8], rgi_id[:11])
-    return url
+
+    return file_downloader(url)
 
 
 def srtm_zone(lon_ex, lat_ex):

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -295,6 +295,13 @@ def _requests_urlretrieve(url, path, reporthook):
 
 
 def oggm_urlretrieve(url, cache_obj_name=None, reset=False, reporthook=None):
+    with _get_download_lock():
+        return _oggm_urlretrieve_unlocked(url, cache_obj_name, reset,
+                                          reporthook)
+
+
+def _oggm_urlretrieve_unlocked(url, cache_obj_name=None, reset=False,
+                               reporthook=None):
     """Wrapper around urlretrieve, to implement our caching logic.
 
     Instead of accepting a destination path, it decided where to store the file

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -420,13 +420,6 @@ def file_downloader(www_path, retry_max=5, cache_name=None, reset=False):
                         (www_path, err.code, retry_counter, retry_max))
             time.sleep(10)
             continue
-        except DownloadVerificationFailedException:
-            logger.info("Downloading %s failed with"
-                        "DownloadVerificationFailedException, "
-                        "retrying in 10 seconds... %s/%s" %
-                        (www_path, retry_counter, retry_max))
-            time.sleep(10)
-            continue
 
     # See if we managed (fail is allowed)
     if not local_path or not os.path.exists(local_path):

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -763,7 +763,11 @@ def _get_prepro_gdir_unlocked(rgi_version, rgi_id, border, prepro_level,
     url += 'L{:d}/'.format(prepro_level)
     url += '{}/{}.tar' .format(rgi_id[:8], rgi_id[:11])
 
-    return file_downloader(url)
+    tar_base = file_downloader(url)
+    if tar_base is None:
+        raise RuntimeError('Could not find file at ' + url)
+
+    return tar_base
 
 
 def srtm_zone(lon_ex, lat_ex):

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -420,6 +420,13 @@ def file_downloader(www_path, retry_max=5, cache_name=None, reset=False):
                         (www_path, err.code, retry_counter, retry_max))
             time.sleep(10)
             continue
+        except DownloadVerificationFailedException:
+            logger.info("Downloading %s failed with"
+                        "DownloadVerificationFailedException, "
+                        "retrying in 10 seconds... %s/%s" %
+                        (www_path, retry_counter, retry_max))
+            time.sleep(10)
+            continue
 
     # See if we managed (fail is allowed)
     if not local_path or not os.path.exists(local_path):

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -211,9 +211,8 @@ def gdir_from_prepro(entity, from_prepro_level=None,
             entity = demo_id
             demo_url = True
 
-    tar_url = utils.prepro_gdir_url(prepro_rgi_version, rid, prepro_border,
-                                    from_prepro_level, demo_url=demo_url)
-    tar_base = utils.file_downloader(tar_url)
+    tar_base = utils.get_prepro_gdir(prepro_rgi_version, rid, prepro_border,
+                                     from_prepro_level, demo_url=demo_url)
     if tar_base is None:
         raise RuntimeError('Could not find file at ' + tar_url)
     from_tar = os.path.join(tar_base.replace('.tar', ''), rid + '.tar.gz')

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -213,8 +213,6 @@ def gdir_from_prepro(entity, from_prepro_level=None,
 
     tar_base = utils.get_prepro_gdir(prepro_rgi_version, rid, prepro_border,
                                      from_prepro_level, demo_url=demo_url)
-    if tar_base is None:
-        raise RuntimeError('Could not find file at ' + tar_url)
     from_tar = os.path.join(tar_base.replace('.tar', ''), rid + '.tar.gz')
     return oggm.GlacierDirectory(entity, from_tar=from_tar)
 


### PR DESCRIPTION
As preprocessed GDirs are regionally grouped, downloading two or more GDirs from one region will cause a `DownloadVerificationFailedException` if multiprocessing is enabled: If the file is not already downloaded, the first entity task will start downloading it, while the subsequent tasks see the existing but only partially downloaded file and will raise the above error.

This PR implements a multiprocessing Lock structure, following other download functions.

There might be smarter/faster ways to improve this in near feature.