### PR TITLE
Except DownloadVerificationFailedException in file_downloader

### DIFF
--- a/oggm/exceptions.py
+++ b/oggm/exceptions.py
@@ -24,7 +24,9 @@ class NoInternetException(Exception):
 
 
 class DownloadVerificationFailedException(Exception):
-    pass
+    def __init__(self, msg=None, path=None):
+        self.msg = msg
+        self.path = path
 
 
 class HttpDownloadError(Exception):

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -555,6 +555,31 @@ class TestStartFromOnlinePrepro(unittest.TestCase):
         workflow.execute_entity_task(tasks.run_random_climate, gdirs,
                                      nyears=10)
 
+    def test_corrupted_file(self):
+
+        # Go - initialize working directories
+        gdirs = workflow.init_glacier_regions(['hef'],
+                                              from_prepro_level=4,
+                                              prepro_rgi_version='61',
+                                              prepro_border=10)
+
+        cfile = utils.get_prepro_gdir('61', 'RGI60-11.00787', 10, 4,
+                                      demo_url=True)
+        assert 'cluster.klima.uni-bremen.de/~fmaussion/' in cfile
+
+        # Replace with a dummy file
+        os.remove(cfile)
+        with open(cfile, 'w') as f:
+            f.write('ups')
+
+        # This should retrigger a download and just work
+        gdirs = workflow.init_glacier_regions(['hef'],
+                                              from_prepro_level=4,
+                                              prepro_rgi_version='61',
+                                              prepro_border=10)
+        workflow.execute_entity_task(tasks.run_random_climate, gdirs,
+                                     nyears=10)
+
 
 class TestPreproCLI(unittest.TestCase):
 

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -414,7 +414,10 @@ def file_downloader(www_path, retry_max=5, cache_name=None, reset=False):
             time.sleep(10)
             continue
         except DownloadVerificationFailedException as err:
-            os.remove(err.path)
+            try:
+                os.remove(err.path)
+            except FileNotFoundError:
+                pass
             logger.info("Downloading %s failed with "
                         "DownloadVerificationFailedException\n %s\n"
                         "The file might have changed or is corrupted. "

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -417,9 +417,9 @@ def file_downloader(www_path, retry_max=5, cache_name=None, reset=False):
             os.remove(err.path)
             logger.info("Downloading %s failed with "
                         "DownloadVerificationFailedException\n %s\n"
-                        "File deleted and retrying in 10 seconds... %s/%s" %
-                        (www_path, err.msg, retry_counter, retry_max))
-            time.sleep(10)
+                        "The file might have changed or is corrupted."
+                        "File deleted. Re-downloading... %s/%s" %
+                        (www_path, err.msg, retry_counter, retry_max)
             continue
 
     # See if we managed (fail is allowed)

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -417,9 +417,9 @@ def file_downloader(www_path, retry_max=5, cache_name=None, reset=False):
             os.remove(err.path)
             logger.info("Downloading %s failed with "
                         "DownloadVerificationFailedException\n %s\n"
-                        "The file might have changed or is corrupted."
+                        "The file might have changed or is corrupted. "
                         "File deleted. Re-downloading... %s/%s" %
-                        (www_path, err.msg, retry_counter, retry_max)
+                        (www_path, err.msg, retry_counter, retry_max))
             continue
 
     # See if we managed (fail is allowed)

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -257,7 +257,7 @@ def _verified_download_helper(cache_obj_name, dl_func, reset=False):
                     path,
                     size, crc32.to_bytes(4, byteorder='big').hex(),
                     data[0], data[1].to_bytes(4, byteorder='big').hex())
-                raise DownloadVerificationFailedException(err)
+                raise DownloadVerificationFailedException(msg=err, path=path)
             logger.info('%s verified successfully.' % path)
 
     return path
@@ -411,6 +411,14 @@ def file_downloader(www_path, retry_max=5, cache_name=None, reset=False):
             logger.info("Downloading %s failed with ContentTooShortError"
                         " error %s, retrying in 10 seconds... %s/%s" %
                         (www_path, err.code, retry_counter, retry_max))
+            time.sleep(10)
+            continue
+        except DownloadVerificationFailedException as err:
+            os.remove(err.path)
+            logger.info("Downloading %s failed with "
+                        "DownloadVerificationFailedException\n %s\n"
+                        "File deleted and retrying in 10 seconds... %s/%s" %
+                        (www_path, err.msg, retry_counter, retry_max))
             time.sleep(10)
             continue
 


### PR DESCRIPTION
This PR implements a `except` in the main `file_downloader` function in order to retry the download several times if the checksums do not match.
The file will be deleted and redownloaded.

Needs PR #704 to be merged, as unlocked downloads would fail otherwise.


