### PR TITLE
doc run examples

### DIFF
--- a/docs/run_examples/_code/mb_crossval.py
+++ b/docs/run_examples/_code/mb_crossval.py
@@ -51,7 +51,8 @@ for i, gdir in enumerate(gdirs):
     tasks.mu_star_calibration(gdir)
 
     # Mass-balance model with cross-validated parameters instead
-    mb_mod = MultipleFlowlineMassBalance(gdir, mb_model_class=PastMassBalance)
+    mb_mod = MultipleFlowlineMassBalance(gdir, mb_model_class=PastMassBalance,
+                                         use_inversion_flowlines=True)
 
     # Mass-balance timeseries, observed and simulated
     refmb = gdir.get_ref_mb_data().copy()
@@ -92,8 +93,7 @@ ax.set_ylabel('N Glaciers')
 ax.set_xlabel('Mass-balance error (mm w.e. yr$^{-1}$)')
 ax.legend(loc='best')
 plt.tight_layout()
-fn = os.path.join(WORKING_DIR, 'mb_crossval_rgi{}.png'.format(rgi_version))
-plt.savefig(fn, dpi=150)
+plt.show()
 
 scores = 'Median bias: {:.2f}\n'.format(ref_df['CV_MB_BIAS'].median())
 scores += 'Mean bias: {:.2f}\n'.format(ref_df['CV_MB_BIAS'].mean())

--- a/docs/run_examples/_code/run_reference_mb_glaciers.py
+++ b/docs/run_examples/_code/run_reference_mb_glaciers.py
@@ -130,11 +130,13 @@ for gd in gdirs:
 
     mb_mod = MultipleFlowlineMassBalance(gd,
                                          mb_model_class=ConstantMassBalance,
+                                         use_inversion_flowlines=True,
                                          bias=0)  # bias=0 because of calib!
     mb = mb_mod.get_specific_mb()
     np.testing.assert_allclose(mb, 0, atol=5)  # atol for numerical errors
 
-    mb_mod = MultipleFlowlineMassBalance(gd, mb_model_class=PastMassBalance)
+    mb_mod = MultipleFlowlineMassBalance(gd, mb_model_class=PastMassBalance,
+                                         use_inversion_flowlines=True)
 
     refmb = gd.get_ref_mb_data().copy()
     refmb['OGGM'] = mb_mod.get_specific_mb(year=refmb.index)


### PR DESCRIPTION
- [x] the MB-models in the crossvalidation run examples explicitly need `use_inversion_flowlines=True`
- [x] showing the barplot is more straight forward than storing it somewhere on the users disk in my opinion

might receive more commits 