### PR TITLE
Update test base

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,21 +33,21 @@ matrix:
     - env: TEST_CONTAINER=py37 OGGM_TEST_ENV=workflow MPL=--mpl OGGM_TEST_MULTIPROC=False
     - env: TEST_CONTAINER=py37 OGGM_TEST_ENV=graphics MPL=--mpl
   include:
-    - env: TEST_CONTAINER=20190308 OGGM_TEST_ENV=prepro MPL=
+    - env: TEST_CONTAINER=20190409 OGGM_TEST_ENV=prepro MPL=
       os: linux
-    - env: TEST_CONTAINER=20190308 OGGM_TEST_ENV=numerics MPL=
+    - env: TEST_CONTAINER=20190409 OGGM_TEST_ENV=numerics MPL=
       os: linux
-    - env: TEST_CONTAINER=20190308 OGGM_TEST_ENV=models MPL=
+    - env: TEST_CONTAINER=20190409 OGGM_TEST_ENV=models MPL=
       os: linux
-    - env: TEST_CONTAINER=20190308 OGGM_TEST_ENV=benchmark MPL=
+    - env: TEST_CONTAINER=20190409 OGGM_TEST_ENV=benchmark MPL=
       os: linux
-    - env: TEST_CONTAINER=20190308 OGGM_TEST_ENV=utils MPL=
+    - env: TEST_CONTAINER=20190409 OGGM_TEST_ENV=utils MPL=
       os: linux
-    - env: TEST_CONTAINER=20190308 OGGM_TEST_ENV=workflow MPL=--mpl OGGM_TEST_MULTIPROC=True
+    - env: TEST_CONTAINER=20190409 OGGM_TEST_ENV=workflow MPL=--mpl OGGM_TEST_MULTIPROC=True
       os: linux
-    - env: TEST_CONTAINER=20190308 OGGM_TEST_ENV=workflow MPL=--mpl OGGM_TEST_MULTIPROC=False
+    - env: TEST_CONTAINER=20190409 OGGM_TEST_ENV=workflow MPL=--mpl OGGM_TEST_MULTIPROC=False
       os: linux
-    - env: TEST_CONTAINER=20190308 OGGM_TEST_ENV=graphics MPL=--mpl
+    - env: TEST_CONTAINER=20190409 OGGM_TEST_ENV=graphics MPL=--mpl
       os: linux
     - env: TEST_CONTAINER=py37 OGGM_TEST_ENV=prepro MPL=
       os: linux


### PR DESCRIPTION
Shrunk the docker images by almost 200MB by using multistage builds to get rid of build-time-only dependencies.