### PR TITLE
Consistent parameter names in run output dataset

### DIFF
--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -798,24 +798,24 @@ class FlowlineModel(object):
         diag_ds['calendar_month'].attrs['description'] = 'Calendar month'
 
         # Variables and attributes
-        diag_ds['volume_m3'] = ('time', np.zeros(nm) * np.NaN)
-        diag_ds['volume_m3'].attrs['description'] = 'Total glacier volume'
-        diag_ds['volume_m3'].attrs['unit'] = 'm 3'
-        diag_ds['area_m2'] = ('time', np.zeros(nm) * np.NaN)
-        diag_ds['area_m2'].attrs['description'] = 'Total glacier area'
-        diag_ds['area_m2'].attrs['unit'] = 'm 2'
-        diag_ds['length_m'] = ('time', np.zeros(nm) * np.NaN)
-        diag_ds['length_m'].attrs['description'] = 'Glacier length'
-        diag_ds['length_m'].attrs['unit'] = 'm 3'
-        diag_ds['ela_m'] = ('time', np.zeros(nm) * np.NaN)
-        diag_ds['ela_m'].attrs['description'] = ('Annual Equilibrium Line '
+        diag_ds['volume'] = ('time', np.zeros(nm) * np.NaN)
+        diag_ds['volume'].attrs['description'] = 'Total glacier volume'
+        diag_ds['volume'].attrs['unit'] = 'm 3'
+        diag_ds['area'] = ('time', np.zeros(nm) * np.NaN)
+        diag_ds['area'].attrs['description'] = 'Total glacier area'
+        diag_ds['area'].attrs['unit'] = 'm 2'
+        diag_ds['length'] = ('time', np.zeros(nm) * np.NaN)
+        diag_ds['length'].attrs['description'] = 'Glacier length'
+        diag_ds['length'].attrs['unit'] = 'm'
+        diag_ds['ela'] = ('time', np.zeros(nm) * np.NaN)
+        diag_ds['ela'].attrs['description'] = ('Annual Equilibrium Line '
                                                  'Altitude  (ELA)')
-        diag_ds['ela_m'].attrs['unit'] = 'm a.s.l'
+        diag_ds['ela'].attrs['unit'] = 'm a.s.l'
         if self.is_tidewater:
-            diag_ds['calving_m3'] = ('time', np.zeros(nm) * np.NaN)
-            diag_ds['calving_m3'].attrs['description'] = ('Total accumulated '
+            diag_ds['calving'] = ('time', np.zeros(nm) * np.NaN)
+            diag_ds['calving'].attrs['description'] = ('Total accumulated '
                                                           'calving flux')
-            diag_ds['calving_m3'].attrs['unit'] = 'm 3'
+            diag_ds['calving'].attrs['unit'] = 'm 3'
 
         # Run
         j = 0
@@ -828,12 +828,12 @@ class FlowlineModel(object):
                     w[j, :] = fl.widths_m
                 j += 1
             # Diagnostics
-            diag_ds['volume_m3'].data[i] = self.volume_m3
-            diag_ds['area_m2'].data[i] = self.area_m2
-            diag_ds['length_m'].data[i] = self.length_m
-            diag_ds['ela_m'].data[i] = self.mb_model.get_ela(year=yr)
+            diag_ds['volume'].data[i] = self.volume_m3
+            diag_ds['area'].data[i] = self.area_m2
+            diag_ds['length'].data[i] = self.length_m
+            diag_ds['ela'].data[i] = self.mb_model.get_ela(year=yr)
             if self.is_tidewater:
-                diag_ds['calving_m3'].data[i] = self.calving_m3_since_y0
+                diag_ds['calving'].data[i] = self.calving_m3_since_y0
 
         # to datasets
         run_ds = []

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -1332,10 +1332,10 @@ class TestIO(unittest.TestCase):
         np.testing.assert_allclose(ds.ts_section.isel(time=-1),
                                    secfortest)
 
-        np.testing.assert_allclose(ds_diag.volume_m3, vol_diag)
-        np.testing.assert_allclose(ds_diag.area_m2, a_diag)
-        np.testing.assert_allclose(ds_diag.length_m, l_diag)
-        np.testing.assert_allclose(ds_diag.ela_m, ela_diag)
+        np.testing.assert_allclose(ds_diag.volume, vol_diag)
+        np.testing.assert_allclose(ds_diag.area, a_diag)
+        np.testing.assert_allclose(ds_diag.length, l_diag)
+        np.testing.assert_allclose(ds_diag.ela, ela_diag)
 
         fls = dummy_constant_bed()
         run_path = os.path.join(self.test_dir, 'ts_ideal.nc')


### PR DESCRIPTION
The parameter names in the run output datasets produced by different tasks are not the same. The dataset returned by `FlowlineModel.run_until_and_store()` has units as suffixes (for the parameters length, area, volume, etc.) while the dataset returned by `utils.compile_run_output()` does not. Given that the datasets are otherwise identical in structure, it seems useful to make the parameter names coherent.
I chose to delete the suffixes, since the parameters store the unit as attribute. On the other hand, most variables in the code base have their units in the name as suffix. Therefore I am not sure which method to prefer... Anyway, it should used consistently.
