### PR TITLE
possible bug in get_ref_mb_glaciers_candidates

### DIFF
--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -1871,7 +1871,7 @@ def get_ref_mb_glaciers_candidates(rgi_version=None):
 
     if key not in cfg.DATA:
         flink, _ = get_wgms_files()
-        cfg.DATA[key] = flink['RGI{}0_ID'.format(rgi_version)].to_list()
+        cfg.DATA[key] = flink['RGI{}0_ID'.format(rgi_version)].tolist()
 
     return cfg.DATA[key]
 


### PR DESCRIPTION
For me line 1874 in utils.`_downloads.py`:
`cfg.DATA[key] = flink['RGI{}0_ID'.format(rgi_version)].to_list() `
does not work:
`AttributeError: 'Series' object has no attribute 'to_list'`

I think it should be `tolist()`

**But**: How does this code pass the tests and also the crossvalidation on the cluster? Maybe I got something wrong here... 