### PR TITLE
Docs: mass balance calibration with HISTALP

### DIFF
--- a/docs/run_examples/_code/run_reference_mb_glaciers.py
+++ b/docs/run_examples/_code/run_reference_mb_glaciers.py
@@ -77,9 +77,12 @@ log.info('Process the climate data...')
 if baseline == 'CRU':
     execute_entity_task(tasks.process_cru_data, gdirs, print_log=False)
 elif baseline == 'HISTALP':
+	# exclude glaciers outside of the Alps
+	gdirs = [gdir for gdir in gdirs if gdir.rgi_subregion == '11-01']
     cfg.PARAMS['continue_on_error'] = True  # Some glaciers are not in Alps
     execute_entity_task(tasks.process_histalp_data, gdirs, print_log=False)
     cfg.PARAMS['continue_on_error'] = False
+
 
 gdirs = utils.get_ref_mb_glaciers(gdirs)
 

--- a/docs/run_examples/_code/run_reference_mb_glaciers.py
+++ b/docs/run_examples/_code/run_reference_mb_glaciers.py
@@ -79,9 +79,7 @@ if baseline == 'CRU':
 elif baseline == 'HISTALP':
     # exclude glaciers outside of the Alps
     gdirs = [gdir for gdir in gdirs if gdir.rgi_subregion == '11-01']
-    cfg.PARAMS['continue_on_error'] = True  # Some glaciers are not in Alps
     execute_entity_task(tasks.process_histalp_data, gdirs, print_log=False)
-    cfg.PARAMS['continue_on_error'] = False
 
 gdirs = utils.get_ref_mb_glaciers(gdirs)
 

--- a/docs/run_examples/_code/run_reference_mb_glaciers.py
+++ b/docs/run_examples/_code/run_reference_mb_glaciers.py
@@ -83,7 +83,6 @@ elif baseline == 'HISTALP':
     execute_entity_task(tasks.process_histalp_data, gdirs, print_log=False)
     cfg.PARAMS['continue_on_error'] = False
 
-
 gdirs = utils.get_ref_mb_glaciers(gdirs)
 
 # Keep only these

--- a/docs/run_examples/_code/run_reference_mb_glaciers.py
+++ b/docs/run_examples/_code/run_reference_mb_glaciers.py
@@ -77,8 +77,8 @@ log.info('Process the climate data...')
 if baseline == 'CRU':
     execute_entity_task(tasks.process_cru_data, gdirs, print_log=False)
 elif baseline == 'HISTALP':
-	# exclude glaciers outside of the Alps
-	gdirs = [gdir for gdir in gdirs if gdir.rgi_subregion == '11-01']
+    # exclude glaciers outside of the Alps
+    gdirs = [gdir for gdir in gdirs if gdir.rgi_subregion == '11-01']
     cfg.PARAMS['continue_on_error'] = True  # Some glaciers are not in Alps
     execute_entity_task(tasks.process_histalp_data, gdirs, print_log=False)
     cfg.PARAMS['continue_on_error'] = False


### PR DESCRIPTION
The mass balance calibration script results in an error when calibration with HISTALP climate data. Some reference glaciers in the RGI region 11 are outside the HISTALP domain. For those glaciers no climate data is processed. This result in a `RuntimeError('Please process some climate data before call')` thrown by the task `utils.get_ref_mb_glaciers`.

To prevent this I subset the glaciers for RGI subregion 11-01.