### PR TITLE
Remove dependency on boto3

### DIFF
--- a/docs/installing-oggm.rst
+++ b/docs/installing-oggm.rst
@@ -58,6 +58,7 @@ GIS tools:
 
 Testing:
     - pytest
+    - pytest-mpl ([OGGM fork][https://github.com/OGGM/pytest-mpl] required)
 
 Other libraries:
     - `salem <https://github.com/fmaussion/salem>`_
@@ -347,8 +348,9 @@ Now install further dependencies::
 
     $ pip install pyproj rasterio Pillow geopandas netcdf4 scikit-image configobj joblib xarray progressbar2 pytest motionless dask bottleneck
 
-Finally, install the salem and python-colorspace libraries::
+Finally, install the pytest-mpl OGGM fork, salem and python-colorspace libraries::
 
+    $ pip install git+https://github.com/OGGM/pytest-mpl.git
     $ pip install git+https://github.com/fmaussion/salem.git
     $ pip install git+https://github.com/retostauffer/python-colorspace.git
 

--- a/docs/installing-oggm.rst
+++ b/docs/installing-oggm.rst
@@ -60,7 +60,6 @@ Testing:
     - pytest
 
 Other libraries:
-    - boto3
     - `salem <https://github.com/fmaussion/salem>`_
     - `motionless <https://github.com/ryancox/motionless/>`_
 
@@ -346,7 +345,7 @@ Fiona also builds upon GDAL, so let's compile it the same way::
 
 Now install further dependencies::
 
-    $ pip install pyproj rasterio Pillow geopandas netcdf4 scikit-image configobj joblib xarray boto3 progressbar2 pytest motionless dask bottleneck
+    $ pip install pyproj rasterio Pillow geopandas netcdf4 scikit-image configobj joblib xarray progressbar2 pytest motionless dask bottleneck
 
 Finally, install the salem and python-colorspace libraries::
 

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -461,18 +461,7 @@ def _aws_file_download_unlocked(aws_path, cache_name=None, reset=False):
         cache_obj_name = 'astgtmv2/' + aws_path
 
     def _dlf(cache_path):
-        import boto3
-        import botocore
-        client = boto3.client('s3')
-        logger.info("Downloading %s from s3 to %s..." % (aws_path, cache_path))
-        try:
-            client.download_file('astgtmv2', aws_path, cache_path)
-        except botocore.exceptions.ClientError as e:
-            if e.response['Error']['Code'] == "404":
-                return None
-            else:
-                raise
-        return cache_path
+        raise NotImplementedError("Downloads from AWS are no longer supported")
 
     return _verified_download_helper(cache_obj_name, _dlf, reset)
 

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,6 @@ req_packages = ['numpy',
                 'pytest',
                 'xarray',
                 'progressbar2',
-                'boto3',
                 'requests',
                 'salem']
 


### PR DESCRIPTION
It was causing a slight dependency headache, and the files it tries to download are long gone anyway.

The download function itself is still left in place, so it will continue to work if the files are in local cache for now.
Once we figured out what to do about those files, it should be replaced with a regular download function.