### PR TITLE
Use salems pyproj.transform wrapper

### DIFF
--- a/oggm/core/gis.py
+++ b/oggm/core/gis.py
@@ -11,6 +11,7 @@ from functools import partial
 from distutils.version import LooseVersion
 # External libs
 import salem
+from salem.gis import transform_proj
 import pyproj
 import numpy as np
 import shapely.ops
@@ -271,7 +272,7 @@ def define_glacier_region(gdir, entity=None):
                 "+x_0={x_0} +y_0={y_0} +datum={datum}".format(**proj_params)
     proj_in = pyproj.Proj("+init=EPSG:4326", preserve_units=True)
     proj_out = pyproj.Proj(proj4_str, preserve_units=True)
-    project = partial(pyproj.transform, proj_in, proj_out)
+    project = partial(transform_proj, proj_in, proj_out)
     # transform geometry to map
     geometry = shapely.ops.transform(project, entity['geometry'])
     geometry = multi_to_poly(geometry, gdir=gdir)

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -12,6 +12,7 @@ import pytest
 from unittest import mock
 
 import salem
+from salem.gis import transform_proj
 import numpy as np
 import pandas as pd
 import geopandas as gpd
@@ -2084,5 +2085,5 @@ class TestSkyIsFalling(unittest.TestCase):
         proj_out = pyproj.Proj("+init=EPSG:4326", preserve_units=True)
         proj_in = pyproj.Proj(srs, preserve_units=True)
 
-        lon, lat = pyproj.transform(proj_in, proj_out, -2235000, -2235000)
+        lon, lat = transform_proj(proj_in, proj_out, -2235000, -2235000)
         np.testing.assert_allclose(lon, 70.75731, atol=1e-5)


### PR DESCRIPTION
This way, salem can take care about pyproj version compatibility, at least regarding the transform function.