### PR TITLE
indices had to been treated differently

### DIFF
--- a/oggm/core/centerlines.py
+++ b/oggm/core/centerlines.py
@@ -149,7 +149,7 @@ class Centerline(object):
         for i, p in enumerate(self.flows_to.line.coords):
             if p == tofind:
                 ind.append(i)
-        assert len(ind) == 1
+        assert len(ind) == 1, 'We expect exactly one point to be found here.'
         return ind[0]
 
     @lazy_property
@@ -161,7 +161,8 @@ class Centerline(object):
             ind = [i for (i, pi) in enumerate(self.line.coords)
                    if (p.coords[0] == pi)]
             inds.append(ind[0])
-        assert len(inds) == len(self.inflow_points)
+        assert (len(inds) == len(self.inflow_points),
+                'For every inflow point should be exactly one inflow indice')
         return inds
 
     @lazy_property

--- a/oggm/core/centerlines.py
+++ b/oggm/core/centerlines.py
@@ -144,12 +144,13 @@ class Centerline(object):
     def flows_to_indice(self):
         """Indices instead of geometry"""
 
+        ind = []
         tofind = self.flows_to_point.coords[0]
         for i, p in enumerate(self.flows_to.line.coords):
             if p == tofind:
-                ind = i
-        assert ind is not None
-        return ind
+                ind.append(i)
+        assert len(ind) == 1
+        return ind[0]
 
     @lazy_property
     def inflow_indices(self):

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -2199,7 +2199,7 @@ def clean_merged_flowlines(gdir, buffer=None):
     for fl in allfls:
         try:
             fl.flows_to_indice
-        except UnboundLocalError:
+        except AssertionError:
             mfl = fl.flows_to
             # remove it from original
             mfl.inflow_points.remove(fl.flows_to_point)
@@ -2213,7 +2213,6 @@ def clean_merged_flowlines(gdir, buffer=None):
                 if prdis2 < prdis:
                     mfl_keep = mfl
                     prdis = prdis2
-                    print('does this happen?')
                 mfl = mfl.flows_to
 
             # we should be good to add this line here


### PR DESCRIPTION
always something: for some cases bed got trapezoidal. This is stored with indices rather than on the actual grid points. I did not realize that before.