### PR TITLE
Fix for numpy change in clip

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - scipy
   - pandas
   - shapely
-  - matplotlib<3.0.0
+  - matplotlib=3.0.3
   - Pillow
   - netcdf4
   - scikit-image

--- a/oggm/core/centerlines.py
+++ b/oggm/core/centerlines.py
@@ -161,8 +161,10 @@ class Centerline(object):
             ind = [i for (i, pi) in enumerate(self.line.coords)
                    if (p.coords[0] == pi)]
             inds.append(ind[0])
-        assert (len(inds) == len(self.inflow_points),
-                'For every inflow point should be exactly one inflow indice')
+        assert len(inds) == len(self.inflow_points), ('For every inflow point '
+                                                      'there should be '
+                                                      'exactly one inflow '
+                                                      'indice')
         return inds
 
     @lazy_property
@@ -1099,7 +1101,7 @@ def _parabolic_bed_from_topo(gdir, idl, interpolator):
     # We forbid super small shapes (important! This can lead to huge volumes)
     # Sometimes the parabola fits in flat areas are very good, implying very
     # flat parabolas.
-    bed_int = bed_int.clip(cfg.PARAMS['downstream_min_shape'])
+    bed_int = bed_int.clip(cfg.PARAMS['downstream_min_shape'], None)
 
     # Smoothing
     bed_ma = pd.Series(bed_int)
@@ -1790,7 +1792,7 @@ def catchment_width_correction(gdir):
 
         # Interpolate widths
         widths = utils.interp_nans(fl.widths)
-        widths = np.clip(widths, 0.1, np.max(widths))
+        widths = np.clip(widths, 0.1, None)
 
         # Get topo per catchment and per flowline point
         fhgt = fl.surface_h
@@ -1801,11 +1803,11 @@ def catchment_width_correction(gdir):
 
         # Sometimes, the centerline does not reach as high as each pix on the
         # glacier. (e.g. RGI40-11.00006)
-        catch_h = np.clip(catch_h, np.min(catch_h), maxh)
+        catch_h = np.clip(catch_h, None, maxh)
         # Same for min
         if fl.flows_to is None:
             # We clip only for main flowline (this has reasons)
-            catch_h = np.clip(catch_h, minh, np.max(catch_h))
+            catch_h = np.clip(catch_h, minh, None)
 
         # Now decide on a binsize which ensures at least N element per bin
         bsize = cfg.PARAMS['base_binsize']

--- a/oggm/core/climate.py
+++ b/oggm/core/climate.py
@@ -673,7 +673,7 @@ def mb_climate_on_height(gdir, heights, *, time_range=None, year_range=None):
     grad_temp *= (heights.repeat(len(time)).reshape(grad_temp.shape) - ref_hgt)
     temp2d = np.atleast_2d(itemp).repeat(npix, 0) + grad_temp
     temp2dformelt = temp2d - temp_melt
-    temp2dformelt = np.clip(temp2dformelt, 0, temp2dformelt.max())
+    temp2dformelt = np.clip(temp2dformelt, 0, None)
     # Compute solid precipitation from total precipitation
     prcpsol = np.atleast_2d(iprcp).repeat(npix, 0)
     fac = 1 - (temp2d - temp_all_solid) / (temp_all_liq - temp_all_solid)

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -364,7 +364,7 @@ class PastMassBalance(MassBalanceModel):
         npix = len(heights)
         temp = np.ones(npix) * itemp + igrad * (heights - self.ref_hgt)
         tempformelt = temp - self.t_melt
-        tempformelt[:] = np.clip(tempformelt, 0, tempformelt.max())
+        tempformelt[:] = np.clip(tempformelt, 0., None)
 
         # Compute solid precipitation from total precipitation
         prcp = np.ones(npix) * iprcp
@@ -399,7 +399,7 @@ class PastMassBalance(MassBalanceModel):
                       self.ref_hgt)
         temp2d = np.atleast_2d(itemp).repeat(npix, 0) + grad_temp
         temp2dformelt = temp2d - self.t_melt
-        temp2dformelt[:] = np.clip(temp2dformelt, 0, temp2dformelt.max())
+        temp2dformelt[:] = np.clip(temp2dformelt, 0, None)
 
         # Compute solid precipitation from total precipitation
         prcp = np.atleast_2d(iprcp).repeat(npix, 0)

--- a/oggm/tests/test_graphics.py
+++ b/oggm/tests/test_graphics.py
@@ -31,10 +31,12 @@ _url_retrieve = None
 def setup_module(module):
     module._url_retrieve = utils.oggm_urlretrieve
     oggm.utils._downloads.oggm_urlretrieve = patch_url_retrieve_github
+    graphics.set_oggm_cmaps(use_hcl=False)
 
 
 def teardown_module(module):
     oggm.utils._downloads.oggm_urlretrieve = module._url_retrieve
+    graphics.set_oggm_cmaps()
 
 # ----------------------------------------------------------
 # Lets go

--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -37,10 +37,12 @@ _url_retrieve = None
 def setup_module(module):
     module._url_retrieve = utils.oggm_urlretrieve
     oggm.utils._downloads.oggm_urlretrieve = patch_url_retrieve_github
+    graphics.set_oggm_cmaps(use_hcl=False)
 
 
 def teardown_module(module):
     oggm.utils._downloads.oggm_urlretrieve = module._url_retrieve
+    graphics.set_oggm_cmaps()
 
 
 def clean_dir(testdir):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
 addopts = --strict
+markers =
+    mpl_image_compare: matplotlib image comparison


### PR DESCRIPTION
This was a really hard one

Numpy changed the `clip` function internally (https://docs.scipy.org/doc/numpy/release.html#clip-now-uses-a-ufunc-under-the-hood), and now clip(-1, 0, -2) returns -2!

This was a kind of bug in OGGM, but still. I hope to have properly checked all occurrences of clip now...