### PR TITLE
Added cfg to code example to botain RGI data

### DIFF
--- a/docs/input-data.rst
+++ b/docs/input-data.rst
@@ -240,7 +240,8 @@ and type:
 
 .. code-block:: python
 
-    from oggm import utils
+    from oggm import cfg, utils
+    cfg.initialize()
     utils.get_rgi_intersects_dir()
     utils.get_rgi_dir()
 


### PR DESCRIPTION
Without initialized cfg loading the get_rgi functions don't work:
`version = cfg.PARAMS['rgi_version']` throws `KeyError: 'rgi_version'`

<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->

Closes https://github.com/OGGM/oggm/issues/###

- [ ] Tests added/passed
- [ ] Fully documented
- [ ] Entry in `whats-new.rst` 
