### PR TITLE
Add DEM source information

### DIFF
--- a/docs/input-data.rst
+++ b/docs/input-data.rst
@@ -385,6 +385,12 @@ reproduce this information
     Visit `rgitools <https://rgitools.readthedocs.io/en/latest/dems.html>`_
     for a discussion about our current efforts to find "the best" DEMs.
 
+.. note::
+
+    `In this blogpost <https://oggm.org/2019/10/08/dems/>`_ we talk about which
+    requirements a DEM must fulfill to be helpful to OGGM. And we also explain
+    why and how we preprocess certain DEMs before we make them available to the
+    OGGM workflow.
 
 Climate data
 ~~~~~~~~~~~~

--- a/oggm/data/dem_sources.txt
+++ b/oggm/data/dem_sources.txt
@@ -3,6 +3,7 @@ SRTM V4
 
 Original resolution: 3 arcsec (~90m)
 Date of acquisition: February 2000
+Date range: 2000-2000
 
 # Data Citation
 
@@ -21,6 +22,7 @@ VIEWFINDER PANORAMAS DEMs
 
 Original resolution: 3 arcsec (~90m)
 Date of acquisition: Depending on original source
+Date range: nan-nan
 
 These data are downloaded from Jonathan de Ferranti's webpage:
 http://viewfinderpanoramas.org/dem3.html
@@ -35,6 +37,7 @@ RAMP V2
 
 Original resolution: 200m
 Date of acquisition: 1940-1999 (mostly 1980s and 1990s)
+Date range: 1980-1990
 
 Downloaded by F. Maussion from http://nsidc.org/data/nsidc-0082 on 28.03.2018
 
@@ -53,6 +56,7 @@ GIMP V1.1
 
 Original resolution: 90 m
 Date of acquisition: February 2003 - October 2009
+Date range: 2003-2009
 
 Downloaded by F. Maussion from http://nsidc.org/data/nsidc-0645/ on 28.03.2018
 
@@ -80,7 +84,8 @@ Howat, I., A. Negrete, and B. Smith. 2014. The Greenland Ice Mapping Project
 ARCTICDEM V3
 
 Original resolution: 100m
-Date of acquisition: Mostly 2007-2018
+Date of acquisition: 2007-2018
+Date range: 2007-2018
 
 Downloaded by F. Maussion from http://data.pgc.umn.edu/elev/dem/setsm/ArcticDEM
 on 24.05.2019 and split into 1 degree tiles.
@@ -113,6 +118,7 @@ AW3D30 V1804
 
 Original resolution: 30m
 Date of acquisition: 2006-2011
+Date range: 2006-2011
 
 # Terms of Use for ALOS Global Digital Surface Model (AW3D30)
 
@@ -147,6 +153,7 @@ ASTGTMV3
 
 Original Resolution: 1 arc second (~30m at the equator)
 Date of acquisition: 2000 - 2013
+Date range: 2000-2013
 
 # Literature Citation
 
@@ -159,6 +166,7 @@ TanDEM-X 90m
 
 Original resolution: 90m
 Date of acquisition: December 2010 - January 2016
+Date range: 2011-2015
 
 To access TanDEM-X data self-registration is necessary. Read and follow:
 https://geoservice.dlr.de/web/dataguide/tdm90/#access
@@ -192,6 +200,7 @@ REMA V1.1
 
 Original resolution: 100m
 Date of acquisition: 2009 - 2017 (mostly 2015-2016)
+Date range: 2015-2016
 
 Downloaded by F. Maussion from http://data.pgc.umn.edu/elev/dem/setsm/REMA
 on 24.05.2019 and split into 1 degree tiles.

--- a/oggm/data/dem_sources.txt
+++ b/oggm/data/dem_sources.txt
@@ -73,19 +73,131 @@ Howat, I., A. Negrete, and B. Smith. 2014. The Greenland Ice Mapping Project
 8. 1509-1518. https://doi.org/10.5194/tc-8-1509-2014
 
 [ARCTICDEM]
-# TODO: citation missing
+ARCTICDEM V3
+
+Original resolution: 100m
+
+Downloaded by F. Maussion from http://data.pgc.umn.edu/elev/dem/setsm/ArcticDEM
+on 24.05.2019 and split into 1 degree tiles. See
+# TODO for more information.
+
+# Acknowledgements
+
+These remarks should be included in the acknowledgements section of any
+published work, presentation, poster, or document:
+
+DEMs provided by the Polar Geospatial Center under NSF-OPP awards 1043681,
+1559691, and 1542736.
+
+# Data citation
+
+As a condition of using these data, you must cite the use of this data set
+using the following citation:
+
+Porter, Claire; Morin, Paul; Howat, Ian; Noh, Myoung-Jon; Bates, Brian;
+Peterman, Kenneth; Keesey, Scott; Schlenk, Matthew; Gardiner, Judith;
+Tomko, Karen; Willis, Michael; Kelleher, Cole; Cloutier, Michael; Husby, Eric;
+Foga, Steven; Nakamura, Hitomi; Platson, Melisa; Wethington, Michael, Jr.;
+Williamson, Cathleen; Bauer, Gregory; Enos, Jeremy; Arnold, Galen;
+Kramer, William; Becker, Peter; Doshi, Abhijit; D’Souza, Cristelle;
+Cummens, Pat; Laurier, Fabien; Bojesen, Mikkel, 2018, “ArcticDEM”,
+https://doi.org/10.7910/DVN/OHHUKH, Harvard Dataverse, V1, [Date Accessed]
 
 [AW3D30]
-# TODO: citation missing
+AW3D30 V1804
+
+Original resolution: 30m
+
+# Terms of Use for ALOS Global Digital Surface Model (AW3D30)
+
+- When you provide or publish any products and services to a third party using
+this dataset, you are kindly requested to display that the original data is
+provided by JAXA.
+- When you publish the product(s) using this dataset, you are kindly requested
+to show the copyright (©JAXA) and the source of data.
+- JAXA does not guarantee the quality and reliability of this dataset and JAXA
+assume no responsibility whatsoever for any direct or indirect damage and loss
+caused by use of this dataset. Also, JAXA will not be responsible for any
+damages of users due to changing, deleting or terminating the provision of this
+dataset.
 
 [MAPZEN]
-# TODO: citation missing
+MAPZEN TERRAIN TILES
+
+Original resolution: variable
+
+A collection of DEMs from various sources hosted on Amazons Webs Service.
+https://github.com/tilezen/joerd/tree/master/docs
+
+# Attribution
+
+Attribution is required for most original data sources. Please refer to the
+Mazen attribution page for more information:
+https://github.com/tilezen/joerd/blob/master/docs/attribution.md
+
 
 [ASTER]
+ Advanced Spaceborne Thermal Emission and Reflection Radiometer (ASTER)
 # TODO: citation missing
 
 [TANDEM]
-# TODO: citation missing
+TanDEM-X 90m
+
+Original resolution: 90m
+
+To access TanDEM-X data self-registration is necessary. Read and follow:
+https://geoservice.dlr.de/web/dataguide/tdm90/#access
+Afterwards use `oggm_tdmdem90_login` to store your credentials locally.
+
+# Data rights
+
+In publications based on the TanDEM-X 90m DEM the User undertakes to clearly
+mark all data in such a way that the authorship and copyright of DLR is
+comprehensible to all: “© DLR ”. Derived information must include a reference
+to the TanDEM-X 90m DEM as data source, regardless of the form in which it was
+created.
+
+# Data citation
+
+Citation of one of the two listed papers is adequate if you use the TanDEM-X
+
+Wessel, B., Huber, M., Wohlfart, C., Marschalk, U., Kosmann, D., Roth, A.
+(2018): Accuracy Assessment of the Global TanDEM-X Digital Elevation Model with
+GPS Data., ISPRS Journal of Photogrammetry and Remote Sensing. Vol. 139, pp.
+171-182.
+
+Rizzoli, P., Martone, M., Gonzalez, C., Wecklich, C., Borla Tridon, D.,
+Bräutigam, B., Bachmann, M., Schulze, D., Fritz, T., Huber, M., Wessel, B.,
+Krieger, G., Zink, M., and Moreira, A. (2017): Generation and performance
+assessment of the global TanDEM-X digital elevation model. ISPRS Journal of
+Photogrammetry and Remote Sensing, Vol 132, pp. 119-139.
 
 [REMA]
-# TODO: citation missing
+REMA V1.1
+
+Original resolution: 100m
+
+
+Downloaded by F. Maussion from http://data.pgc.umn.edu/elev/dem/setsm/REMA
+on 24.05.2019 and split into 1 degree tiles. See
+# TODO for more information.
+
+# Acknowledgements
+
+These remarks should be included in the acknowledgements section of any
+published work, presentation, poster, or document:
+
+DEMs provided by the Byrd Polar and Climate Research Center and the Polar
+Geospatial Center under NSF-OPP awards 1543501, 1810976, 1542736, 1559691,
+1043681, 1541332, 0753663, 1548562, 1238993 and NASA award NNX10AN61G. Computer
+time provided through a Blue Waters Innovation Initiative. DEMs produced using
+data from DigitalGlobe, Inc.
+
+# Data citation
+
+As a condition of using these data, you must cite the use of this data set
+using the following citation:
+
+Howat, I. M., Porter, C., Smith, B. E., Noh, M.-J., and Morin, P.:
+The Reference Elevation Model of Antarctica, The Cryosphere, 13, 665-674,
+https://doi.org/10.5194/tc-13-665-2019, 2019.

--- a/oggm/data/dem_sources.txt
+++ b/oggm/data/dem_sources.txt
@@ -2,6 +2,7 @@
 SRTM V4
 
 Original resolution: 3 arcsec (~90m)
+Date of acquisition: February 2000
 
 # Data Citation
 
@@ -19,6 +20,7 @@ from http://srtm.csi.cgiar.org,
 VIEWFINDER PANORAMAS DEMs
 
 Original resolution: 3 arcsec (~90m)
+Date of acquisition: Depending on original source
 
 These data are downloaded from Jonathan de Ferranti's webpage:
 http://viewfinderpanoramas.org/dem3.html
@@ -32,6 +34,7 @@ above in case of doubt.
 RAMP V2
 
 Original resolution: 200m
+Date of acquisition: 1940-1999 (mostly 1980s and 1990s)
 
 Downloaded by F. Maussion from http://nsidc.org/data/nsidc-0082 on 28.03.2018
 
@@ -49,6 +52,7 @@ doi: https://doi.org/10.5067/8JKNEW6BFRVD. [28.03.2018].
 GIMP V1.1
 
 Original resolution: 90 m
+Date of acquisition: February 2003 - October 2009
 
 Downloaded by F. Maussion from http://nsidc.org/data/nsidc-0645/ on 28.03.2018
 
@@ -76,6 +80,7 @@ Howat, I., A. Negrete, and B. Smith. 2014. The Greenland Ice Mapping Project
 ARCTICDEM V3
 
 Original resolution: 100m
+Date of acquisition: Mostly 2007-2018
 
 Downloaded by F. Maussion from http://data.pgc.umn.edu/elev/dem/setsm/ArcticDEM
 on 24.05.2019 and split into 1 degree tiles.
@@ -107,6 +112,7 @@ https://doi.org/10.7910/DVN/OHHUKH, Harvard Dataverse, V1, [Date Accessed]
 AW3D30 V1804
 
 Original resolution: 30m
+Date of acquisition: 2006-2011
 
 # Terms of Use for ALOS Global Digital Surface Model (AW3D30)
 
@@ -125,6 +131,7 @@ dataset.
 MAPZEN TERRAIN TILES
 
 Original resolution: variable
+Date of acquisition: Depending on original source
 
 A collection of DEMs from various sources hosted on Amazons Webs Service.
 https://github.com/tilezen/joerd/tree/master/docs
@@ -139,6 +146,7 @@ https://github.com/tilezen/joerd/blob/master/docs/attribution.md
 ASTGTMV3
 
 Original Resolution: 1 arc second (~30m at the equator)
+Date of acquisition: 2000 - 2013
 
 # Literature Citation
 
@@ -150,6 +158,7 @@ Processes DAAC. Accessed 20xx-x-x from https://doi.org/10.5067/ASTER/ASTGTM.003
 TanDEM-X 90m
 
 Original resolution: 90m
+Date of acquisition: December 2010 - January 2016
 
 To access TanDEM-X data self-registration is necessary. Read and follow:
 https://geoservice.dlr.de/web/dataguide/tdm90/#access
@@ -182,6 +191,7 @@ Photogrammetry and Remote Sensing, Vol 132, pp. 119-139.
 REMA V1.1
 
 Original resolution: 100m
+Date of acquisition: 2009 - 2017 (mostly 2015-2016)
 
 Downloaded by F. Maussion from http://data.pgc.umn.edu/elev/dem/setsm/REMA
 on 24.05.2019 and split into 1 degree tiles.

--- a/oggm/data/dem_sources.txt
+++ b/oggm/data/dem_sources.txt
@@ -22,7 +22,6 @@ VIEWFINDER PANORAMAS DEMs
 
 Original resolution: 3 arcsec (~90m)
 Date of acquisition: Depending on original source
-Date range: nan-nan
 
 These data are downloaded from Jonathan de Ferranti's webpage:
 http://viewfinderpanoramas.org/dem3.html
@@ -138,7 +137,6 @@ MAPZEN TERRAIN TILES
 
 Original resolution: variable
 Date of acquisition: Depending on original source
-Date range: nan-nan
 
 A collection of DEMs from various sources hosted on Amazons Webs Service.
 https://github.com/tilezen/joerd/tree/master/docs

--- a/oggm/data/dem_sources.txt
+++ b/oggm/data/dem_sources.txt
@@ -78,8 +78,8 @@ ARCTICDEM V3
 Original resolution: 100m
 
 Downloaded by F. Maussion from http://data.pgc.umn.edu/elev/dem/setsm/ArcticDEM
-on 24.05.2019 and split into 1 degree tiles. See
-# TODO for more information.
+on 24.05.2019 and split into 1 degree tiles.
+See https://oggm.org/2019/10/08/dems/ for more information.
 
 # Acknowledgements
 
@@ -135,10 +135,16 @@ Attribution is required for most original data sources. Please refer to the
 Mazen attribution page for more information:
 https://github.com/tilezen/joerd/blob/master/docs/attribution.md
 
-
 [ASTER]
- Advanced Spaceborne Thermal Emission and Reflection Radiometer (ASTER)
-# TODO: citation missing
+ASTGTMV3
+
+Original Resolution: 1 arc second (~30m at the equator)
+
+# Literature Citation
+
+NASA/METI/AIST/Japan Spacesystems, and U.S./Japan ASTER Science Team (2019).
+ASTER Global Digital Elevation Model V003 [Data set]. NASA EOSDIS Land
+Processes DAAC. Accessed 20xx-x-x from https://doi.org/10.5067/ASTER/ASTGTM.003
 
 [TANDEM]
 TanDEM-X 90m
@@ -177,10 +183,9 @@ REMA V1.1
 
 Original resolution: 100m
 
-
 Downloaded by F. Maussion from http://data.pgc.umn.edu/elev/dem/setsm/REMA
-on 24.05.2019 and split into 1 degree tiles. See
-# TODO for more information.
+on 24.05.2019 and split into 1 degree tiles.
+See https://oggm.org/2019/10/08/dems/ for more information.
 
 # Acknowledgements
 

--- a/oggm/data/dem_sources.txt
+++ b/oggm/data/dem_sources.txt
@@ -165,8 +165,8 @@ Processes DAAC. Accessed 20xx-x-x from https://doi.org/10.5067/ASTER/ASTGTM.003
 TanDEM-X 90m
 
 Original resolution: 90m
-Date of acquisition: December 2010 - January 2016
-Date range: 2011-2015
+Date of acquisition: December 2010 - January 2015
+Date range: 2011-2014
 
 To access TanDEM-X data self-registration is necessary. Read and follow:
 https://geoservice.dlr.de/web/dataguide/tdm90/#access

--- a/oggm/data/dem_sources.txt
+++ b/oggm/data/dem_sources.txt
@@ -138,6 +138,7 @@ MAPZEN TERRAIN TILES
 
 Original resolution: variable
 Date of acquisition: Depending on original source
+Date range: nan-nan
 
 A collection of DEMs from various sources hosted on Amazons Webs Service.
 https://github.com/tilezen/joerd/tree/master/docs

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -345,6 +345,16 @@ class TestGIS(unittest.TestCase):
                   'RAMP', 'GIMP', 'ARCTICDEM', 'DEM3', 'REMA']:
             assert s in gis.DEM_SOURCE_INFO.keys()
 
+    def test_dem_daterange_dateinfo(self):
+        hef_file = get_demo_file('Hintereisferner_RGI5.shp')
+        entity = gpd.read_file(hef_file).iloc[0]
+        gdir = oggm.GlacierDirectory(entity, base_dir=self.testdir)
+        gis.define_glacier_region(gdir, entity=entity)
+
+        # there is no daterange/info for demo/custom data
+        self.assertIsNone(gdir.dem_daterange)
+        self.assertIsNone(gdir.dem_dateinfo)
+
     def test_custom_basename(self):
 
         hef_file = get_demo_file('Hintereisferner_RGI5.shp')

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -355,6 +355,20 @@ class TestGIS(unittest.TestCase):
         self.assertIsNone(gdir.dem_daterange)
         self.assertIsNone(gdir.dem_dateinfo)
 
+        # but we can make some
+        with open(os.path.join(gdir.dir, 'dem_source.txt'), 'a') as f:
+            f.write('Date of acquisition: February 2000\n')
+            f.write('Date range: 2000-2000')
+        # delete lazy properties
+        delattr(gdir, '_lazy_dem_daterange')
+        delattr(gdir, '_lazy_dem_dateinfo')
+
+        # now call again and check return type
+        self.assertIsInstance(gdir.dem_dateinfo, str)
+        self.assertIsInstance(gdir.dem_daterange, tuple)
+        self.assertTrue(all(isinstance(year, float)
+                            for year in gdir.dem_daterange))
+
     def test_custom_basename(self):
 
         hef_file = get_demo_file('Hintereisferner_RGI5.shp')

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -351,20 +351,19 @@ class TestGIS(unittest.TestCase):
         gdir = oggm.GlacierDirectory(entity, base_dir=self.testdir)
         gis.define_glacier_region(gdir, entity=entity)
 
-        # there is no daterange/info for demo/custom data
+        # dem_info should return a string
+        self.assertIsInstance(gdir.dem_info, str)
+
+        # there is no daterange for demo/custom data
         self.assertIsNone(gdir.dem_daterange)
-        self.assertIsNone(gdir.dem_dateinfo)
 
         # but we can make some
         with open(os.path.join(gdir.dir, 'dem_source.txt'), 'a') as f:
-            f.write('Date of acquisition: February 2000\n')
             f.write('Date range: 2000-2000')
         # delete lazy properties
         delattr(gdir, '_lazy_dem_daterange')
-        delattr(gdir, '_lazy_dem_dateinfo')
 
         # now call again and check return type
-        self.assertIsInstance(gdir.dem_dateinfo, str)
         self.assertIsInstance(gdir.dem_daterange, tuple)
         self.assertTrue(all(isinstance(year, int)
                             for year in gdir.dem_daterange))

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -366,7 +366,7 @@ class TestGIS(unittest.TestCase):
         # now call again and check return type
         self.assertIsInstance(gdir.dem_dateinfo, str)
         self.assertIsInstance(gdir.dem_daterange, tuple)
-        self.assertTrue(all(isinstance(year, float)
+        self.assertTrue(all(isinstance(year, int)
                             for year in gdir.dem_daterange))
 
     def test_custom_basename(self):

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -1714,12 +1714,14 @@ class GlacierDirectory(object):
     def dem_info(self):
         """More detailed information on the acquisition of the DEM data"""
         source_file = self.get_filepath('dem_source')
+        source_text = ''
         if os.path.isfile(source_file):
             with open(source_file, 'r') as f:
                 for line in f.readlines():
-                    print(line.strip('\n'))
+                    source_text += line
         else:
             log.warning('No DEM source file found.')
+        return source_text
 
     @property
     def rgi_area_m2(self):

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -1705,9 +1705,10 @@ class GlacierDirectory(object):
         source_txt = DEM_SOURCE_INFO.get(dem_source, dem_source)
         for line in source_txt.split('\n'):
             if 'Date range:' in line:
-                daterange = tuple(map(float, line.split(':')[1].split('-')))
-                break
-        return daterange
+                return tuple(map(float, line.split(':')[1].split('-')))
+        # we did not find the information in the dem_source file
+        log.warning('No DEM date range specified in `dem_source.txt`')
+        return None
 
     @lazy_property
     def dem_dateinfo(self):
@@ -1718,6 +1719,9 @@ class GlacierDirectory(object):
         for line in source_txt.split('\n'):
             if 'Date of acquisition:' in line:
                 return line
+        # we did not find the information in the dem_source file
+        log.warning('No DEM date information found in `dem_source.txt`')
+        return None
 
     @property
     def rgi_area_m2(self):

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -1700,12 +1700,12 @@ class GlacierDirectory(object):
     @lazy_property
     def dem_daterange(self):
         """Years in which most of the DEM data was acquired"""
-        from oggm.core.gis import DEM_SOURCE_INFO
-        dem_source = self.get_diagnostics()['dem_source']
-        source_txt = DEM_SOURCE_INFO.get(dem_source, dem_source)
-        for line in source_txt.split('\n'):
-            if 'Date range:' in line:
-                return tuple(map(float, line.split(':')[1].split('-')))
+        source_txt = self.get_filepath('dem_source')
+        if os.path.isfile(source_txt):
+            with open(source_txt, 'r') as f:
+                for line in f.readlines():
+                    if 'Date range:' in line:
+                        return tuple(map(float, line.split(':')[1].split('-')))
         # we did not find the information in the dem_source file
         log.warning('No DEM date range specified in `dem_source.txt`')
         return None
@@ -1713,12 +1713,12 @@ class GlacierDirectory(object):
     @lazy_property
     def dem_dateinfo(self):
         """More detailed information on the acquisition of the DEM data"""
-        from oggm.core.gis import DEM_SOURCE_INFO
-        dem_source = self.get_diagnostics()['dem_source']
-        source_txt = DEM_SOURCE_INFO.get(dem_source, dem_source)
-        for line in source_txt.split('\n'):
-            if 'Date of acquisition:' in line:
-                return line
+        source_txt = self.get_filepath('dem_source')
+        if os.path.isfile(source_txt):
+            with open(source_txt, 'r') as f:
+                for line in f.readlines():
+                    if 'Date of acquisition:' in line:
+                        return line
         # we did not find the information in the dem_source file
         log.warning('No DEM date information found in `dem_source.txt`')
         return None

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -1697,6 +1697,28 @@ class GlacierDirectory(object):
             raise RuntimeError('Please run `define_glacier_region` before '
                                'using this property.')
 
+    @lazy_property
+    def dem_daterange(self):
+        """Years in which most of the DEM data was acquired"""
+        from oggm.core.gis import DEM_SOURCE_INFO
+        dem_source = self.get_diagnostics()['dem_source']
+        source_txt = DEM_SOURCE_INFO.get(dem_source, dem_source)
+        for line in source_txt.split('\n'):
+            if 'Date range:' in line:
+                daterange = tuple(map(float, line.split(':')[1].split('-')))
+                break
+        return daterange
+
+    @lazy_property
+    def dem_dateinfo(self):
+        """More detailed information on the acquisition of the DEM data"""
+        from oggm.core.gis import DEM_SOURCE_INFO
+        dem_source = self.get_diagnostics()['dem_source']
+        source_txt = DEM_SOURCE_INFO.get(dem_source, dem_source)
+        for line in source_txt.split('\n'):
+            if 'Date of acquisition:' in line:
+                return line
+
     @property
     def rgi_area_m2(self):
         """The glacier's RGI area (m2)."""

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -1711,17 +1711,15 @@ class GlacierDirectory(object):
         return None
 
     @lazy_property
-    def dem_dateinfo(self):
+    def dem_info(self):
         """More detailed information on the acquisition of the DEM data"""
-        source_txt = self.get_filepath('dem_source')
-        if os.path.isfile(source_txt):
-            with open(source_txt, 'r') as f:
+        source_file = self.get_filepath('dem_source')
+        if os.path.isfile(source_file):
+            with open(source_file, 'r') as f:
                 for line in f.readlines():
-                    if 'Date of acquisition:' in line:
-                        return line
-        # we did not find the information in the dem_source file
-        log.warning('No DEM date information found in `dem_source.txt`')
-        return None
+                    print(line.strip('\n'))
+        else:
+            log.warning('No DEM source file found.')
 
     @property
     def rgi_area_m2(self):

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -1705,7 +1705,7 @@ class GlacierDirectory(object):
             with open(source_txt, 'r') as f:
                 for line in f.readlines():
                     if 'Date range:' in line:
-                        return tuple(map(float, line.split(':')[1].split('-')))
+                        return tuple(map(int, line.split(':')[1].split('-')))
         # we did not find the information in the dem_source file
         log.warning('No DEM date range specified in `dem_source.txt`')
         return None


### PR DESCRIPTION
Every GlacierDirectory gets a file `dem_source.txt` where we specify the used DEM and advise the user how to cite it in publications. There were still some DEMs missing.

Also added a "Date of acquisition" to the source text. Could be used for #850 but for most DEMs this is a quite broad range of a decade or so...