### PR TITLE
Some DEM download fixes and logging

### DIFF
--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -62,6 +62,9 @@ def _rename_dem_folder(gdir, source=''):
         f = gdir.get_filepath(fname)
         os.rename(f, os.path.join(out, os.path.basename(f)))
 
+    # log SUCCESS for this DEM source
+    gdir.log('{},DEM SOURCE,{}'.format(gdir.rgi_id, source))
+
 
 def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
                       output_folder='', working_dir='', dem_source='',

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -1458,7 +1458,7 @@ class TestFakeDownloads(unittest.TestCase):
         def down_check(url, *args, **kwargs):
             expected = ('https://cluster.klima.uni-bremen.de/~fmaussion/DEM/'
                         'REMA_100m_v1.1/'
-                        '40_10_100m_v3.1/40_10_100m_v1.1_reg_dem.tif')
+                        '40_10_100m_v1.1/40_10_100m_v1.1_reg_dem.tif')
             self.assertEqual(expected, url)
             return tf
 
@@ -1797,8 +1797,9 @@ class TestDataFiles(unittest.TestCase):
         assert utils.is_dem_source_available('ARCTICDEM', [-25, -25], [71, 71])
         assert utils.is_dem_source_available('RAMP', [-25, -25], [-71, -71])
         assert utils.is_dem_source_available('REMA', [-25, -25], [-71, -71])
+        assert not utils.is_dem_source_available('AW3D30', [5, 5], [-60, -60])
 
-        for s in ['TANDEM', 'AW3D30', 'MAPZEN', 'DEM3', 'ASTER']:
+        for s in ['TANDEM', 'AW3D30', 'MAPZEN', 'DEM3', 'ASTER', 'AW3D30']:
             assert utils.is_dem_source_available(s, [11, 11], [47, 47])
 
     def test_find_dem_zone(self):

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -58,7 +58,8 @@ import oggm.cfg as cfg
 from oggm.exceptions import (InvalidParamsError, NoInternetException,
                              DownloadVerificationFailedException,
                              DownloadCredentialsMissingException,
-                             HttpDownloadError, HttpContentTooShortError)
+                             HttpDownloadError, HttpContentTooShortError,
+                             InvalidDEMError)
 
 # Module logger
 logger = logging.getLogger('.'.join(__name__.split('.')[:-1]))
@@ -912,7 +913,14 @@ def _download_aw3d30_file_unlocked(fullzone):
     # Did we download it yet?
     ftpfile = ('ftp://ftp.eorc.jaxa.jp/pub/ALOS/ext1/AW3D30/release_v1804/'
                + fullzone + '.tar.gz')
-    dest_file = file_downloader(ftpfile, timeout=180)
+    try:
+        dest_file = file_downloader(ftpfile, timeout=180)
+    except urllib.error.URLError as err:
+        if 'No such file' in err.args[0]:
+            raise InvalidDEMError('Source: AW3D30 not available for ' +
+                                  'tile {}'.format(tile))
+        else:
+            raise err
 
     # None means we tried hard but we couldn't find it
     if not dest_file:

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -2025,7 +2025,7 @@ def get_topo_file(lon_ex, lat_ex, rgi_region=None, rgi_subregion=None,
             with _get_download_lock():
                 url = 'https://cluster.klima.uni-bremen.de/~fmaussion/'
                 url += 'DEM/REMA_100m_v1.1/'
-                url += '{}_100m_v3.1/{}_100m_v1.1_reg_dem.tif'.format(z, z)
+                url += '{}_100m_v1.1/{}_100m_v1.1_reg_dem.tif'.format(z, z)
                 files.append(file_downloader(url))
 
     if source == 'TANDEM':

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -915,12 +915,9 @@ def _download_aw3d30_file_unlocked(fullzone):
                + fullzone + '.tar.gz')
     try:
         dest_file = file_downloader(ftpfile, timeout=180)
-    except urllib.error.URLError as err:
-        if 'No such file' in err.args[0]:
-            raise InvalidDEMError('Source: AW3D30 not available for ' +
-                                  'tile {}'.format(tile))
-        else:
-            raise err
+    except urllib.error.URLError:
+        # This error is raised if file is not available, could be water
+        return None
 
     # None means we tried hard but we couldn't find it
     if not dest_file:
@@ -1859,7 +1856,7 @@ def is_dem_source_available(source, lon_ex, lat_ex):
     elif source == 'TANDEM':
         return True
     elif source == 'AW3D30':
-        return True
+        return np.min(lat_ex) > -60
     elif source == 'MAPZEN':
         return True
     elif source == 'DEM3':
@@ -2063,8 +2060,9 @@ def get_topo_file(lon_ex, lat_ex, rgi_region=None, rgi_subregion=None,
     if files:
         return files, source
     else:
-        raise RuntimeError('No topography file available for extent lat:{0},'
-                           'lon:{1}!'.format(lat_ex, lon_ex))
+        raise InvalidDEMError('Source: {2} no topography file available for '
+                              'extent lat:{0}, lon:{1}!'.
+                              format(lat_ex, lon_ex, source))
 
 
 def get_cmip5_file(filename, reset=False):


### PR DESCRIPTION
- AW3D30 raises a specific URL error if tile is not available. Catch this and return `None`. This could be an ocean tile.
- AW3D30 is really bad for Antarctica ([see map](https://www.eorc.jaxa.jp/ALOS/en/aw3d30/index.htm)) I suggest to not even try getting a DEM here and implemented this.
- There was a bug in REMA, which means nobody ever used this o_O
- Added a log-entry to the `_rename_dem_folder` function: This should allow to make nice statistics for the RGI DEM tests.