### PR TITLE
remove double slash in ASTER URL

### DIFF
--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -1524,7 +1524,7 @@ class TestFakeDownloads(unittest.TestCase):
                               fakefile='ASTGTMV003_S89W121_dem.tif')
 
         def down_check(url, *args, **kwargs):
-            expect = ('https://e4ftl01.cr.usgs.gov//ASTER_B/ASTT/ASTGTM.003/' +
+            expect = ('https://e4ftl01.cr.usgs.gov/ASTER_B/ASTT/ASTGTM.003/' +
                       '2000.03.01/ASTGTMV003_S89W121.zip')
             self.assertEqual(url, expect)
             return tf

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -832,7 +832,7 @@ def _download_aster_file_unlocked(zone):
     # extract directory
     tmpdir = cfg.PATHS['tmp_dir']
     mkdir(tmpdir)
-    wwwfile = ('https://e4ftl01.cr.usgs.gov//ASTER_B/ASTT/ASTGTM.003/'
+    wwwfile = ('https://e4ftl01.cr.usgs.gov/ASTER_B/ASTT/ASTGTM.003/'
                '2000.03.01/{}.zip'.format(zone))
     outpath = os.path.join(tmpdir, zone + '_dem.tif')
 


### PR DESCRIPTION
The ASTER download URL is given with a double slash after the domain to start the actual file path in the root directory. But this double slash is of course not present on the Bremen cluster for the download verification. The hash-key is therefor not known.

Download from NASA earthdata seems to work without the double slash as well though. So I think that is the easiest fix.

@fmaussion @TimoRoth 