### PR TITLE
Fix TanDEM-x download behavior for none-files

### DIFF
--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -361,6 +361,9 @@ def parse_args(args):
     parser.add_argument('--test', nargs='?', const=True, default=False,
                         help='if you want to do a test on a couple of '
                              'glaciers first.')
+    parser.add_argument('--test_nr', type=int, default=4,
+                        help='if --test True, specify how many glaciers to'
+                             'test.')
     parser.add_argument('--logging-level', type=str, default='WORKFLOW',
                         help='the logging level to use (DEBUG, INFO, WARNING, '
                              'WORKFLOW).')
@@ -399,7 +402,8 @@ def parse_args(args):
     # All good
     return dict(rgi_version=rgi_version, rgi_reg=rgi_reg,
                 border=border, output_folder=output_folder,
-                working_dir=working_dir, is_test=args.test,
+                working_dir=working_dir,
+                is_test=args.test, test_nr=args.test_nr,
                 demo=args.demo, dem_source=args.dem_source,
                 max_level=args.max_level, timeout=args.timeout,
                 disable_mp=args.disable_mp, logging_level=args.logging_level)

--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -65,7 +65,7 @@ def _rename_dem_folder(gdir, source=''):
 
 def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
                       output_folder='', working_dir='', dem_source='',
-                      is_test=False, demo=False, test_rgidf=None,
+                      is_test=False, test_nr=4, demo=False, test_rgidf=None,
                       test_intersects_file=None, test_topofile=None,
                       test_crudir=None, disable_mp=False, timeout=0,
                       max_level=4, logging_level='WORKFLOW'):
@@ -87,6 +87,8 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
         path to the OGGM working directory
     is_test : bool
         to test on a couple of glaciers only!
+    test_nr : int
+        if is_test = True: Amount of glaciers to test
     demo : bool
         to run the prepro for the list of demo glaciers
     test_rgidf : shapefile
@@ -174,7 +176,7 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
 
     if is_test:
         # Just for fun
-        rgidf = rgidf.sample(4)
+        rgidf = rgidf.sample(test_nr)
 
     # Sort for more efficient parallel computing
     rgidf = rgidf.sort_values('Area', ascending=False)

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -710,6 +710,10 @@ def _download_tandem_file_unlocked(zone):
     # That means we tried hard but we couldn't find it
     if not dest_file:
         return None
+    elif not zipfile.is_zipfile(dest_file):
+        # If the TanDEM-X tile does not exist, a invalid file is created.
+        # See https://github.com/OGGM/oggm/issues/893 for more details
+        return None
 
     # ok we have to extract it
     if not os.path.exists(outpath):


### PR DESCRIPTION
Closes #893 

- [x] Tests added/passed

Also added a parameter `test_nr` to `prepro_levels.run_prepro_levels`. Not related to the tandemx bug but makes testing the DEMs easier.