### PR TITLE
add rasterio_glacier_mask

### DIFF
--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -113,6 +113,11 @@ _doc = ('A geotiff file containing the DEM (reprojected into the local grid).'
         'original DEM source.')
 BASENAMES['dem'] = ('dem.tif', _doc)
 
+_doc = ('A glacier mask geotiff file with the same extend and projection as '
+        'the `dem.tif`. This geotiff has value 1 at glaciated grid points and '
+        ' value 0 at unglaciated points.')
+BASENAMES['dem_mask'] = ('dem_mask.tif', _doc)
+
 _doc = ('The glacier outlines in the local map projection (Transverse '
         'Mercator).')
 BASENAMES['outlines'] = ('outlines.shp', _doc)

--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -42,6 +42,8 @@ def _rename_dem_folder(gdir, source=''):
         # Error reading file, no problem - still, delete the file if needed
         if os.path.exists(dem_f):
             os.remove(dem_f)
+        gdir.log('{},DEM SOURCE,{}'.format(gdir.rgi_id, source),
+                 err=InvalidParamsError('File does not exist'))
         return
 
     # Check the DEM
@@ -50,6 +52,9 @@ def _rename_dem_folder(gdir, source=''):
         # Remove the file and return
         if os.path.exists(dem_f):
             os.remove(dem_f)
+        gdir.log('{},DEM SOURCE,{}'.format(gdir.rgi_id, source),
+                 err=InvalidParamsError('DEM does not contain more than one '
+                                        'valid values.'))
         return
 
     # Create a source dir and move the files
@@ -200,6 +205,10 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
             log.workflow('Running prepro on sources: {}'.format(s))
             gdirs = workflow.init_glacier_regions(rgidf, reset=rs, force=rs)
             workflow.execute_entity_task(_rename_dem_folder, gdirs, source=s)
+
+        # make a GeoTiff mask of the glacier, choose any source
+        workflow.execute_entity_task(gis.rasterio_glacier_mask,
+                                     gdirs, source='ALL')
 
         # Compress all in output directory
         l_base_dir = os.path.join(base_dir, 'L1')

--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -17,7 +17,7 @@ import geopandas as gpd
 import oggm.cfg as cfg
 from oggm import utils, workflow, tasks
 from oggm.core import gis
-from oggm.exceptions import InvalidParamsError
+from oggm.exceptions import InvalidParamsError, InvalidDEMError
 
 # Module logger
 log = logging.getLogger(__name__)
@@ -43,7 +43,7 @@ def _rename_dem_folder(gdir, source=''):
         if os.path.exists(dem_f):
             os.remove(dem_f)
         gdir.log('{},DEM SOURCE,{}'.format(gdir.rgi_id, source),
-                 err=InvalidParamsError('File does not exist'))
+                 err=InvalidDEMError('File does not exist'))
         return
 
     # Check the DEM
@@ -53,8 +53,8 @@ def _rename_dem_folder(gdir, source=''):
         if os.path.exists(dem_f):
             os.remove(dem_f)
         gdir.log('{},DEM SOURCE,{}'.format(gdir.rgi_id, source),
-                 err=InvalidParamsError('DEM does not contain more than one '
-                                        'valid values.'))
+                 err=InvalidDEMError('DEM does not contain more than one '
+                                     'valid values.'))
         return
 
     # Create a source dir and move the files

--- a/oggm/core/gis.py
+++ b/oggm/core/gis.py
@@ -962,10 +962,6 @@ def rasterio_glacier_mask(gdir, source=None):
     with rasterio.open(dempath, 'r', driver='GTiff') as ds:
         profile = ds.profile
         data = ds.read(1).astype(profile['dtype'])
-        crs = ds.crs
-        # data[data <= -999.] = np.NaN
-        # data[ds.read_masks(1) == 0] = np.NaN
-        # dsmasks = ds.read_masks(1)
 
     # Read RGI outlines
     geometry = gdir.read_shapefile('outlines').geometry[0]

--- a/oggm/core/gis.py
+++ b/oggm/core/gis.py
@@ -1003,7 +1003,7 @@ def rasterio_glacier_mask(gdir, source=None):
 
     dem_mask = gdir.get_filepath('dem_mask')
     with rasterio.open(dem_mask, 'w', **profile) as dest:
-        dest.write(out.astype(dtype), 1r
+        dest.write(out.astype(dtype), 1)
 
 
 @entity_task(log, writes=['gridded_data'])


### PR DESCRIPTION
- [x] Tests added/passed

This function will read the GDir DEM and the corresponding RGI outlines and write a `dem_mask.tif` file It has the same extent and projection as the DEM but only consists of zeros (unglaciated grid points) and ones (glaciated grid points).

It does *not* contain NaNs or other nodata values, as this mask is independent of the original source DEM.