### PR TITLE
Read the download verification hash file before multiprocessing

### DIFF
--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -459,6 +459,9 @@ def initialize(file=None, logging_level='INFO'):
                     pass
         DATA['dem_grids'] = grids
 
+    # Download verification dictionary
+    DATA['dl_verify_data'] = None
+
 
 def oggm_static_paths():
     """Initialise the OGGM paths from the config file."""

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -119,9 +119,6 @@ tuple2int = partial(np.array, dtype=np.int64)
 # Global Lock
 lock = mp.Lock()
 
-# Download verification dictionary
-_dl_verify_data = None
-
 
 def mkdir(path, reset=False):
     """Checks if directory exists and if not, create one.
@@ -190,10 +187,8 @@ def get_dl_verify_data():
     The returned dictionary resolves str: cache_obj_name
     to a tuple (int: size, bytes: sha256).
     """
-    global _dl_verify_data
-
-    if _dl_verify_data is not None:
-        return _dl_verify_data
+    if cfg.DATA['dl_verify_data'] is not None:
+        return cfg.DATA['dl_verify_data']
 
     verify_file_path = os.path.join(cfg.CACHE_DIR, 'downloads.sha256.xz')
 
@@ -246,11 +241,11 @@ def get_dl_verify_data():
                 continue
             elems = line.split(maxsplit=2)
             data[elems[2]] = (int(elems[1]), bytearray.fromhex(elems[0]))
-    _dl_verify_data = data
 
+    cfg.DATA['dl_verify_data'] = data
     logger.info('Successfully loaded verification data.')
 
-    return _dl_verify_data
+    return cfg.DATA['dl_verify_data']
 
 
 def _call_dl_func(dl_func, cache_path):

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -187,7 +187,7 @@ def get_dl_verify_data():
     The returned dictionary resolves str: cache_obj_name
     to a tuple (int: size, bytes: sha256).
     """
-    if cfg.DATA['dl_verify_data'] is not None:
+    if cfg.DATA.get('dl_verify_data') is not None:
         return cfg.DATA['dl_verify_data']
 
     verify_file_path = os.path.join(cfg.CACHE_DIR, 'downloads.sha256.xz')

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -315,6 +315,8 @@ def init_glacier_regions(rgidf=None, *, reset=False, force=False,
             log.workflow('init_glacier_regions from prepro level {} on '
                          '{} glaciers.'.format(from_prepro_level,
                                                len(entities)))
+            # Read the hash dictionary before we use multiproc
+            utils.get_dl_verify_data()
             gdirs = execute_entity_task(gdir_from_prepro, entities,
                                         from_prepro_level=from_prepro_level,
                                         prepro_border=prepro_border,
@@ -339,8 +341,11 @@ def init_glacier_regions(rgidf=None, *, reset=False, force=False,
         fp = utils.get_rgi_intersects_entities(rgi_ids, version=rgi_version)
         cfg.set_intersects_db(fp)
 
-    # If not initialized, run the task in parallel
-    execute_entity_task(tasks.define_glacier_region, new_gdirs)
+    if len(new_gdirs) > 0:
+        # Read the hash dictionary before we use multiproc
+        utils.get_dl_verify_data()
+        # If not initialized, run the task in parallel
+        execute_entity_task(tasks.define_glacier_region, new_gdirs)
 
     return gdirs
 


### PR DESCRIPTION
<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->

Reading the compressed hash takes a few seconds - you don't want to do this each time. 

This covers the most common use case, at the init_glacier_region level. cc @TimoRoth 
