### PR TITLE
Small bug in get_task_log and get_task_time

### DIFF
--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -2380,7 +2380,8 @@ class GlacierDirectory(object):
         with open(self.logfile) as logfile:
             lines = logfile.readlines()
 
-        lines = [l.replace('\n', '') for l in lines if task_name in l]
+        lines = [l.replace('\n', '') for l in lines
+                 if task_name == l.split(';')[1]]
         if lines:
             # keep only the last log
             return lines[-1].split(';')[-1]
@@ -2407,7 +2408,8 @@ class GlacierDirectory(object):
         with open(self.logfile) as logfile:
             lines = logfile.readlines()
 
-        lines = [l.replace('\n', '') for l in lines if task_name in l]
+        lines = [l.replace('\n', '') for l in lines
+                 if task_name == l.split(';')[1]]
         if lines:
             line = lines[-1]
             # Last log is message


### PR DESCRIPTION
<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->

if a task name was a subset of another (e.g. 'exp_01' and `exp_01_b`) this would lead to false search results
