### PR TITLE
Use spawn-multiprocessing

### DIFF
--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -117,7 +117,7 @@ DEM3REG = {
 tuple2int = partial(np.array, dtype=np.int64)
 
 # Global Lock
-lock = mp.Lock()
+lock = mp.get_context('spawn').Lock()
 
 
 def mkdir(path, reset=False):


### PR DESCRIPTION
This avoids issues with pyproj corrupting its database due to passing
the already opened handle to forked child processes, which then modify
it in parallel.