### PR TITLE
add Copernicus DEM

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -17,6 +17,12 @@ Breaking changes
 Enhancements
 ~~~~~~~~~~~~
 
+- Added Copernicus DEM GLO-90 as optional DEM. Requires credentials to
+  ``spacedata.copernicus.eu`` stored in a local ``.netrc`` file. Credentials
+  can be added on the command line via ``$ oggm_netrc_credentials``
+  (:pull:`961`).
+  By `Matthias Dusch <https://github.com/matthiasdusch>`_.
+
 Bug fixes
 ~~~~~~~~~
 

--- a/oggm/cli/netrc_credentials.py
+++ b/oggm/cli/netrc_credentials.py
@@ -4,26 +4,57 @@ import getpass
 import requests
 from netrc import netrc
 from subprocess import Popen
+from urllib.parse import urlparse
+import ftplib
+import socket
 
 
 def _test_credentials(authfile, key, testurl):
     """ Helper function to test the credentials
     """
-    # checking requests.head does work for some servers even with wrong
-    # credentials -> use requests.get but only for some bytes
-    header = {"Range": "bytes=0-100"}
 
-    r = requests.get(testurl, headers=header,
-                     auth=(netrc(authfile).authenticators(key)[0],
-                           netrc(authfile).authenticators(key)[2]))
-    if (r.status_code == 206) or (r.status_code == 200):
-        # code 200 is "OK", code 206 is "partial content" which is ok here
-        print("Authentication successful!")
-        return 0
+    if 'ftps' in testurl:
+        # FTP_TLS needs some extra workflow
+        try:
+            upar = urlparse(testurl)
+
+            # Decide if Implicit or Explicit FTPS
+            if upar.port == 990:
+                from oggm.utils import ImplicitFTPTLS
+                ftps = ImplicitFTPTLS()
+            elif upar.port == 21:
+                ftps = ftplib.FTP_TLS()
+
+            # establish ssl connection
+            ftps.connect(host=upar.hostname, port=upar.port, timeout=30)
+            ftps.login(user=netrc(authfile).authenticators(key)[0],
+                       passwd=netrc(authfile).authenticators(key)[2])
+            ftps.prot_p()
+            ftps.close()
+            print("Authentication successful!")
+            return 0
+        except (ftplib.error_perm, socket.timeout, socket.gaierror) as err:
+            print("Authentication for {} failed with: {1}".
+                  format(key, err))
+            ftps.close()
+            return -1
+
     else:
-        print("Authentication failed with HTML status code {}!".
-              format(r.status_code))
-        return -1
+        # checking requests.head does work for some servers even with wrong
+        # credentials -> use requests.get but only for some bytes
+        header = {"Range": "bytes=0-100"}
+
+        r = requests.get(testurl, headers=header,
+                         auth=(netrc(authfile).authenticators(key)[0],
+                               netrc(authfile).authenticators(key)[2]))
+        if (r.status_code == 206) or (r.status_code == 200):
+            # code 200 is "OK", code 206 is "partial content" which is ok here
+            print("Authentication successful!")
+            return 0
+        else:
+            print("Authentication failed with HTML status code {}!".
+                  format(r.status_code))
+            return -1
 
 
 def read_credentials(key, testurl):
@@ -92,21 +123,36 @@ def read_credentials(key, testurl):
     sys.exit(_test_credentials(authfile, key, testurl))
 
 
-def earthdata():
-    """ setup the credentials for NASA Earthdata, where we get ASTER from
+def cli():
+    """ command line interface to store different NETRC credentials
+    call via 'oggm_netrc_credentials'
     """
-    key = 'urs.earthdata.nasa.gov'
-    testurl = ('https://e4ftl01.cr.usgs.gov//ASTER_B/ASTT/ASTGTM.003/' +
-               '2000.03.01/ASTGTMV003_S09W158.zip')
+
+    print('This will store login credentials in a local .netrc file.\n'
+          'Enter the number or the service you want to add credentials for, '
+          'this might override existing credentials in the .netrc file!\n\n'
+          '[0] urs.earthdata.nasa.gov, ASTER DEM\n'
+          '[1] geoservice.dlr.de, TanDEM-X\n'
+          '[2] spacedata.copernicus.eu, Copernicus DEM Glo-90\n\n')
+    nr = input("Number: ")
+
+    if nr == '0':
+        key = 'urs.earthdata.nasa.gov'
+        testurl = ('https://e4ftl01.cr.usgs.gov//ASTER_B/ASTT/ASTGTM.003/' +
+                   '2000.03.01/ASTGTMV003_S09W158.zip')
+
+    elif nr == '1':
+        key = 'geoservice.dlr.de'
+        testurl = ("https://download.geoservice.dlr.de" +
+                   "/TDM90/files/N57/E000/TDM1_DEM__30_N57E006.zip")
+
+    elif nr == '2':
+        key = 'spacedata.copernicus.eu'
+        testurl = 'ftps://cdsdata.copernicus.eu:990'
+
+    else:
+        print('Not a valid number, aborting.')
+        sys.exit(-1)
 
     read_credentials(key, testurl)
 
-
-def tandemx():
-    """ setup the credentials for Tandem-X from DLR
-    """
-    key = 'geoservice.dlr.de'
-    testurl = ("https://download.geoservice.dlr.de" +
-               "/TDM90/files/N57/E000/TDM1_DEM__30_N57E006.zip")
-
-    read_credentials(key, testurl)

--- a/oggm/cli/netrc_credentials.py
+++ b/oggm/cli/netrc_credentials.py
@@ -13,7 +13,7 @@ def _test_credentials(authfile, key, testurl):
     """ Helper function to test the credentials
     """
 
-    if 'ftps' in testurl:
+    if 'ftps://' in testurl:
         # FTP_TLS needs some extra workflow
         try:
             upar = urlparse(testurl)

--- a/oggm/cli/netrc_credentials.py
+++ b/oggm/cli/netrc_credentials.py
@@ -155,4 +155,3 @@ def cli():
         sys.exit(-1)
 
     read_credentials(key, testurl)
-

--- a/oggm/data/dem_sources.txt
+++ b/oggm/data/dem_sources.txt
@@ -250,3 +250,18 @@ using the following citation:
  deriving glacier centerlines applied to glaciers in Alaska and northwest
  Canada, The Cryosphere, 8, 503–519, https://doi.org/10.5194/tc-8-503-2014,
  2014.
+
+[COPDEM]
+Copernicus DEM GLO-90
+
+Original resolution: 3 arc seconds (~90m)
+Date of acquisition: 2010-2015
+Date range: 2010-2015
+
+# Credit
+Any usage or publication must include the following statement:
+“Includes material ©CCME (year of acquisition ), provided under COPERNICUS by
+the European Union and ESA, all rights reserved”.
+
+Please also read and agree to the full ESA user license:
+https://spacedata.copernicus.eu/documents/12833/14545/CSCDA_ESA_User_Licence

--- a/oggm/exceptions.py
+++ b/oggm/exceptions.py
@@ -39,5 +39,10 @@ class HttpDownloadError(Exception):
         self.url = url
 
 
+class FTPSDownloadError(Exception):
+    def __init__(self, orgerr):
+        self.orgerr = orgerr
+
+
 class HttpContentTooShortError(Exception):
     pass

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -21,6 +21,8 @@ from urllib.parse import urlparse
 import socket
 import multiprocessing
 from netrc import netrc
+import ftplib
+import ssl
 
 # External libs
 import pandas as pd
@@ -89,7 +91,7 @@ WEB_N_PIX = 256
 WEB_EARTH_RADUIS = 6378137.
 
 DEM_SOURCES = ['GIMP', 'ARCTICDEM', 'RAMP', 'TANDEM', 'AW3D30', 'MAPZEN',
-               'DEM3', 'ASTER', 'SRTM', 'REMA', 'ALASKA']
+               'DEM3', 'ASTER', 'SRTM', 'REMA', 'ALASKA', 'COPDEM']
 
 _RGI_METADATA = dict()
 
@@ -410,6 +412,76 @@ def _classic_urlretrieve(url, path, reporthook, auth=None, timeout=None):
         socket.setdefaulttimeout(old_def_timeout)
 
 
+class _ImplicitFTPTLS(ftplib.FTP_TLS):
+    """ FTP_TLS subclass that automatically wraps sockets in SSL to support
+        implicit FTPS.
+
+        Taken from https://stackoverflow.com/a/36049814
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._sock = None
+
+    @property
+    def sock(self):
+        """Return the socket."""
+        return self._sock
+
+    @sock.setter
+    def sock(self, value):
+        """When modifying the socket, ensure that it is ssl wrapped."""
+        if value is not None and not isinstance(value, ssl.SSLSocket):
+            value = self.context.wrap_socket(value)
+        self._sock = value
+
+
+def _ftps_retrieve(url, path, reporthook, auth=None, timeout=None):
+    """ Wrapper around ftplib to download from FTPS server
+    """
+
+    if not auth:
+        raise DownloadCredentialsMissingException('No auth no ssl... duh!')
+
+    upar = urlparse(url)
+
+    # Decide if Implicit or Explicit FTPS is used based on the port in url
+    if upar.port == 990:
+        ftps = _ImplicitFTPTLS()
+    elif upar.port == 21:
+        ftps = ftplib.FTP_TLS()
+
+    old_def_timeout = socket.getdefaulttimeout()
+
+    try:
+        # establish ssl connection
+        ftps.connect(host=upar.hostname, port=upar.port, timeout=timeout)
+        ftps.login(user=auth[0], passwd=auth[1])
+        ftps.prot_p()
+
+        logger.info('Established connection %s' % upar.hostname)
+
+        # meta for progress bar size
+        count = 0
+        total = ftps.size(upar.path)
+        bs = 12*1024
+
+        def _ftps_progress(data):
+            outfile.write(data)
+            nonlocal count
+            count += 1
+            reporthook(count, count*bs, total)
+
+        with open(path, 'wb') as outfile:
+            ftps.retrbinary('RETR ' + upar.path, _ftps_progress, blocksize=bs)
+
+    except BaseException as e:
+        raise HttpDownloadError(e.code, url)
+    finally:
+        ftps.close()
+        socket.setdefaulttimeout(old_def_timeout)
+
+
 def _get_url_cache_name(url):
     """Returns the cache name for any given url.
     """
@@ -436,7 +508,11 @@ def oggm_urlretrieve(url, cache_obj_name=None, reset=False,
         try:
             _requests_urlretrieve(url, cache_path, reporthook, auth, timeout)
         except requests.exceptions.InvalidSchema:
-            _classic_urlretrieve(url, cache_path, reporthook, auth, timeout)
+            if 'ftps://' in url:
+                _ftps_retrieve(url, cache_path, reporthook, auth, timeout)
+            else:
+                _classic_urlretrieve(url, cache_path, reporthook, auth,
+                                     timeout)
         return cache_path
 
     return _verified_download_helper(cache_obj_name, _dlf, reset)
@@ -594,7 +670,7 @@ def download_with_authentification(wwwfile, key):
     # Attempt to download without credentials first to hit the cache
     try:
         dest_file = file_downloader(wwwfile)
-    except HttpDownloadError:
+    except (HttpDownloadError, DownloadCredentialsMissingException):
         dest_file = None
 
     # Grab auth parameters
@@ -906,6 +982,52 @@ def _download_topo_file_from_cluster_unlocked(fname):
     return outpath
 
 
+def _download_copdem_file(zone):
+    with _get_download_lock():
+        return _download_copdem_file_unlocked(zone)
+
+
+def _download_copdem_file_unlocked(zone):
+    """Checks if Copernicus DEM file is in the directory, if not download it.
+    """
+
+    # extract directory
+    tmpdir = cfg.PATHS['tmp_dir']
+    mkdir(tmpdir)
+
+    # tarfiles are extracted in directories per each tile
+    # tile = zone.split('/')[1]
+    fpath = 'Copernicus_DSM_30_N46_00_E010_00/DEM/Copernicus_DSM_30_N46_00_E010_00_DEM.tif'
+    demfile = os.path.join(tmpdir, fpath)
+
+    # check if extracted file exists already
+    if os.path.exists(demfile):
+        return demfile
+
+    # Did we download it yet?
+    ftpfile = ('ftps://cdsdata.copernicus.eu:990/datasets/COP-DEM_GLO-90-DGED/2019_1/' +
+               zone)
+
+    dest_file = download_with_authentification(ftpfile, 'copernicus.eu')
+
+    # None means we tried hard but we couldn't find it
+    if not dest_file:
+        return None
+
+    # ok we have to extract it
+    if not os.path.exists(demfile):
+        from oggm.utils import robust_tar_extract
+        dempath = os.path.dirname(demfile)
+        robust_tar_extract(dest_file, dempath)
+
+    # See if we're good, don't overfill the tmp directory
+    assert os.path.exists(demfile)
+    # this tarfile contains several files
+    for file in os.listdir(dempath):
+        cfg.get_lru_handler(tmpdir).append(os.path.join(dempath, file))
+    return demfile
+
+
 def _download_aw3d30_file(zone):
     with _get_download_lock():
         return _download_aw3d30_file_unlocked(zone)
@@ -1172,6 +1294,13 @@ def rema_zone(lon_ex, lat_ex):
     p = _extent_to_polygon(lon_ex, lat_ex, to_crs=gdf.crs)
     gdf = gdf.loc[gdf.intersects(p)]
     return gdf.tile.values if len(gdf) > 0 else []
+
+
+def copdem_zone(lon_ex, lat_ex):
+    """Returns a list of Copernicus DEM tiles covering the desired extent.
+    """
+
+    return ['DEM1_SAR_DGE_90_20110517T170701_20140817T170857_ADS_000000_4723.DEM.tar']
 
 
 def dem3_viewpano_zone(lon_ex, lat_ex):
@@ -1888,6 +2017,8 @@ def is_dem_source_available(source, lon_ex, lat_ex):
         return True
     elif source == 'SRTM':
         return np.max(np.abs(lat_ex)) < 60
+    elif source == 'COPDEM':
+        return True
     elif source == 'USER':
         return True
     elif source is None:
@@ -1987,7 +2118,7 @@ def get_topo_file(lon_ex, lat_ex, rgi_region=None, rgi_subregion=None,
           - 'AW3D30' : https://www.eorc.jaxa.jp/ALOS/en/aw3d30
           - 'MAPZEN' : https://registry.opendata.aws/terrain-tiles/
           - 'ALASKA' : https://www.the-cryosphere.net/8/503/2014/
-
+          - 'COPDEM' : Copernicus DEM GLO-90 https://bit.ly/2T98qqs
     Returns
     -------
     tuple: (list with path(s) to the DEM file(s), data source str)
@@ -2084,6 +2215,11 @@ def get_topo_file(lon_ex, lat_ex, rgi_region=None, rgi_subregion=None,
         zones = srtm_zone(lon_ex, lat_ex)
         for z in zones:
             files.append(_download_srtm_file(z))
+
+    if source == 'COPDEM':
+        zones = copdem_zone(lon_ex, lat_ex)
+        for z in zones:
+            files.append(_download_copdem_file(z))
 
     # filter for None (e.g. oceans)
     files = [s for s in files if s]

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -1313,8 +1313,6 @@ def copdem_zone(lon_ex, lat_ex):
 
     # path to the lookup shapefiles
     gdf = gpd.read_file(get_demo_file('RGI60_COPDEM_lookup.shp'))
-    #look = '/home/matthias/rgi/copernicus/lookup/RGI60_COPDEM_lookup.shp'
-    #gdf = gpd.read_file(look)
 
     # intersect with lat lon extents
     p = _extent_to_polygon(lon_ex, lat_ex, to_crs=gdf.crs)

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -2146,6 +2146,7 @@ def get_topo_file(lon_ex, lat_ex, rgi_region=None, rgi_subregion=None,
           - 'MAPZEN' : https://registry.opendata.aws/terrain-tiles/
           - 'ALASKA' : https://www.the-cryosphere.net/8/503/2014/
           - 'COPDEM' : Copernicus DEM GLO-90 https://bit.ly/2T98qqs
+
     Returns
     -------
     tuple: (list with path(s) to the DEM file(s), data source str)

--- a/setup.py
+++ b/setup.py
@@ -87,8 +87,7 @@ setup(
         'console_scripts': [
             'oggm_prepro = oggm.cli.prepro_levels:main',
             'oggm_benchmark = oggm.cli.benchmark:main',
-            'oggm_tdmdem90_login = oggm.cli.netrc_credentials:tandemx',
-            'oggm_nasa_earthdata_login = oggm.cli.netrc_credentials:earthdata',
+            'oggm_netrc_credentials = oggm.cli.netrc_credentials:cli',
         ],
     },
 )


### PR DESCRIPTION
Closes https://github.com/GLIMS-RGI/rgitools/issues/35
work in progress, right now my account is locked for entering a wrong password.

unfortunately this will increase the complexity of the download module even more. Copernicus not only uses FTP**S** for their data, they use the apparently deprecated *implicit* FTPS...

Also they don't name their files in a meaningful way so this will need a lookup table of some sorts.

And the download is rather slow. Not the actual download but something along the way, SSL handshake or such...

- [x] Tests added/passed
- [x] Fully documented
- [x] Entry in `whats-new.rst` 
- [x] update `SAMPLE_DATA_COMMIT` if lookup table ends up there

