### PR TITLE
avoid init_glacier_regions in prepro_levels

### DIFF
--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -183,25 +183,6 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
         # Just for fun
         rgidf = rgidf.sample(test_nr)
 
-    myglcs = ['RGI60-11.00897',
-              'RGI60-11.01827',
-              'RGI60-01.10689',
-              'RGI60-06.00477',
-              'RGI60-05.10137',
-              'RGI60-03.02489',
-              'RGI60-16.02207',
-              'RGI60-19.02274',
-              'RGI60-19.00124',
-              'RGI60-19.01251',
-              'RGI60-03.00251',
-              'RGI60-15.02578',
-              'RGI60-07.01114',
-              'RGI60-08.01126',
-              'RGI60-18.00854',
-              'RGI60-09.00552']
-
-    rgidf = rgidf.loc[rgidf.RGIId.isin(myglcs)]
-
     # Sort for more efficient parallel computing
     rgidf = rgidf.sort_values('Area', ascending=False)
 

--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -203,7 +203,6 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
             rs = i == 0
             rgidf['DEM_SOURCE'] = s
             log.workflow('Running prepro on sources: {}'.format(s))
-            #gdirs = workflow.init_glacier_regions(rgidf, reset=rs, force=rs)
             gdirs = []
             for_task = []
             for _, entity in rgidf.iterrows():

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -26,7 +26,7 @@ from oggm import cfg
 from oggm.tests.funcs import (get_test_dir, patch_url_retrieve_github,
                               init_hef, TempEnvironmentVariable)
 from oggm.utils import shape_factor_adhikari
-from oggm.exceptions import (InvalidParamsError,
+from oggm.exceptions import (InvalidParamsError, InvalidDEMError,
                              DownloadVerificationFailedException)
 
 
@@ -1927,8 +1927,9 @@ class TestDataFiles(unittest.TestCase):
         self.assertTrue('Copernicus_DSM_30_N46_00_E007_00' in
                         [z[0][1], z[1][1]])
 
-        z = utils.copdem_zone(lat_ex=[0, 1], lon_ex=[0, 1])
-        self.assertTrue(len(z) == 0)
+        # we want an error if copdem does not find all or any
+        self.assertRaises(InvalidDEMError, utils.copdem_zone,
+                          lat_ex=[0, 1], lon_ex=[0, 1])
 
     def test_is_dem_source_available(self):
         assert utils.is_dem_source_available('SRTM', [11, 11], [47, 47])

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -29,6 +29,7 @@ import tarfile
 import pandas as pd
 import numpy as np
 from shapely.ops import transform as shp_trafo
+from shapely.ops import unary_union
 import shapely.geometry as shpg
 import requests
 
@@ -1317,6 +1318,13 @@ def copdem_zone(lon_ex, lat_ex):
     # intersect with lat lon extents
     p = _extent_to_polygon(lon_ex, lat_ex, to_crs=gdf.crs)
     gdf = gdf.loc[gdf.intersects(p)]
+
+    # COPDEM is global, if we miss any tile it is worth an error
+    if (len(gdf) == 0) or (not unary_union(gdf.geometry).contains(p)):
+        raise InvalidDEMError('Could not find all necessary Copernicus DEM '
+                              'tiles. This should not happen in a global DEM. '
+                              'Check the RGI-CopernicusDEM lookup shapefile '
+                              'for this particular glacier!')
 
     flist = []
     for _, g in gdf.iterrows():


### PR DESCRIPTION
only for the task where dem_source=='ALL'. The call to create the *true* prepro-directories with only one call to init_glacier_regions should still work.

Closes #964 

also small unrelated edit to the COPDEM zone: COPDEM is a global DEM. If a tile can not be found or a glacier is only partially covered this should raise a proper error: It's more likely for the lookup table to be wrong in that case than the DEM having a gap.