### PR TITLE
Remove port from cache name

### DIFF
--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -487,7 +487,7 @@ def _get_url_cache_name(url):
     """
 
     res = urlparse(url)
-    return res.netloc + res.path
+    return res.netloc.split(':', 1)[0] + res.path
 
 
 def oggm_urlretrieve(url, cache_obj_name=None, reset=False,


### PR DESCRIPTION
Having a `:` in file/dir names is a bad idea. It can cause a real headache on Windows, creating undeletable untouchable files that are still there.
There is very little reason to have the port in the cache name. It is highly unlikely hostname + path is not unique enough.