### PR TITLE
avoid downloads without credentials

### DIFF
--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -1504,7 +1504,7 @@ class TestFakeDownloads(unittest.TestCase):
             self.assertEqual(expected, url)
             return tf
 
-        with FakeDownloadManager('_progress_urlretrieve', down_check):
+        with FakeDownloadManager('download_with_authentication', down_check):
             of, source = utils.get_topo_file([10.5, 10.8], [46.6, 46.8],
                                              source='COPDEM')
 
@@ -1626,7 +1626,7 @@ class TestFakeDownloads(unittest.TestCase):
             self.assertEqual(url, expect)
             return tf
 
-        with FakeDownloadManager('_progress_urlretrieve', down_check):
+        with FakeDownloadManager('download_with_authentication', down_check):
             of, source = utils.get_topo_file([-120.2, -120.2], [-88.1, -88.9],
                                              source='ASTER')
 
@@ -1644,7 +1644,7 @@ class TestFakeDownloads(unittest.TestCase):
             self.assertEqual(url, expect)
             return tf
 
-        with FakeDownloadManager('_progress_urlretrieve', down_check):
+        with FakeDownloadManager('download_with_authentication', down_check):
             of, source = utils.get_topo_file([-145.2, -145.3], [60.1, 60.9],
                                              source='TANDEM')
 
@@ -1678,7 +1678,7 @@ class TestFakeDownloads(unittest.TestCase):
 
             return file
 
-        with FakeDownloadManager('_progress_urlretrieve', down_check):
+        with FakeDownloadManager('download_with_authentication', down_check):
             of, source = utils.get_topo_file([-144.1, -143.9], [60.5, 60.6],
                                              source='TANDEM')
 

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -2124,19 +2124,6 @@ class TestDataFiles(unittest.TestCase):
 
     @pytest.mark.download
     @pytest.mark.creds
-    def test_tandemdownload_cache(self):
-        from oggm.utils._downloads import download_with_authentification
-
-        # this zone does exist but without credentials this should just check
-        # the cache and return None if it does not exist
-        zone = 'N47/E010/TDM1_DEM__30_N47E011'
-        wwwfile = ('https://download.geoservice.dlr.de/TDM90/files/'
-                   '{}.zip'.format(zone))
-
-        dest_file = download_with_authentification(wwwfile, 'geoservice.dlr.de')
-
-    @pytest.mark.download
-    @pytest.mark.creds
     def test_tandemdownloadfails(self):
         from oggm.utils._downloads import _download_tandem_file
 

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -2124,6 +2124,29 @@ class TestDataFiles(unittest.TestCase):
 
     @pytest.mark.download
     @pytest.mark.creds
+    def test_tandemdownload_cache(self):
+        from oggm.utils._downloads import download_with_authentification
+
+        # this zone does exist but without credentials this should just check
+        # the cache and return None if it does not exist
+        zone = 'N47/E010/TDM1_DEM__30_N47E011'
+        wwwfile = ('https://download.geoservice.dlr.de/TDM90/files/'
+                   '{}.zip'.format(zone))
+
+        dest_file = download_with_authentification(wwwfile, 'geoservice.dlr.de')
+
+    @pytest.mark.download
+    @pytest.mark.creds
+    def test_tandemdownloadfails(self):
+        from oggm.utils._downloads import _download_tandem_file
+
+        # this zone does not exist, so it should return None
+        zone = 'N47/E010/TDM1_DEM__30_NxxExxx'
+        fp = _download_tandem_file(zone)
+        self.assertIsNone(fp)
+
+    @pytest.mark.download
+    @pytest.mark.creds
     def test_copdemdownload(self):
         from oggm.utils._downloads import _download_copdem_file
 

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -657,7 +657,7 @@ def file_downloader(www_path, retry_max=5, cache_name=None,
     return local_path
 
 
-def download_with_authentification(wwwfile, key):
+def download_with_authentication(wwwfile, key):
     """ Uses credentials from a local .netrc file to download files
 
     This is function is currently used for TanDEM-X and ASTER
@@ -841,7 +841,7 @@ def _download_tandem_file_unlocked(zone):
     if os.path.exists(outpath):
         return outpath
 
-    dest_file = download_with_authentification(wwwfile, 'geoservice.dlr.de')
+    dest_file = download_with_authentication(wwwfile, 'geoservice.dlr.de')
 
     # That means we tried hard but we couldn't find it
     if not dest_file:
@@ -981,8 +981,7 @@ def _download_aster_file_unlocked(zone):
         return outpath
 
     # download from NASA Earthdata with credentials
-    dest_file = download_with_authentification(wwwfile,
-                                               'urs.earthdata.nasa.gov')
+    dest_file = download_with_authentication(wwwfile, 'urs.earthdata.nasa.gov')
 
     # That means we tried hard but we couldn't find it
     if not dest_file:
@@ -1059,8 +1058,8 @@ def _download_copdem_file_unlocked(cppfile, tilename):
                'datasets/COP-DEM_GLO-90-DGED/2019_1/' +
                cppfile)
 
-    dest_file = download_with_authentification(ftpfile,
-                                               'spacedata.copernicus.eu')
+    dest_file = download_with_authentication(ftpfile,
+                                             'spacedata.copernicus.eu')
 
     # None means we tried hard but we couldn't find it
     if not dest_file:

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -673,11 +673,14 @@ def download_with_authentification(wwwfile, key):
     -------
 
     """
-    # Attempt to download without credentials first to hit the cache
-    try:
-        dest_file = file_downloader(wwwfile)
-    except (HttpDownloadError, DownloadCredentialsMissingException):
-        dest_file = None
+    # Check the cache first. Use dummy download function to assure nothing is
+    # tried to be downloaded without credentials:
+
+    def _always_none(foo):
+        return None
+
+    cache_obj_name = _get_url_cache_name(wwwfile)
+    dest_file = _verified_download_helper(cache_obj_name, _always_none)
 
     # Grab auth parameters
     if not dest_file:


### PR DESCRIPTION
the DLR server had this annoying habit to return a small/broken file to the OGGM download function even if it did not exist. See #893  
But *I think* until now this only happened if authentication credentials were provided.

Now this also happens to existing files if the download function is called without credentials which we did to check the cache first. So all files not in the cache just returned broken.

Fixed this by not calling the entire file downloader but only parts of it. This should check the cache and verify the file with the hash. But it avoids trying to establish a connection without the credentials by using a dummy function.

Maybe @TimoRoth can have a look if I missed something. 

I'll add 1-2 tests before merging