### PR TITLE
increase LRU file handler size

### DIFF
--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -371,8 +371,8 @@ def initialize_minimal(file=None, logging_level='INFO'):
         log.workflow('Size of LRU cache set to {} '.format(lru_maxsize) +
                      'according to the ENV variable LRU_MAXSIZE')
     except KeyError:
-        lru_maxsize = cp.as_int('LRU_maxsize')
-    PARAMS['LRU_maxsize'] = lru_maxsize
+        lru_maxsize = cp.as_int('lru_maxsize')
+    PARAMS['lru_maxsize'] = lru_maxsize
 
     # Some non-trivial params
     PARAMS['continue_on_error'] = cp.as_bool('continue_on_error')

--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -59,7 +59,7 @@ mpi_recv_buf_size = 131072
 dl_verify = True
 
 # Default number of files to be cached in the temporary directory
-LRU_maxsize = 100
+lru_maxsize = 100
 
 ### CENTERLINE determination
 

--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -58,6 +58,9 @@ mpi_recv_buf_size = 131072
 # Check for the integrity of the files OGGM downloads at run time
 dl_verify = True
 
+# Default number of files to be cached in the temporary directory
+LRU_maxsize = 100
+
 ### CENTERLINE determination
 
 # Decision on grid spatial resolution for each glacier

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -9,6 +9,7 @@ import gzip
 import bz2
 import hashlib
 import pytest
+import itertools
 from unittest import mock
 
 import numpy as np
@@ -2052,25 +2053,39 @@ class TestDataFiles(unittest.TestCase):
 
     def test_lruhandler(self):
 
+        # initiate some files in empty directory
         self.reset_dir()
-        f1 = os.path.join(self.dldir, 'f1.txt')
-        f2 = os.path.join(self.dldir, 'f2.txt')
-        f3 = os.path.join(self.dldir, 'f3.txt')
-        open(f1, 'a').close()
-        time.sleep(0.1)
-        open(f2, 'a').close()
-        time.sleep(0.1)
-        open(f3, 'a').close()
+        foo = []
+        bar = []
+        for i, e in itertools.product(range(1, 4), ['foo', 'bar']):
+            f = os.path.join(self.dldir, 'f{}.{}'.format(i, e))
+            open(f, 'a').close()
+            (foo.append(f) if e == 'foo' else bar.append(f))
+            time.sleep(0.1)
 
-        cfg.get_lru_handler(self.dldir, maxsize=3, ending='.txt')
-        assert os.path.exists(f1)
-        assert os.path.exists(f2)
-        assert os.path.exists(f3)
+        # init handler for dldir and ending 'foo'
+        lru_foo = cfg.get_lru_handler(self.dldir, ending='.foo')
+        # no maxsize specified: use default
+        self.assertTrue(lru_foo.maxsize == cfg.PARAMS['LRU_maxsize'])
+        # all files should exist
+        self.assertTrue(all([os.path.exists(f) for f in foo]))
 
-        cfg.get_lru_handler(self.dldir, maxsize=2, ending='.txt')
-        assert not os.path.exists(f1)
-        assert os.path.exists(f2)
-        assert os.path.exists(f3)
+        # init handler for dldir and ending bar
+        cfg.get_lru_handler(self.dldir, maxsize=3, ending='.bar')
+        # all files should exist
+        self.assertTrue(all([os.path.exists(b) for b in bar]))
+
+        # update foo handler, decresing maxsize should delete first file
+        lru_foo2 = cfg.get_lru_handler(self.dldir, maxsize=2, ending='.foo')
+        self.assertFalse(os.path.exists(foo[0]))
+        self.assertTrue(os.path.exists(foo[1]))
+        self.assertTrue(os.path.exists(foo[2]))
+        # but this should be the same handler instance as above:
+        self.assertTrue(lru_foo is lru_foo2)
+        self.assertTrue(lru_foo.maxsize == 2)
+
+        # And bar files should not be affected by decreased cache size of foo
+        self.assertTrue(all([os.path.exists(b) for b in bar]))
 
     @pytest.mark.download
     def test_srtmdownload(self):

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -2066,7 +2066,7 @@ class TestDataFiles(unittest.TestCase):
         # init handler for dldir and ending 'foo'
         lru_foo = cfg.get_lru_handler(self.dldir, ending='.foo')
         # no maxsize specified: use default
-        self.assertTrue(lru_foo.maxsize == cfg.PARAMS['LRU_maxsize'])
+        self.assertTrue(lru_foo.maxsize == cfg.PARAMS['lru_maxsize'])
         # all files should exist
         self.assertTrue(all([os.path.exists(f) for f in foo]))
 

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -1076,7 +1076,7 @@ def _download_copdem_file_unlocked(cppfile, tilename):
 
     # See if we're good, don't overfill the tmp directory
     assert os.path.exists(demfile)
-    cfg.get_lru_handler(tmpdir).append(demfile)
+    cfg.get_lru_handler(tmpdir, maxsize=1000).append(demfile)
 
     return demfile
 

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -1076,7 +1076,7 @@ def _download_copdem_file_unlocked(cppfile, tilename):
 
     # See if we're good, don't overfill the tmp directory
     assert os.path.exists(demfile)
-    cfg.get_lru_handler(tmpdir, maxsize=1000).append(demfile)
+    cfg.get_lru_handler(tmpdir).append(demfile)
 
     return demfile
 

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -228,7 +228,7 @@ class LRUFileCache():
     The files which are no longer used are deleted from the disk.
     """
 
-    def __init__(self, l0=None, maxsize=100):
+    def __init__(self, l0=None, maxsize=None):
         """Instanciate.
 
         Parameters
@@ -239,6 +239,8 @@ class LRUFileCache():
             the max number of files to keep
         """
         self.files = [] if l0 is None else l0
+        # if no maxsize is specified, use value from configuration
+        maxsize = cfg.PARAMS['LRU_maxsize'] if maxsize is None else maxsize
         self.maxsize = maxsize
         self.purge()
 

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -240,7 +240,7 @@ class LRUFileCache():
         """
         self.files = [] if l0 is None else l0
         # if no maxsize is specified, use value from configuration
-        maxsize = cfg.PARAMS['LRU_maxsize'] if maxsize is None else maxsize
+        maxsize = cfg.PARAMS['lru_maxsize'] if maxsize is None else maxsize
         self.maxsize = maxsize
         self.purge()
 


### PR DESCRIPTION
I noticed some of the DEM runs to fail because they couldn't find/read the downloaded and unpacked .tif file. e.g.:
`RasterioIOError occurred during task define_glacier_region on RGI60-07.00608: /work/mdusch/91650/oggm_tmp/tmp/Copernicus_DSM_30_N79_00_E023_00_DEM.tif: No such file or directory`

This happens only for DEMs with smaller tiles (like the 1x1 degree of Copernicus and TanDEM-X) and probably only on a cluster where there multiple glaciers processed at the same time: Unpacked tiles in the temp directory will be deleted by the file handler before they could actually be used by the define_glacier task...

So far I just checked what happens if I increase the maxsize within the Copernicus download function. And it works/runs without the above error.

But what's the best solution? 
i) Introduce a cfg.PARAMS variable 
ii) Increase the maxsize for the DEM sources where this might happen?
iii) ?

Happy to get some feedback by @TimoRoth and @fmaussion 
Otherwise I will implement variant i) 
