### PR TITLE
Optimize hash verify file IO

### DIFF
--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -1202,7 +1202,8 @@ class TestFakeDownloads(unittest.TestCase):
         file_sha256 = file_sha256.digest()
 
         data = utils.get_dl_verify_data()
-        data['test.com/test.txt'] = (file_size, file_sha256)
+        data.loc['test.com/test.txt', 'size'] = file_size
+        data.loc['test.com/test.txt', 'sha256'] = file_sha256.hex()
 
         return 'https://test.com/test.txt'
 


### PR DESCRIPTION
<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->

On my machine, reading the downloads.sha256.xz into a dict takes about 11-12 seconds. Since we are now reading the hash file in init_glacier_regions (i.e. to avoid a read per process), this is just too long because the simplest test script will read it as well. 

This is a quick hack to store the data in an intermediate binary file the first time it is read. This means that the first call on a new machine will trigger the download of the file and the creation of the intermediate file (ie slilghtly longer than the 12 secs mentioned above), but < 2 secs on all subsequent ones. 

This is already better than what we have, but I still think that the proper solution would be to not have to read the data unless we really want to download something, and this requires communication between processes. I might give a go at th e Manager object this week-end...

- [ ] Tests added/passed
- [ ] Fully documented
- [ ] Entry in `whats-new.rst` 
