### PR TITLE
Update download paths to ~oggm

### DIFF
--- a/oggm/tests/funcs.py
+++ b/oggm/tests/funcs.py
@@ -239,8 +239,8 @@ def patch_url_retrieve_github(url, *args, **kwargs):
     download elsewhere than expected."""
 
     assert ('github' in url or
-            'cluster.klima.uni-bremen.de/~fmaussion/test_gdirs/' in url or
-            'cluster.klima.uni-bremen.de/~fmaussion/demo_gdirs/' in url)
+            'cluster.klima.uni-bremen.de/~oggm/test_gdirs/' in url or
+            'cluster.klima.uni-bremen.de/~oggm/demo_gdirs/' in url)
     return oggm_urlretrieve(url, *args, **kwargs)
 
 

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -34,7 +34,7 @@ from oggm.exceptions import (InvalidParamsError, InvalidDEMError,
 pytestmark = pytest.mark.test_env("utils")
 _url_retrieve = None
 
-TEST_GDIR_URL = ('https://cluster.klima.uni-bremen.de/~fmaussion/'
+TEST_GDIR_URL = ('https://cluster.klima.uni-bremen.de/~oggm/'
                  'test_gdirs/oggm_v1.1/')
 
 
@@ -673,7 +673,7 @@ class TestStartFromOnlinePrepro(unittest.TestCase):
 
         cfile = utils.get_prepro_gdir('61', 'RGI60-11.00787', 10, 4,
                                       base_url=utils.DEMO_GDIR_URL)
-        assert 'cluster.klima.uni-bremen.de/~fmaussion/' in cfile
+        assert 'cluster.klima.uni-bremen.de/~oggm/' in cfile
 
         # Replace with a dummy file
         os.remove(cfile)
@@ -1430,7 +1430,7 @@ class TestFakeDownloads(unittest.TestCase):
         assert source == 'DEM3'
 
         def down_check(url, *args, **kwargs):
-            expected = ('https://cluster.klima.uni-bremen.de/~fmaussion/DEM/'
+            expected = ('https://cluster.klima.uni-bremen.de/~oggm/DEM/'
                         'DEM3_MERGED/ISL.tif')
             self.assertEqual(url, expected)
             return self.dem3_testfile
@@ -1534,7 +1534,7 @@ class TestFakeDownloads(unittest.TestCase):
         tf = touch(os.path.join(self.dldir, 'file.tif'))
 
         def down_check(url, *args, **kwargs):
-            expected = ('https://cluster.klima.uni-bremen.de/~fmaussion/DEM/'
+            expected = ('https://cluster.klima.uni-bremen.de/~oggm/DEM/'
                         'REMA_100m_v1.1/'
                         '40_10_100m_v1.1/40_10_100m_v1.1_reg_dem.tif')
             self.assertEqual(expected, url)
@@ -1560,7 +1560,7 @@ class TestFakeDownloads(unittest.TestCase):
         tf = touch(os.path.join(self.dldir, 'file.tif'))
 
         def down_check(url, *args, **kwargs):
-            expected = ('https://cluster.klima.uni-bremen.de/~fmaussion/DEM/'
+            expected = ('https://cluster.klima.uni-bremen.de/~oggm/DEM/'
                         'Alaska_albers_V3/008_004_Alaska_albers_V3/'
                         '008_004_Alaska_albers_V3.tif')
             self.assertEqual(expected, url)
@@ -1580,7 +1580,7 @@ class TestFakeDownloads(unittest.TestCase):
         tf = touch(os.path.join(self.dldir, 'file.tif'))
 
         def down_check(url, *args, **kwargs):
-            expected = ('https://cluster.klima.uni-bremen.de/~fmaussion/DEM/'
+            expected = ('https://cluster.klima.uni-bremen.de/~oggm/DEM/'
                         'ArcticDEM_100m_v3.0/'
                         '14_52_100m_v3.0/14_52_100m_v3.0_reg_dem.tif')
             self.assertEqual(expected, url)

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -663,7 +663,7 @@ class TestStartFromOnlinePrepro(unittest.TestCase):
         workflow.execute_entity_task(tasks.run_random_climate, gdirs,
                                      nyears=10)
 
-    @pytest.xfail
+    @pytest.mark.xfail
     def test_corrupted_file(self):
 
         # Go - initialize working directories

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -663,6 +663,7 @@ class TestStartFromOnlinePrepro(unittest.TestCase):
         workflow.execute_entity_task(tasks.run_random_climate, gdirs,
                                      nyears=10)
 
+    @pytest.xfail
     def test_corrupted_file(self):
 
         # Go - initialize working directories

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -79,8 +79,8 @@ CRU_SERVER = ('https://crudata.uea.ac.uk/cru/data/hrg/cru_ts_4.01/cruts'
 
 HISTALP_SERVER = 'http://www.zamg.ac.at/histalp/download/grid5m/'
 
-GDIR_URL = 'https://cluster.klima.uni-bremen.de/~fmaussion/gdirs/oggm_v1.1/'
-DEMO_GDIR_URL = 'https://cluster.klima.uni-bremen.de/~fmaussion/demo_gdirs/'
+GDIR_URL = 'https://cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.1/'
+DEMO_GDIR_URL = 'https://cluster.klima.uni-bremen.de/~oggm/demo_gdirs/'
 DEMS_GDIR_URL = 'https://cluster.klima.uni-bremen.de/data/gdirs/dems_v0/'
 
 CMIP5_URL = 'https://cluster.klima.uni-bremen.de/~nicolas/cmip5-ng/'
@@ -894,7 +894,7 @@ def _download_dem3_viewpano_unlocked(zone):
         ifile = 'http://viewfinderpanoramas.org/dem3/' + zone + 'v2.zip'
     elif zone in DEM3REG.keys():
         # We prepared these files as tif already
-        ifile = ('https://cluster.klima.uni-bremen.de/~fmaussion/DEM/'
+        ifile = ('https://cluster.klima.uni-bremen.de/~oggm/DEM/'
                  'DEM3_MERGED/{}.tif'.format(zone))
         return file_downloader(ifile)
     else:
@@ -1707,7 +1707,7 @@ def _get_rgi_dir_unlocked(version=None, reset=False):
     elif version == '61':
         dfile = 'https://cluster.klima.uni-bremen.de/data/rgi/rgi_61.zip'
     elif version == '62':
-        dfile = 'https://cluster.klima.uni-bremen.de/~fmaussion/misc/rgi62.zip'
+        dfile = 'https://cluster.klima.uni-bremen.de/~oggm/misc/rgi62.zip'
 
     test_file = os.path.join(rgi_dir,
                              '*_rgi*{}_manifest.txt'.format(version))
@@ -1838,7 +1838,7 @@ def _get_rgi_intersects_dir_unlocked(version=None, reset=False):
     dfile = 'https://cluster.klima.uni-bremen.de/data/rgi/'
     dfile += 'RGI_V{}_Intersects.zip'.format(version)
     if version == '62':
-        dfile = ('https://cluster.klima.uni-bremen.de/~fmaussion/misc/'
+        dfile = ('https://cluster.klima.uni-bremen.de/~oggm/misc/'
                  'rgi62_Intersects.zip')
 
     odir = os.path.join(rgi_dir, 'RGI_V' + version + '_Intersects')
@@ -2279,7 +2279,7 @@ def get_topo_file(lon_ex, lat_ex, rgi_region=None, rgi_subregion=None,
         zones = arcticdem_zone(lon_ex, lat_ex)
         for z in zones:
             with _get_download_lock():
-                url = 'https://cluster.klima.uni-bremen.de/~fmaussion/'
+                url = 'https://cluster.klima.uni-bremen.de/~oggm/'
                 url += 'DEM/ArcticDEM_100m_v3.0/'
                 url += '{}_100m_v3.0/{}_100m_v3.0_reg_dem.tif'.format(z, z)
                 files.append(file_downloader(url))
@@ -2292,7 +2292,7 @@ def get_topo_file(lon_ex, lat_ex, rgi_region=None, rgi_subregion=None,
         zones = alaska_dem_zone(lon_ex, lat_ex)
         for z in zones:
             with _get_download_lock():
-                url = 'https://cluster.klima.uni-bremen.de/~fmaussion/'
+                url = 'https://cluster.klima.uni-bremen.de/~oggm/'
                 url += 'DEM/Alaska_albers_V3/'
                 url += '{}_Alaska_albers_V3/'.format(z)
                 url += '{}_Alaska_albers_V3.tif'.format(z)
@@ -2302,7 +2302,7 @@ def get_topo_file(lon_ex, lat_ex, rgi_region=None, rgi_subregion=None,
         zones = rema_zone(lon_ex, lat_ex)
         for z in zones:
             with _get_download_lock():
-                url = 'https://cluster.klima.uni-bremen.de/~fmaussion/'
+                url = 'https://cluster.klima.uni-bremen.de/~oggm/'
                 url += 'DEM/REMA_100m_v1.1/'
                 url += '{}_100m_v1.1/{}_100m_v1.1_reg_dem.tif'.format(z, z)
                 files.append(file_downloader(url))

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -247,7 +247,7 @@ def init_glacier_regions(rgidf=None, *, reset=False, force=False,
     prepro_base_url : str
         for `from_prepro_level` only: if you want to override the default
         URL from which to download the gdirs. Default currently is
-        https://cluster.klima.uni-bremen.de/~fmaussion/gdirs/oggm_v1.1/
+        https://cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.1/
     use_demo_glaciers : bool
         whether to check the demo glaciers for download (faster than the
         standard prepro downloads). The default is to decide whether or


### PR DESCRIPTION
<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->

Using ~fmaussion (or any personnal folder) should not happen anymore in the future. Use ~oggm when you want to share data with OGGM users via the OGGM download interface

