### PR TITLE
Small optimisations in checksum checks

### DIFF
--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -509,8 +509,9 @@ def initialize(file=None, logging_level='INFO'):
                     pass
         DATA['dem_grids'] = grids
 
-    # Download verification dictionary
-    DATA['dl_verify_data'] = None
+    # Trigger a one time check of the hash file
+    from oggm.utils import get_dl_verify_data
+    get_dl_verify_data('dummy_section')
 
 
 def oggm_static_paths():

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -669,7 +669,6 @@ class TestStartFromOnlinePrepro(unittest.TestCase):
         workflow.execute_entity_task(tasks.run_random_climate, gdirs,
                                      nyears=10)
 
-    @pytest.mark.xfail
     def test_corrupted_file(self):
 
         # Go - initialize working directories
@@ -1209,7 +1208,8 @@ class TestFakeDownloads(unittest.TestCase):
         file_sha256 = file_sha256.digest()
 
         data = utils.get_dl_verify_data('cluster.klima.uni-bremen.de')
-        s = pd.Series({'size': file_size, 'sha256': file_sha256}, name='test.txt')
+        s = pd.Series({'size': file_size, 'sha256': file_sha256},
+                      name='test.txt')
         data = data.append(s)
         cfg.DATA['dl_verify_data_test.com'] = data
 

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -346,8 +346,6 @@ def init_glacier_regions(rgidf=None, *, reset=False, force=False,
                 gdirs.append(gdir)
 
     if len(new_gdirs) > 0:
-        # Read the hash dictionary before we use multiproc
-        utils.get_dl_verify_data('cluster.klima.uni-bremen.de')
         # If not initialized, run the task in parallel
         execute_entity_task(tasks.define_glacier_region, new_gdirs)
 


### PR DESCRIPTION
<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->

This change now avoids to re-check the verification file's own checksum at each call to `get_dl_verify_data`. 

The current situation is following:
- the verification file itself is checked once (at the call to `cfg.initialize()`)
- the cluster data file is loaded previous to multiprocessing when we know that we are going to need it (i.e. when glacier directories are started from prepro levels, i.e. the huge majority of user cases). 
- all other checks (DEMs, climate, etc) will trigger a read of the verification file. If we are in multiproc, it means that the file is going to be read by each process. 

The last point could be further optimized but I decided against it, because:
-  reading the file is quite fast (the slowest read is for the huge `s3.amazonaws.com` at 500 ms, all others are in about 10-20 ms)
- pre-read the file would be useless in a huge majority of the cases
- pre-read the file would mean pickling about 150 Mb of data for each process.

There is one possible exception where we might think of pre-reading the data: in `run_prepro_levels`, where per definition we are going to need to do a lot of checks. To consider, maybe after some performance tests...

cc @TimoRoth @matthiasdusch 