### PR TITLE
source argument for define_glacier_region

### DIFF
--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -680,7 +680,7 @@ def get_lru_handler(tmpdir=None, maxsize=None, ending='.tif'):
         from oggm.utils import LRUFileCache
         # the files already present have to be counted, too
         l0 = list(glob.glob(os.path.join(tmpdir, '*' + ending)))
-        l0.sort(key=os.path.getmtime)
+        l0.sort(key=os.path.getctime)
         lru = LRUFileCache(l0, maxsize=maxsize)
         LRUHANDLERS[k] = lru
         return lru

--- a/oggm/core/gis.py
+++ b/oggm/core/gis.py
@@ -209,8 +209,8 @@ def _polygon_to_pix(polygon):
 
 
 @entity_task(log, writes=['glacier_grid', 'dem', 'outlines'])
-def define_glacier_region(gdir, entity=None):
-    """Very first task: define the glacier's local grid.
+def define_glacier_region(gdir, entity=None, source=None):
+    """Very first task after initialization: define the glacier's local grid.
 
     Defines the local projection (Transverse Mercator), centered on the
     glacier. There is some options to set the resolution of the local grid.
@@ -231,6 +231,22 @@ def define_glacier_region(gdir, entity=None):
         where to write the data
     entity : geopandas.GeoSeries
         the glacier geometry to process - DEPRECATED. It is now ignored
+    source : str or list of str, optional
+        If you want to force the use of a certain DEM source. Available are:
+          - 'USER' : file set in cfg.PATHS['dem_file']
+          - 'SRTM' : http://srtm.csi.cgiar.org/
+          - 'GIMP' : https://bpcrc.osu.edu/gdg/data/gimpdem
+          - 'RAMP' : http://nsidc.org/data/docs/daac/nsidc0082_ramp_dem.gd.html
+          - 'REMA' : https://www.pgc.umn.edu/data/rema/
+          - 'DEM3' : http://viewfinderpanoramas.org/
+          - 'ASTER' : https://lpdaac.usgs.gov/products/astgtmv003/
+          - 'TANDEM' : https://geoservice.dlr.de/web/dataguide/tdm90/
+          - 'ARCTICDEM' : https://www.pgc.umn.edu/data/arcticdem/
+          - 'AW3D30' : https://www.eorc.jaxa.jp/ALOS/en/aw3d30
+          - 'MAPZEN' : https://registry.opendata.aws/terrain-tiles/
+          - 'ALASKA' : https://www.the-cryosphere.net/8/503/2014/
+          - 'COPDEM' : Copernicus DEM GLO-90 https://bit.ly/2T98qqs
+          - 'NASADEM': https://lpdaac.usgs.gov/products/nasadem_hgtv001/
     """
 
     # Get the local map proj params and glacier extent
@@ -289,8 +305,6 @@ def define_glacier_region(gdir, entity=None):
     minlon, maxlon, minlat, maxlat = tmp_grid.extent_in_crs(crs=salem.wgs84)
 
     # Open DEM
-    entity = gdf.iloc[0]
-    source = entity.DEM_SOURCE if hasattr(entity, 'DEM_SOURCE') else None
     # We test DEM availability for glacier only (maps can grow big)
     if not is_dem_source_available(source, *gdir.extent_ll):
         raise InvalidDEMError('Source: {} not available for glacier {}'

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -401,7 +401,8 @@ class TestGIS(unittest.TestCase):
     def test_dem_source_text(self):
 
         for s in ['TANDEM', 'AW3D30', 'MAPZEN', 'DEM3', 'ASTER', 'SRTM',
-                  'RAMP', 'GIMP', 'ARCTICDEM', 'DEM3', 'REMA']:
+                  'RAMP', 'GIMP', 'ARCTICDEM', 'DEM3', 'REMA', 'COPDEM',
+                  'NASADEM', 'ALASKA']:
             assert s in gis.DEM_SOURCE_INFO.keys()
 
     def test_dem_daterange_dateinfo(self):

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -2223,21 +2223,7 @@ def get_topo_file(lon_ex, lat_ex, rgi_region=None, rgi_subregion=None,
     zoom : int, optional
         if you know the zoom already (for MAPZEN only)
     source : str or list of str, optional
-        If you want to force the use of a certain DEM source. Available are:
-          - 'USER' : file set in cfg.PATHS['dem_file']
-          - 'SRTM' : http://srtm.csi.cgiar.org/
-          - 'GIMP' : https://bpcrc.osu.edu/gdg/data/gimpdem
-          - 'RAMP' : http://nsidc.org/data/docs/daac/nsidc0082_ramp_dem.gd.html
-          - 'REMA' : https://www.pgc.umn.edu/data/rema/
-          - 'DEM3' : http://viewfinderpanoramas.org/
-          - 'ASTER' : https://lpdaac.usgs.gov/products/astgtmv003/
-          - 'TANDEM' : https://geoservice.dlr.de/web/dataguide/tdm90/
-          - 'ARCTICDEM' : https://www.pgc.umn.edu/data/arcticdem/
-          - 'AW3D30' : https://www.eorc.jaxa.jp/ALOS/en/aw3d30
-          - 'MAPZEN' : https://registry.opendata.aws/terrain-tiles/
-          - 'ALASKA' : https://www.the-cryosphere.net/8/503/2014/
-          - 'COPDEM' : Copernicus DEM GLO-90 https://bit.ly/2T98qqs
-          - 'NASADEM': https://lpdaac.usgs.gov/products/nasadem_hgtv001/
+        Name of specific DEM source. See gis.define_glacier_region for details
 
     Returns
     -------

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -1759,9 +1759,6 @@ class GlacierDirectory(object):
                 entity[k] = int(s)
         towrite = gpd.GeoDataFrame(entity).T
         towrite.crs = proj4_str
-        # Delete the source before writing
-        if 'DEM_SOURCE' in towrite:
-            del towrite['DEM_SOURCE']
 
         # Write shapefile
         self.write_shapefile(towrite, 'outlines')


### PR DESCRIPTION
If using an alternative DEM it was common until now to declare this as an entry of the GeoPandasDataFrame.
Due to some recent changes (#983 ) it is necessary and also more appropriate to change this.
Following this PR one has to specify an alternative DEM source as parameter to `define_glacier_region`. 

Closes #992 

Unrelated: This PR also changes the sorting of the LRU file handler from `getmtime` to `getctime`. ctime is updated when the files are moved/extracted on the disc while mtime only shows the last modification which usually happened months/years ago at the original file (DEM) creation.