### PR TITLE
Change way we log warnings

### DIFF
--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -281,7 +281,7 @@ def set_logging_config(logging_level='INFO'):
         but that OGGM is still working on this glacier.
     WORKFLOW
         Print only high level, workflow information (typically, one message
-        per task). Errors will still be printed, but warnings won't.
+        per task). Errors and warnings will still be printed.
     ERROR
         Print errors only, e.g. when a glacier cannot run properly.
     CRITICAL
@@ -296,15 +296,15 @@ def set_logging_config(logging_level='INFO'):
     """
 
     # Add a custom level - just for us
-    logging.addLevelName(35, 'WORKFLOW')
+    logging.addLevelName(25, 'WORKFLOW')
 
     def workflow(self, message, *args, **kws):
         """Standard log message with a custom level."""
-        if self.isEnabledFor(35):
+        if self.isEnabledFor(25):
             # Yes, logger takes its '*args' as 'args'.
-            self._log(35, message, args, **kws)
+            self._log(25, message, args, **kws)
 
-    logging.WORKFLOW = 35
+    logging.WORKFLOW = 25
     logging.Logger.workflow = workflow
 
     # Remove all handlers associated with the root logger object.

--- a/oggm/core/centerlines.py
+++ b/oggm/core/centerlines.py
@@ -1227,7 +1227,7 @@ def _mask_to_polygon(mask, gdir=None):
         sr = region_sizes.pop(am)
         for ss in region_sizes:
             if (ss / sr) > 0.2:
-                log.warning('(%s) this blob was unusually large', rid)
+                log.info('(%s) this blob was unusually large', rid)
         mask[:] = 0
         mask[np.where(regions == (am+1))] = 1
 
@@ -1379,7 +1379,7 @@ def _filter_for_altitude_range(widths, wlines, topo):
             break
         else:
             alt_range_th += 20
-            log.warning('Set altitude threshold to {}'.format(alt_range_th))
+            log.info('Set altitude threshold to {}'.format(alt_range_th))
         if alt_range_th > 2000:
             raise GeometryError('Problem by altitude filter.')
 
@@ -1657,9 +1657,9 @@ def initialize_flowlines(gdir):
             diag_n_pix += len(isfin)
             perc_bad = np.sum(~isfin) / len(isfin)
             if perc_bad > 0.8:
-                log.warning('({}) more than {:.0%} of the flowline is cropped '
-                            'due to negative slopes.'.format(gdir.rgi_id,
-                                                             perc_bad))
+                log.info('({}) more than {:.0%} of the flowline is cropped '
+                         'due to negative slopes.'.format(gdir.rgi_id,
+                                                          perc_bad))
 
             sp = np.min(np.where(np.isfinite(hgts))[0])
             while len(hgts[sp:]) < 5:
@@ -1782,7 +1782,7 @@ def catchment_width_geom(gdir):
         if len(valid[0]) == 0:
             # This happens very rarely. Just pick the middle and
             # the correction task should do the rest
-            log.warning('({}) width filtering too strong.'.format(gdir.rgi_id))
+            log.info('({}) width filtering too strong.'.format(gdir.rgi_id))
             fil_widths = widths[np.int(len(widths) / 2.)]
 
         # Special treatment for tidewater glaciers
@@ -1901,13 +1901,13 @@ def catchment_width_correction(gdir):
             if bsize > 500:
                 nmin -= 1
                 bsize = cfg.PARAMS['base_binsize']
-                log.warning('(%s) reduced min n per bin to %d', gdir.rgi_id,
-                            nmin)
+                log.info('(%s) reduced min n per bin to %d', gdir.rgi_id,
+                         nmin)
                 if nmin == 0:
                     raise GeometryError('({}) no binsize could be chosen '
                                         .format(gdir.rgi_id))
         if bsize > 150:
-            log.warning('(%s) chosen binsize %d', gdir.rgi_id, bsize)
+            log.info('(%s) chosen binsize %d', gdir.rgi_id, bsize)
         else:
             log.debug('(%s) chosen binsize %d', gdir.rgi_id, bsize)
 

--- a/oggm/core/climate.py
+++ b/oggm/core/climate.py
@@ -1303,8 +1303,8 @@ def mu_star_calibration(gdir):
     # If not marine and a bit far from zero, warning
     cmb = calving_mb(gdir)
     if cmb == 0 and not np.allclose(fls[-1].flux[-1], 0., atol=0.01):
-        log.warning('(%s) flux should be zero, but is: '
-                    '%.4f km3 ice yr-1', gdir.rgi_id, aflux)
+        log.info('(%s) flux should be zero, but is: '
+                 '%.4f km3 ice yr-1', gdir.rgi_id, aflux)
     # If not marine and quite far from zero, error
     if cmb == 0 and not np.allclose(fls[-1].flux[-1], 0., atol=1):
         msg = ('({}) flux should be zero, but is: {:.4f} km3 ice yr-1'
@@ -1383,8 +1383,8 @@ def apparent_mb_from_linear_mb(gdir, mb_gradient=3., ela_h=None):
     aflux = fls[-1].flux[-1] * 1e-9 / rho * gdir.grid.dx**2
     # If not marine and a bit far from zero, warning
     if cmb == 0 and not np.allclose(fls[-1].flux[-1], 0., atol=0.01):
-        log.warning('(%s) flux should be zero, but is: '
-                    '%.4f km3 ice yr-1', gdir.rgi_id, aflux)
+        log.info('(%s) flux should be zero, but is: '
+                 '%.4f km3 ice yr-1', gdir.rgi_id, aflux)
     # If not marine and quite far from zero, error
     if cmb == 0 and not np.allclose(fls[-1].flux[-1], 0., atol=1):
         msg = ('({}) flux should be zero, but is: {:.4f} km3 ice yr-1'
@@ -1445,8 +1445,8 @@ def apparent_mb_from_any_mb(gdir, mb_model=None, mb_years=None):
     aflux = fls[-1].flux[-1] * 1e-9 / rho * gdir.grid.dx**2
     # If not marine and a bit far from zero, warning
     if cmb == 0 and not np.allclose(fls[-1].flux[-1], 0., atol=0.01):
-        log.warning('(%s) flux should be zero, but is: '
-                    '%.4f km3 ice yr-1', gdir.rgi_id, aflux)
+        log.info('(%s) flux should be zero, but is: '
+                 '%.4f km3 ice yr-1', gdir.rgi_id, aflux)
     # If not marine and quite far from zero, error
     if cmb == 0 and not np.allclose(fls[-1].flux[-1], 0., atol=1):
         msg = ('({}) flux should be zero, but is: {:.4f} km3 ice yr-1'

--- a/oggm/core/gis.py
+++ b/oggm/core/gis.py
@@ -502,7 +502,7 @@ def process_dem(gdir):
     if np.any(~valid_mask):
         # We interpolate
         if np.sum(~valid_mask) > (0.25 * nx * ny):
-            log.warning('({}) more than 25% NaNs in DEM'.format(gdir.rgi_id))
+            log.info('({}) more than 25% NaNs in DEM'.format(gdir.rgi_id))
         xx, yy = gdir.grid.ij_coordinates
         pnan = np.nonzero(~valid_mask)
         pok = np.nonzero(valid_mask)
@@ -513,7 +513,7 @@ def process_dem(gdir):
                                  method='linear')
         except ValueError:
             raise InvalidDEMError('DEM interpolation not possible.')
-        log.warning(gdir.rgi_id + ': DEM needed interpolation.')
+        log.info(gdir.rgi_id + ': DEM needed interpolation.')
         gdir.add_to_diagnostics('dem_needed_interpolation', True)
         gdir.add_to_diagnostics('dem_invalid_perc', len(pnan[0]) / (nx * ny))
 
@@ -531,7 +531,7 @@ def process_dem(gdir):
                                  method='nearest')
         except ValueError:
             raise InvalidDEMError('DEM extrapolation not possible.')
-        log.warning(gdir.rgi_id + ': DEM needed extrapolation.')
+        log.info(gdir.rgi_id + ': DEM needed extrapolation.')
         gdir.add_to_diagnostics('dem_needed_extrapolation', True)
         gdir.add_to_diagnostics('dem_extrapol_perc', len(pnan[0]) / (nx * ny))
 

--- a/oggm/core/inversion.py
+++ b/oggm/core/inversion.py
@@ -85,7 +85,7 @@ def prepare_for_inversion(gdir, add_debug_var=False,
 
         # Clip flux to 0
         if np.any(flux < -0.1):
-            log.warning('(%s) has negative flux somewhere', gdir.rgi_id)
+            log.info('(%s) has negative flux somewhere', gdir.rgi_id)
         utils.clip_min(flux, 0, out=flux)
 
         if fl.flows_to is None and gdir.inversion_calving_rate == 0:

--- a/oggm/utils/_funcs.py
+++ b/oggm/utils/_funcs.py
@@ -510,7 +510,7 @@ def multipolygon_to_polygon(geometry, gdir=None):
             # This happens for bad geometries. We keep the largest
             geometry = parts[0]
             if np.any(areas[1:] > (areas[0] / 4)):
-                log.warning('Geometry {} lost quite a chunk.'.format(rid))
+                log.info('Geometry {} lost quite a chunk.'.format(rid))
 
     if geometry.type != 'Polygon':
         raise InvalidGeometryError('Geometry {} is not a Polygon.'.format(rid))


### PR DESCRIPTION
<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->

Previously warnings were not printed in `workflow` logging mode. They are now.

But as a result, I changed some warnings in the code to "info", because they were old warnings which we accept since a long time and on which the user can have no influence. The new warnings are things that the user should take into account and acknowledge (that's not many) 