### PR TITLE
Add area "conservation" test for init_present_time_glacier

### DIFF
--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -236,7 +236,11 @@ class TestFullRun(unittest.TestCase):
             df.loc[gd.rgi_id, 'start_volume_km3'] = model.volume_km3
             df.loc[gd.rgi_id, 'start_length'] = model.length_m
         assert_allclose(df['rgi_area_km2'], df['start_area_km2'], 0.06)
+        assert_allclose(df['rgi_area_km2'].sum(), df['start_area_km2'].sum(),
+                        0.003)
         assert_allclose(df['inv_volume_km3'], df['start_volume_km3'], 0.04)
+        assert_allclose(df['inv_volume_km3'].sum(),
+                        df['start_volume_km3'].sum(), 0.001)
         assert_allclose(df['main_flowline_length'], df['start_length'])
 
         workflow.execute_entity_task(flowline.run_random_climate, gdirs,

--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -237,7 +237,7 @@ class TestFullRun(unittest.TestCase):
             df.loc[gd.rgi_id, 'start_length'] = model.length_m
         assert_allclose(df['rgi_area_km2'], df['start_area_km2'], 0.06)
         assert_allclose(df['rgi_area_km2'].sum(), df['start_area_km2'].sum(),
-                        0.003)
+                        0.004)
         assert_allclose(df['inv_volume_km3'], df['start_volume_km3'], 0.04)
         assert_allclose(df['inv_volume_km3'].sum(),
                         df['start_volume_km3'].sum(), 0.001)

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -1185,8 +1185,11 @@ def glacier_statistics(gdir, inversion_only=False):
         for fl in fls:
             hgt = fl.surface_h
             h = np.append(h, hgt)
-            widths = np.append(widths, fl.widths * dx)
+            widths = np.append(widths, fl.widths * gdir.grid.dx)
             slope = np.append(slope, np.arctan(-np.gradient(hgt, dx)))
+            length = len(hgt) * dx
+        d['main_flowline_length'] = length
+        d['inv_flowline_glacier_area'] = np.sum(widths * dx)
         d['flowline_mean_elev'] = np.average(h, weights=widths)
         d['flowline_max_elev'] = np.max(h)
         d['flowline_min_elev'] = np.min(h)


### PR DESCRIPTION
<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->

This is a couple of tests added after a slack bug report by @hydrojon who noticed that areas and volume are not the same than the rgi ones at year 0 of the simulation.

After some digging, it appears that the problem is not in how we store the output. I knew that `init_present_time_glacier` is neither area nor volume conservative, but I thought that the numbers were small. For our basin test case in the alps, glacier areas (volumes) can individually change by up to 6% (4%). The basin-wide changes are much smaller (0.2% and 0.1%, respectively). I assume that the percentage changes are higher for small glaciers, but it would be good to test this at larger scales.

This PR also adds a new diagnostic variable (`'main_flowline_length'`) which is the true length of the flowline glacier (i.e. after filtering) and is the one that the model will use.

I'll open a separate issue for the `init_present_time_glacier` issues - I think we can do better

