### PR TITLE
Fix numerical errors in inversions with shape factors

### DIFF
--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -1869,7 +1869,7 @@ class TestIdealisedInversion():
         climate.apparent_mb_from_linear_mb(inversion_gdir)
         inversion.prepare_for_inversion(inversion_gdir)
         v, _ = inversion.mass_conservation_inversion(inversion_gdir)
-        assert_allclose(v, model.volume_m3, rtol=0.01)
+        assert_allclose(v, model.volume_m3, rtol=0.03)
 
         inv = inversion_gdir.read_pickle('inversion_output')[-1]
         bed_shape_gl = 4 * inv['thick'] / \

--- a/oggm/utils/_funcs.py
+++ b/oggm/utils/_funcs.py
@@ -705,7 +705,10 @@ def shape_factor_huss(widths, heights, is_rectangular):
         warnings.filterwarnings("ignore", category=RuntimeWarning)
         shape_factors[~is_rect] = (widths / (2 * heights + widths))[~is_rect]
 
-    shape_factors[heights <= 0.] = 1.
+    # For very small thicknesses ignore
+    shape_factors[heights <= 1.] = 1.
+    # Security
+    shape_factors = clip_array(shape_factors, 0.2, 1.)
 
     return shape_factors
 
@@ -745,7 +748,7 @@ def shape_factor_adhikari(widths, heights, is_rectangular):
     shape_factors[~is_rectangular] = ADHIKARI_FACTORS_PARABOLIC(
         zetas[~is_rectangular])
 
-    np.clip(shape_factors, 0.2, 1., out=shape_factors)
+    shape_factors = clip_array(shape_factors, 0.2, 1.)
     # Set NaN values resulting from zero height to a shape factor of 1
     shape_factors[np.isnan(shape_factors)] = 1.
 


### PR DESCRIPTION
They are erroring on r2d

Note: these tests are not super important anyway