### PR TITLE
Verify downloaded files only once per run

### DIFF
--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -9,6 +9,7 @@ import sys
 import glob
 import json
 from collections import OrderedDict
+from multiprocessing import Manager
 from distutils.util import strtobool
 
 import numpy as np
@@ -38,6 +39,9 @@ CONFIG_FILE = os.path.join(os.path.expanduser('~'), '.oggm_config')
 
 # config was changed, indicates that multiprocessing needs a reset
 CONFIG_MODIFIED = False
+
+# Share state accross process
+DL_VERIFIED = Manager().dict()
 
 
 class DocumentedDict(dict):

--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -40,7 +40,7 @@ CONFIG_FILE = os.path.join(os.path.expanduser('~'), '.oggm_config')
 # config was changed, indicates that multiprocessing needs a reset
 CONFIG_MODIFIED = False
 
-# Share state accross process
+# Share state accross processes
 DL_VERIFIED = Manager().dict()
 
 

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -1166,9 +1166,13 @@ class TestFakeDownloads(unittest.TestCase):
         utils.mkdir(cfg.PATHS['tmp_dir'])
         utils.mkdir(cfg.PATHS['rgi_dir'])
 
-    def prepare_verify_test(self, valid_size=True, valid_crc32=True):
+    def prepare_verify_test(self, valid_size=True, valid_crc32=True,
+                            reset_dl_dict=True):
         self.reset_dir()
         cfg.PARAMS['dl_verify'] = True
+
+        if reset_dl_dict:
+            cfg.DL_VERIFIED.clear()
 
         tgt_path = os.path.join(cfg.PATHS['dl_cache_dir'], 'test.com',
                                 'test.txt')
@@ -1216,7 +1220,6 @@ class TestFakeDownloads(unittest.TestCase):
             url = self.prepare_verify_test(False, False)
             with self.assertRaises(DownloadVerificationFailedException):
                 utils.oggm_urlretrieve(url)
-
 
     def test_github_no_internet(self):
         self.reset_dir()

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -6,6 +6,7 @@ import os
 import shutil
 import time
 import hashlib
+import tarfile
 import pytest
 import itertools
 from unittest import mock
@@ -672,7 +673,15 @@ class TestStartFromOnlinePrepro(unittest.TestCase):
         with open(cfile, 'w') as f:
             f.write('ups')
 
+        # Since we already verified this will error
+        with pytest.raises(tarfile.ReadError):
+            gdirs = workflow.init_glacier_directories(['hef'],
+                                                      from_prepro_level=4,
+                                                      prepro_rgi_version='61',
+                                                      prepro_border=10)
+
         # This should retrigger a download and just work
+        cfg.DL_VERIFIED.clear()
         gdirs = workflow.init_glacier_directories(['hef'],
                                                   from_prepro_level=4,
                                                   prepro_rgi_version='61',

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -332,11 +332,12 @@ def _verified_download_helper(cache_obj_name, dl_func, reset=False):
     except KeyError:
         dl_verify = True
 
-    if dl_verify and path is not None:
+    if dl_verify and path and cache_obj_name not in cfg.DL_VERIFIED:
         cache_section, cache_path = cache_obj_name.split('/', 1)
         data = get_dl_verify_data(cache_section)
         if cache_path not in data.index:
             logger.info('No known hash for %s' % cache_obj_name)
+            cfg.DL_VERIFIED[cache_obj_name] = True
         else:
             # compute the hash
             sha256 = hashlib.sha256()
@@ -353,6 +354,7 @@ def _verified_download_helper(cache_obj_name, dl_func, reset=False):
                     path, size, sha256.hex(), data[0], data[1].hex())
                 raise DownloadVerificationFailedException(msg=err, path=path)
             logger.info('%s verified successfully.' % path)
+            cfg.DL_VERIFIED[cache_obj_name] = True
 
     return path
 

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -316,7 +316,8 @@ def init_glacier_regions(rgidf=None, *, reset=False, force=False,
                          '{} glaciers.'.format(from_prepro_level,
                                                len(entities)))
             # Read the hash dictionary before we use multiproc
-            utils.get_dl_verify_data('cluster.klima.uni-bremen.de')
+            if cfg.PARAMS['dl_verify']:
+                utils.get_dl_verify_data('cluster.klima.uni-bremen.de')
             gdirs = execute_entity_task(gdir_from_prepro, entities,
                                         from_prepro_level=from_prepro_level,
                                         prepro_border=prepro_border,
@@ -456,7 +457,8 @@ def init_glacier_directories(rgidf=None, *, reset=False, force=False,
                          '{} glaciers.'.format(from_prepro_level,
                                                len(entities)))
             # Read the hash dictionary before we use multiproc
-            utils.get_dl_verify_data('cluster.klima.uni-bremen.de')
+            if cfg.PARAMS['dl_verify']:
+                utils.get_dl_verify_data('cluster.klima.uni-bremen.de')
             gdirs = execute_entity_task(gdir_from_prepro, entities,
                                         from_prepro_level=from_prepro_level,
                                         prepro_border=prepro_border,


### PR DESCRIPTION
<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->

This was so easy to implement that it is almost embarrassing that we lost so much time because of that.

cc @matthiasdusch @TimoRoth 

I will also add a pytest option to disable it entirely when doing tests, this will make my life a bit easier as I always develop in tests and the verification takes time