### PR TITLE
GlacierDirectory creation is now parallelized

### DIFF
--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -1770,9 +1770,9 @@ class GlacierDirectory(object):
         # Reproject
         proj_in = pyproj.Proj("epsg:4326", preserve_units=True)
         proj_out = pyproj.Proj(proj4_str, preserve_units=True)
-        project = partial(transform_proj, proj_in, proj_out)
 
         # transform geometry to map
+        project = partial(transform_proj, proj_in, proj_out)
         geometry = shp_trafo(project, entity['geometry'])
         geometry = multipolygon_to_polygon(geometry, gdir=self)
 

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -335,13 +335,14 @@ def init_glacier_regions(rgidf=None, *, reset=False, force=False,
                                                        version=rgi_version)
                 cfg.set_intersects_db(fp)
 
-            for entity in entities:
-                gdir = oggm.GlacierDirectory(entity, reset=reset,
-                                             from_tar=from_tar,
-                                             delete_tar=delete_tar)
+            gdirs = execute_entity_task(utils.GlacierDirectory, entities,
+                                        reset=reset,
+                                        from_tar=from_tar,
+                                        delete_tar=delete_tar)
+
+            for gdir in gdirs:
                 if not os.path.exists(gdir.get_filepath('dem')):
                     new_gdirs.append(gdir)
-                gdirs.append(gdir)
 
     if len(new_gdirs) > 0:
         # If not initialized, run the task in parallel
@@ -480,12 +481,10 @@ def init_glacier_directories(rgidf=None, *, reset=False, force=False,
                     # List of str
                     pass
 
-            gdirs = []
-            for entity in entities:
-                gdir = oggm.GlacierDirectory(entity, reset=reset,
-                                             from_tar=from_tar,
-                                             delete_tar=delete_tar)
-                gdirs.append(gdir)
+            gdirs = execute_entity_task(utils.GlacierDirectory, entities,
+                                        reset=reset,
+                                        from_tar=from_tar,
+                                        delete_tar=delete_tar)
 
     return gdirs
 


### PR DESCRIPTION
<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->

In https://github.com/OGGM/oggm/pull/983 we split the "creation of directories" and the "generation of DEMs" in two separate steps in the workflow. 

One of the results is that the GlacierDirectories are now responsible for re-projecting the outlines to a local map which, as it turns out, is quite expensive. I'm not sure if this can be made faster.

So one easy solution is to make this step parallel as well. It's still slow (count a couple of minutes for the 4000 glaciers of the Alps) but at least not ultra slow any more.

Thanks @keeptg for the bug report. 
