### PR TITLE
Fix test_env_var

### DIFF
--- a/oggm/tests/funcs.py
+++ b/oggm/tests/funcs.py
@@ -454,11 +454,14 @@ class TempEnvironmentVariable:
         self.old_envs = {}
         for k, v in self.envs.items():
             self.old_envs[k] = os.environ.get(k)
-            os.environ[k] = v
+            if v is not None:
+                os.environ[k] = v
+            elif k in os.environ:
+                del os.environ[k]
 
     def __exit__(self, *args):
         for k, v in self.old_envs.items():
-            if v:
+            if v is not None:
                 os.environ[k] = v
-            else:
+            elif k in os.environ:
                 del os.environ[k]

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -298,7 +298,8 @@ class TestInitialize(unittest.TestCase):
         self.homedir = os.path.expanduser('~')
 
     def test_env_var(self):
-        with TempEnvironmentVariable(OGGM_USE_MULTIPROCESSING='1'):
+        with TempEnvironmentVariable(OGGM_USE_MULTIPROCESSING='1',
+                                     OGGM_USE_MP_SPAWN=None):
             cfg.initialize()
             assert cfg.PARAMS['use_multiprocessing']
             assert cfg.PARAMS['mp_processes'] >= 1


### PR DESCRIPTION
In a test-environment which has OGGM_USE_MP_SPAWN set this test
otherwise fails.