### PR TITLE
Add support to calibrate inversion on consensus thickness estimate

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -58,6 +58,10 @@ Enhancements
   :py:func:`tasks.elevation_band_flowline` and
   :py:func:`tasks.fixed_dx_elevation_band_flowline`.
   By `Fabien Maussion <https://github.com/fmaussion>`_
+- Added a `calibrate_inversion_from_consensus_estimate` global task which
+  calibrates Glen A so that the volume of glaciers in a selection is
+  matched (:pull:`1043`).
+  By `Fabien Maussion <https://github.com/fmaussion>`_
 
 
 Bug fixes

--- a/oggm/core/inversion.py
+++ b/oggm/core/inversion.py
@@ -413,8 +413,10 @@ def mass_conservation_inversion(gdir, glen_a=None, fs=None, write=True,
 
     if write:
         gdir.write_pickle(cls, 'inversion_output', filesuffix=filesuffix)
+        gdir.add_to_diagnostics('inversion_glen_a', glen_a)
+        gdir.add_to_diagnostics('inversion_fs', fs)
 
-    return out_volume, gdir.rgi_area_km2 * 1e6
+    return out_volume
 
 
 @entity_task(log, writes=['inversion_output'])
@@ -938,7 +940,7 @@ def find_inversion_calving(gdir, water_level=None, fixed_water_depth=None):
         climate.local_t_star(gdir)
         climate.mu_star_calibration(gdir)
         prepare_for_inversion(gdir, add_debug_var=True)
-        v_ref, _ = mass_conservation_inversion(gdir, water_level=water_level)
+        v_ref = mass_conservation_inversion(gdir, water_level=water_level)
 
     # Store for statistics
     gdir.add_to_diagnostics('volume_before_calving', v_ref)

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -13,6 +13,7 @@ from oggm.utils import (SuperclassMeta, lazy_property, floatyear_to_date,
                         tolist, clip_min, clip_max, clip_array)
 from oggm.exceptions import InvalidWorkflowError
 
+
 class MassBalanceModel(object, metaclass=SuperclassMeta):
     """Common logic for the mass balance models.
 

--- a/oggm/tests/funcs.py
+++ b/oggm/tests/funcs.py
@@ -377,7 +377,7 @@ def init_hef(reset=False, border=40, logging_level='INFO'):
         _fd = 1.9e-24 * x[0]
         glen_a = (glen_n+2) * _fd / 2.
         fs = 5.7e-20 * x[1]
-        v, _ = inversion.mass_conservation_inversion(gdir, fs=fs,
+        v = inversion.mass_conservation_inversion(gdir, fs=fs,
                                                      glen_a=glen_a)
         return (v - ref_v)**2
 
@@ -387,9 +387,9 @@ def init_hef(reset=False, border=40, logging_level='INFO'):
     _fd = 1.9e-24 * out[0]
     glen_a = (glen_n+2) * _fd / 2.
     fs = 5.7e-20 * out[1]
-    v, _ = inversion.mass_conservation_inversion(gdir, fs=fs,
-                                                 glen_a=glen_a,
-                                                 write=True)
+    v = inversion.mass_conservation_inversion(gdir, fs=fs,
+                                              glen_a=glen_a,
+                                              write=True)
 
     d = dict(fs=fs, glen_a=glen_a)
     d['factor_glen_a'] = out[0]

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -182,7 +182,7 @@ class TestInitFlowlineOtherGlacier:
         climate.local_t_star(gdir, tstar=1930, bias=0)
         climate.mu_star_calibration(gdir)
         inversion.prepare_for_inversion(gdir)
-        v, ainv = inversion.mass_conservation_inversion(gdir)
+        v = inversion.mass_conservation_inversion(gdir)
         init_present_time_glacier(gdir)
 
         myarea = 0.
@@ -190,7 +190,6 @@ class TestInitFlowlineOtherGlacier:
         for cl in cls:
             myarea += np.sum(cl.widths * cl.dx * gdir.grid.dx**2)
 
-        np.testing.assert_allclose(ainv, gdir.rgi_area_m2, rtol=1e-2)
         np.testing.assert_allclose(myarea, gdir.rgi_area_m2, rtol=1e-2)
 
         myarea = 0.
@@ -1666,7 +1665,7 @@ class TestIdealisedInversion():
 
         climate.apparent_mb_from_linear_mb(inversion_gdir)
         inversion.prepare_for_inversion(inversion_gdir, add_debug_var=True)
-        v, _ = inversion.mass_conservation_inversion(inversion_gdir)
+        v = inversion.mass_conservation_inversion(inversion_gdir)
 
         assert_allclose(v, model.volume_m3, rtol=0.01)
 
@@ -1731,7 +1730,7 @@ class TestIdealisedInversion():
 
         climate.apparent_mb_from_linear_mb(inversion_gdir)
         inversion.prepare_for_inversion(inversion_gdir, add_debug_var=True)
-        v, _ = inversion.mass_conservation_inversion(inversion_gdir)
+        v = inversion.mass_conservation_inversion(inversion_gdir)
         assert_allclose(v, model.volume_m3, rtol=0.01)
 
         inv = inversion_gdir.read_pickle('inversion_output')[-1]
@@ -1808,7 +1807,7 @@ class TestIdealisedInversion():
 
         climate.apparent_mb_from_linear_mb(inversion_gdir)
         inversion.prepare_for_inversion(inversion_gdir)
-        v, _ = inversion.mass_conservation_inversion(inversion_gdir)
+        v = inversion.mass_conservation_inversion(inversion_gdir)
         assert_allclose(v, model.volume_m3, rtol=0.02)
 
         inv = inversion_gdir.read_pickle('inversion_output')[-1]
@@ -1868,7 +1867,7 @@ class TestIdealisedInversion():
 
         climate.apparent_mb_from_linear_mb(inversion_gdir)
         inversion.prepare_for_inversion(inversion_gdir)
-        v, _ = inversion.mass_conservation_inversion(inversion_gdir)
+        v = inversion.mass_conservation_inversion(inversion_gdir)
         assert_allclose(v, model.volume_m3, rtol=0.03)
 
         inv = inversion_gdir.read_pickle('inversion_output')[-1]
@@ -1925,7 +1924,7 @@ class TestIdealisedInversion():
 
         climate.apparent_mb_from_linear_mb(inversion_gdir)
         inversion.prepare_for_inversion(inversion_gdir)
-        v, _ = inversion.mass_conservation_inversion(inversion_gdir)
+        v = inversion.mass_conservation_inversion(inversion_gdir)
 
         assert_allclose(v, model.volume_m3, rtol=0.05)
         if do_plot:  # pragma: no cover
@@ -1954,7 +1953,7 @@ class TestIdealisedInversion():
 
         climate.apparent_mb_from_linear_mb(inversion_gdir)
         inversion.prepare_for_inversion(inversion_gdir)
-        v, _ = inversion.mass_conservation_inversion(inversion_gdir)
+        v = inversion.mass_conservation_inversion(inversion_gdir)
 
         assert_allclose(v, model.volume_m3, rtol=0.05)
         if do_plot:  # pragma: no cover
@@ -1989,7 +1988,7 @@ class TestIdealisedInversion():
 
         climate.apparent_mb_from_linear_mb(inversion_gdir)
         inversion.prepare_for_inversion(inversion_gdir)
-        v, _ = inversion.mass_conservation_inversion(inversion_gdir)
+        v = inversion.mass_conservation_inversion(inversion_gdir)
 
         assert_allclose(v, model.volume_m3, rtol=0.05)
         if do_plot:  # pragma: no cover
@@ -2027,7 +2026,7 @@ class TestIdealisedInversion():
 
         climate.apparent_mb_from_linear_mb(inversion_gdir)
         inversion.prepare_for_inversion(inversion_gdir)
-        v, _ = inversion.mass_conservation_inversion(inversion_gdir)
+        v = inversion.mass_conservation_inversion(inversion_gdir)
 
         assert_allclose(v, model.volume_m3, rtol=0.05)
         if do_plot:  # pragma: no cover
@@ -2057,7 +2056,7 @@ class TestIdealisedInversion():
 
         climate.apparent_mb_from_linear_mb(inversion_gdir)
         inversion.prepare_for_inversion(inversion_gdir)
-        v, _ = inversion.mass_conservation_inversion(inversion_gdir)
+        v = inversion.mass_conservation_inversion(inversion_gdir)
 
         assert_allclose(v, model.volume_m3, rtol=0.05)
         if do_plot:  # pragma: no cover
@@ -2090,7 +2089,7 @@ class TestIdealisedInversion():
 
         climate.apparent_mb_from_linear_mb(inversion_gdir)
         inversion.prepare_for_inversion(inversion_gdir)
-        v, _ = inversion.mass_conservation_inversion(inversion_gdir)
+        v = inversion.mass_conservation_inversion(inversion_gdir)
 
         assert_allclose(v, model.volume_m3, rtol=0.05)
         if do_plot:  # pragma: no cover
@@ -2127,7 +2126,7 @@ class TestIdealisedInversion():
 
         climate.apparent_mb_from_linear_mb(inversion_gdir)
         inversion.prepare_for_inversion(inversion_gdir)
-        v, _ = inversion.mass_conservation_inversion(inversion_gdir)
+        v = inversion.mass_conservation_inversion(inversion_gdir)
 
         assert_allclose(v, model.volume_m3, rtol=0.05)
         if do_plot:  # pragma: no cover
@@ -2161,7 +2160,7 @@ class TestIdealisedInversion():
 
         climate.apparent_mb_from_linear_mb(inversion_gdir)
         inversion.prepare_for_inversion(inversion_gdir)
-        v, _ = inversion.mass_conservation_inversion(inversion_gdir)
+        v = inversion.mass_conservation_inversion(inversion_gdir)
 
         assert_allclose(v, model.volume_m3, rtol=0.02)
         if do_plot:  # pragma: no cover
@@ -2200,7 +2199,7 @@ class TestIdealisedInversion():
 
         climate.apparent_mb_from_linear_mb(inversion_gdir)
         inversion.prepare_for_inversion(inversion_gdir)
-        v, _ = inversion.mass_conservation_inversion(inversion_gdir)
+        v = inversion.mass_conservation_inversion(inversion_gdir)
 
         assert_allclose(v, model.volume_m3, rtol=0.02)
         if do_plot:  # pragma: no cover
@@ -2241,7 +2240,7 @@ class TestIdealisedInversion():
 
         climate.apparent_mb_from_linear_mb(inversion_gdir)
         inversion.prepare_for_inversion(inversion_gdir)
-        v, _ = inversion.mass_conservation_inversion(inversion_gdir)
+        v = inversion.mass_conservation_inversion(inversion_gdir)
 
         assert_allclose(v, model.volume_m3, rtol=0.02)
         if do_plot:  # pragma: no cover
@@ -2276,7 +2275,7 @@ class TestIdealisedInversion():
 
         climate.apparent_mb_from_linear_mb(inversion_gdir)
         inversion.prepare_for_inversion(inversion_gdir)
-        v, _ = inversion.mass_conservation_inversion(inversion_gdir)
+        v = inversion.mass_conservation_inversion(inversion_gdir)
 
         # expected errors
         assert v > model.volume_m3
@@ -2307,7 +2306,7 @@ class TestIdealisedInversion():
 
         climate.apparent_mb_from_linear_mb(inversion_gdir)
         inversion.prepare_for_inversion(inversion_gdir)
-        v, _ = inversion.mass_conservation_inversion(inversion_gdir)
+        v = inversion.mass_conservation_inversion(inversion_gdir)
 
         assert_allclose(v, model.volume_m3, rtol=0.01)
 

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -2889,7 +2889,7 @@ class TestGrindelInvert(unittest.TestCase):
 
         # Write out
         gdir.write_pickle(towrite, 'inversion_input')
-        v  = inversion.mass_conservation_inversion(gdir, glen_a=glen_a)
+        v = inversion.mass_conservation_inversion(gdir, glen_a=glen_a)
         np.testing.assert_allclose(v, model.volume_m3, rtol=0.01)
 
         cl = gdir.read_pickle('inversion_output')[0]

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -864,7 +864,7 @@ class TestElevationBandFlowlines(unittest.TestCase):
         climate.local_t_star(gdir, tstar=t_star, bias=bias)
         climate.mu_star_calibration(gdir)
         inversion.prepare_for_inversion(gdir)
-        v1, _ = inversion.mass_conservation_inversion(gdir)
+        v1 = inversion.mass_conservation_inversion(gdir)
         inversion.distribute_thickness_per_altitude(gdir)
         with xr.open_dataset(gdir.get_filepath('gridded_data')) as ds:
             ds1 = ds.load()
@@ -885,7 +885,7 @@ class TestElevationBandFlowlines(unittest.TestCase):
         climate.local_t_star(gdir, tstar=t_star, bias=bias)
         climate.mu_star_calibration(gdir)
         inversion.prepare_for_inversion(gdir)
-        v2, _ = inversion.mass_conservation_inversion(gdir)
+        v2 = inversion.mass_conservation_inversion(gdir)
         inversion.distribute_thickness_per_altitude(gdir)
         with xr.open_dataset(gdir.get_filepath('gridded_data')) as ds:
             ds2 = ds.load()
@@ -916,7 +916,7 @@ class TestElevationBandFlowlines(unittest.TestCase):
         climate.local_t_star(gdir, tstar=t_star, bias=bias)
         climate.mu_star_calibration(gdir)
         inversion.prepare_for_inversion(gdir)
-        v1, _ = inversion.mass_conservation_inversion(gdir)
+        v1 = inversion.mass_conservation_inversion(gdir)
         flowline.init_present_time_glacier(gdir)
         flowline.run_random_climate(gdir, nyears=50, y0=1985)
 
@@ -2187,8 +2187,8 @@ class TestInversion(unittest.TestCase):
         fs = 5.7e-20
 
         def to_optimize(x):
-            v, _ = inversion.mass_conservation_inversion(gdir, fs=fs * x[1],
-                                                         glen_a=glen_a * x[0])
+            v = inversion.mass_conservation_inversion(gdir, fs=fs * x[1],
+                                                      glen_a=glen_a * x[0])
             return (v - ref_v)**2
 
         import scipy.optimize as optimization
@@ -2201,9 +2201,9 @@ class TestInversion(unittest.TestCase):
         self.assertTrue(out[1] < 1.1)
         glen_a = glen_a * out[0]
         fs = fs * out[1]
-        v, _ = inversion.mass_conservation_inversion(gdir, fs=fs,
-                                                     glen_a=glen_a,
-                                                     write=True)
+        v = inversion.mass_conservation_inversion(gdir, fs=fs,
+                                                  glen_a=glen_a,
+                                                  write=True)
         np.testing.assert_allclose(ref_v, v)
 
         cls = gdir.read_pickle('inversion_output')
@@ -2261,6 +2261,29 @@ class TestInversion(unittest.TestCase):
                                    inv['u_integrated'][20:60] / 0.8,
                                    rtol=0.16)
 
+    def test_invert_hef_from_consensus(self):
+
+        hef_file = get_demo_file('Hintereisferner_RGI5.shp')
+        entity = gpd.read_file(hef_file).iloc[0]
+        entity['RGIId'] = 'RGI60-11.00897'
+        gdir = oggm.GlacierDirectory(entity, base_dir=self.testdir)
+        gis.define_glacier_region(gdir)
+        gis.glacier_masks(gdir)
+        centerlines.compute_centerlines(gdir)
+        centerlines.initialize_flowlines(gdir)
+        centerlines.catchment_area(gdir)
+        centerlines.catchment_width_geom(gdir)
+        centerlines.catchment_width_correction(gdir)
+        climate.process_custom_climate_data(gdir)
+        mbdf = gdir.get_ref_mb_data()
+        res = climate.t_star_from_refmb(gdir, mbdf=mbdf['ANNUAL_BALANCE'])
+        t_star, bias = res['t_star'], res['bias']
+        climate.local_t_star(gdir, tstar=t_star, bias=bias)
+        climate.mu_star_calibration(gdir)
+        inversion.prepare_for_inversion(gdir, add_debug_var=True)
+        df = workflow.calibrate_inversion_from_consensus_estimate(gdir)
+        np.testing.assert_allclose(df.vol_itmix_m3, df.vol_oggm_m3, rtol=0.01)
+
     def test_invert_hef_from_linear_mb(self):
 
         hef_file = get_demo_file('Hintereisferner_RGI5.shp')
@@ -2309,7 +2332,7 @@ class TestInversion(unittest.TestCase):
         fs = 5.7e-20
 
         def to_optimize(x):
-            v, _ = inversion.mass_conservation_inversion(gdir, fs=fs * x[1],
+            v = inversion.mass_conservation_inversion(gdir, fs=fs * x[1],
                                                          glen_a=glen_a * x[0])
             return (v - ref_v)**2
 
@@ -2323,7 +2346,7 @@ class TestInversion(unittest.TestCase):
         self.assertTrue(out[1] < 1.1)
         glen_a = glen_a * out[0]
         fs = fs * out[1]
-        v, _ = inversion.mass_conservation_inversion(gdir, fs=fs,
+        v = inversion.mass_conservation_inversion(gdir, fs=fs,
                                                      glen_a=glen_a,
                                                      write=True)
         np.testing.assert_allclose(ref_v, v)
@@ -2374,13 +2397,13 @@ class TestInversion(unittest.TestCase):
         climate.apparent_mb_from_linear_mb(gdir)
         inversion.prepare_for_inversion(gdir, add_debug_var=True)
         cls1 = gdir.read_pickle('inversion_input')
-        v1, _ = inversion.mass_conservation_inversion(gdir)
+        v1 = inversion.mass_conservation_inversion(gdir)
         # New should be equivalent
         mb_model = massbalance.LinearMassBalance(ela_h=1800, grad=3)
         climate.apparent_mb_from_any_mb(gdir, mb_model=mb_model,
                                         mb_years=np.arange(30))
         inversion.prepare_for_inversion(gdir, add_debug_var=True)
-        v2, _ = inversion.mass_conservation_inversion(gdir)
+        v2 = inversion.mass_conservation_inversion(gdir)
         cls2 = gdir.read_pickle('inversion_input')
 
         # Now the tests
@@ -2420,7 +2443,7 @@ class TestInversion(unittest.TestCase):
         def to_optimize(x):
             glen_a = cfg.PARAMS['inversion_glen_a'] * x[0]
             fs = cfg.PARAMS['inversion_fs'] * x[1]
-            v, _ = inversion.mass_conservation_inversion(gdir, fs=fs,
+            v = inversion.mass_conservation_inversion(gdir, fs=fs,
                                                          glen_a=glen_a)
             return (v - ref_v)**2
         import scipy.optimize as optimization
@@ -2429,7 +2452,7 @@ class TestInversion(unittest.TestCase):
                                     tol=1e-1)['x']
         glen_a = cfg.PARAMS['inversion_glen_a'] * out[0]
         fs = cfg.PARAMS['inversion_fs'] * out[1]
-        v, _ = inversion.mass_conservation_inversion(gdir, fs=fs,
+        v = inversion.mass_conservation_inversion(gdir, fs=fs,
                                                      glen_a=glen_a,
                                                      write=True)
         np.testing.assert_allclose(ref_v, v)
@@ -2482,7 +2505,7 @@ class TestInversion(unittest.TestCase):
         def to_optimize(x):
             glen_a = cfg.PARAMS['inversion_glen_a'] * x[0]
             fs = 0.
-            v, _ = inversion.mass_conservation_inversion(gdir, fs=fs,
+            v = inversion.mass_conservation_inversion(gdir, fs=fs,
                                                          glen_a=glen_a)
             return (v - ref_v)**2
 
@@ -2496,7 +2519,7 @@ class TestInversion(unittest.TestCase):
 
         glen_a = cfg.PARAMS['inversion_glen_a'] * out[0]
         fs = 0.
-        v, _ = inversion.mass_conservation_inversion(gdir, fs=fs,
+        v = inversion.mass_conservation_inversion(gdir, fs=fs,
                                                      glen_a=glen_a,
                                                      write=True)
         np.testing.assert_allclose(ref_v, v)
@@ -2525,7 +2548,7 @@ class TestInversion(unittest.TestCase):
         climate.local_t_star(gdir, tstar=t_star, bias=bias)
         climate.mu_star_calibration(gdir)
         inversion.prepare_for_inversion(gdir, add_debug_var=True)
-        v, _ = inversion.mass_conservation_inversion(gdir, fs=fs,
+        v = inversion.mass_conservation_inversion(gdir, fs=fs,
                                                      glen_a=glen_a,
                                                      write=True)
 
@@ -2866,7 +2889,7 @@ class TestGrindelInvert(unittest.TestCase):
 
         # Write out
         gdir.write_pickle(towrite, 'inversion_input')
-        v, a = inversion.mass_conservation_inversion(gdir, glen_a=glen_a)
+        v  = inversion.mass_conservation_inversion(gdir, glen_a=glen_a)
         np.testing.assert_allclose(v, model.volume_m3, rtol=0.01)
 
         cl = gdir.read_pickle('inversion_output')[0]
@@ -2892,7 +2915,7 @@ class TestGrindelInvert(unittest.TestCase):
         climate.local_t_star(gdir, tstar=1975, bias=0.)
         climate.mu_star_calibration(gdir)
         inversion.prepare_for_inversion(gdir)
-        v, a = inversion.mass_conservation_inversion(gdir, glen_a=glen_a)
+        v = inversion.mass_conservation_inversion(gdir, glen_a=glen_a)
         inversion.filter_inversion_output(gdir)
         flowline.init_present_time_glacier(gdir)
         mb_mod = massbalance.ConstantMassBalance(gdir)
@@ -3248,7 +3271,7 @@ class TestIdealizedGdir(unittest.TestCase):
         centerlines.catchment_width_correction(gdir)
         climate.apparent_mb_from_linear_mb(gdir)
         inversion.prepare_for_inversion(gdir, invert_all_rectangular=True)
-        v1, _ = inversion.mass_conservation_inversion(gdir)
+        v1 = inversion.mass_conservation_inversion(gdir)
         tt1 = gdir.read_pickle('inversion_input')[0]
         gdir1 = gdir
 
@@ -3261,7 +3284,7 @@ class TestIdealizedGdir(unittest.TestCase):
                                     base_dir=self.testdir)
         climate.apparent_mb_from_linear_mb(gdir)
         inversion.prepare_for_inversion(gdir, invert_all_rectangular=True)
-        v2, _ = inversion.mass_conservation_inversion(gdir)
+        v2 = inversion.mass_conservation_inversion(gdir)
 
         tt2 = gdir.read_pickle('inversion_input')[0]
         np.testing.assert_allclose(tt1['width'], tt2['width'])

--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -194,10 +194,11 @@ class TestFullRun(unittest.TestCase):
         assert np.all(dfc.tstar_aar.mean() > 0.5)
 
     @pytest.mark.slow
-    def test_calibrate_inversion(self):
+    def test_calibrate_inversion_from_consensus(self):
 
         gdirs = up_to_inversion()
-        df = workflow.calibrate_inversion_from_consensus_estimate(gdirs)
+        df = workflow.calibrate_inversion_from_consensus_estimate(gdirs,
+                                                                  ignore_missing=True)
         df = df.dropna()
         np.testing.assert_allclose(df.vol_itmix_m3.sum(),
                                    df.vol_oggm_m3.sum(),

--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -255,7 +255,7 @@ class TestFullRun(unittest.TestCase):
                         0.01)
         assert_allclose(df['inv_volume_km3'], df['start_volume_km3'], 0.04)
         assert_allclose(df['inv_volume_km3'].sum(),
-                        df['start_volume_km3'].sum(), 0.001)
+                        df['start_volume_km3'].sum(), 0.005)
         assert_allclose(df['main_flowline_length'], df['start_length'])
 
         workflow.execute_entity_task(flowline.run_random_climate, gdirs,

--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -252,7 +252,7 @@ class TestFullRun(unittest.TestCase):
             df.loc[gd.rgi_id, 'start_length'] = model.length_m
         assert_allclose(df['rgi_area_km2'], df['start_area_km2'], 0.06)
         assert_allclose(df['rgi_area_km2'].sum(), df['start_area_km2'].sum(),
-                        0.004)
+                        0.01)
         assert_allclose(df['inv_volume_km3'], df['start_volume_km3'], 0.04)
         assert_allclose(df['inv_volume_km3'].sum(),
                         df['start_volume_km3'].sum(), 0.001)

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -71,7 +71,7 @@ logger = logging.getLogger('.'.join(__name__.split('.')[:-1]))
 # The given commit will be downloaded from github and used as source for
 # all sample data
 SAMPLE_DATA_GH_REPO = 'OGGM/oggm-sample-data'
-SAMPLE_DATA_COMMIT = '40d1e12bce713ab1155d83e5f77b9e070151be41'
+SAMPLE_DATA_COMMIT = 'b0bd2f361ce305b7b9d2267abb405e1bd0cf3f4e'
 
 GDIR_URL = 'https://cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.1/'
 DEMO_GDIR_URL = 'https://cluster.klima.uni-bremen.de/~oggm/demo_gdirs/'


### PR DESCRIPTION
<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->

This adds a `workflow.calibrate_inversion_from_consensus_estimate` global task which matches the volume of all glaciers in a selection to that of the consensus estimate. In the EU Alps on the few glaciers I tested it settles on an A value about three times the default one (i.e. as expected for this region). Experience will show how it looks like on other regions.

CC @drounce  for future reference.

This is not (yet) all I want to do about the inversion, next PR is coming... 

- [x] Tests added/passed
- [x] Fully documented
- [x] Entry in `whats-new.rst` 
