### PR TITLE
Try to avoid random IO errors when writing to tar

### DIFF
--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -230,7 +230,7 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
 
     # Which DEM source?
     if dem_source.upper() == 'ALL':
-        # This is the complex one, just do the job an leave
+        # This is the complex one, just do the job and leave
         log.workflow('Running prepro on ALL sources')
         for i, s in enumerate(utils.DEM_SOURCES):
             rs = i == 0
@@ -430,6 +430,8 @@ def parse_args(args):
         if rgi_reg is None:
             raise InvalidParamsError('--rgi-reg is required!')
     rgi_reg = '{:02}'.format(int(rgi_reg))
+    if rgi_reg not in ['{:02}'.format(int(r)) for r in range(1, 20)]:
+        raise InvalidParamsError('--rgi-reg should range from 01 to 19!')
 
     rgi_version = args.rgi_version
 

--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -430,7 +430,8 @@ def parse_args(args):
         if rgi_reg is None:
             raise InvalidParamsError('--rgi-reg is required!')
     rgi_reg = '{:02}'.format(int(rgi_reg))
-    if rgi_reg not in ['{:02}'.format(int(r)) for r in range(1, 20)]:
+    ok_regs = ['{:02}'.format(int(r)) for r in range(1, 20)]
+    if not args.demo and rgi_reg not in ok_regs:
         raise InvalidParamsError('--rgi-reg should range from 01 to 19!')
 
     rgi_version = args.rgi_version


### PR DESCRIPTION
<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->

@TimoRoth an example of error happening on cluster: 


```
2020-08-05 09:57:38: oggm.workflow: Execute entity task gdir_to_tar on 3537 glaciers
Traceback (most recent call last):
  File "/work/fmaussion/71/oggm_env/bin/oggm_prepro", line 8, in <module>
    sys.exit(main())
  File "/work/fmaussion/71/oggm_env/lib/python3.7/site-packages/oggm/cli/prepro_levels.py", line 470, in main
    run_prepro_levels(**parse_args(sys.argv[1:]))
  File "/work/fmaussion/71/oggm_env/lib/python3.7/site-packages/oggm/cli/prepro_levels.py", line 222, in run_prepro_levels
    utils.base_dir_to_tar(l_base_dir)
  File "/work/fmaussion/71/oggm_env/lib/python3.7/site-packages/oggm/utils/_workflow.py", line 2855, in base_dir_to_tar
    tar.add(dirname, arcname=os.path.basename(dirname))
  File "/usr/local/pyenv/versions/3.7.8/lib/python3.7/tarfile.py", line 1949, in add
    recursive, filter=filter)
  File "/usr/local/pyenv/versions/3.7.8/lib/python3.7/tarfile.py", line 1941, in add
    with bltn_open(name, "rb") as f:
FileNotFoundError: [Errno 2] No such file or directory: '/home/users/fmaussion/run_scripts/run_rgitopo/RGI62/b_010/L0/RGI60-12/RGI60-12.00/RGI60-12.00845.tar.gz'
srun: error: node06: task 0: Exited with exit code 1
srun: Terminating job step 71.0
```

This is truely random but happens quite often, at least once among the 19 RGI regions. It doesn't make sense because the file which is apparently "not there" should be created by the statement, so this has to be some OS or NFS issue not responding fast enough or something. 