### PR TITLE
Add option to override params.cfg parameters at initialize time

### DIFF
--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -406,10 +406,11 @@ def initialize_minimal(file=None, logging_level='INFO', params=None):
     PATHS['climate_file'] = cp['climate_file']
 
     # Ephemeral paths overrides
-    if os.environ.get('OGGM_WORKDIR') is not None:
-        PATHS['working_dir'] = os.environ.get('OGGM_WORKDIR')
-        log.workflow('Overriding initial working dir with OGGM_WORKDIR: ' +
-                     PATHS['working_dir'])
+    env_wd = os.environ.get('OGGM_WORKDIR')
+    if env_wd and not PATHS['working_dir']:
+        PATHS['working_dir'] = env_wd
+        log.workflow("PATHS['working_dir'] set to env variable $OGGM_WORKDIR: "
+                     + env_wd)
 
     # Do not spam
     PARAMS.do_log = False

--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -354,7 +354,7 @@ def set_logging_config(logging_level='INFO'):
                         level=getattr(logging, logging_level))
 
 
-def initialize_minimal(file=None, logging_level='INFO'):
+def initialize_minimal(file=None, logging_level='INFO', params=None):
     """Same as initialise() but without requiring any download of data.
 
     This is useful for "flowline only" OGGM applications
@@ -365,6 +365,8 @@ def initialize_minimal(file=None, logging_level='INFO'):
         path to the configuration file (default: OGGM params.cfg)
     logging_level : str
         set a logging level. See :func:`set_logging_config` for options.
+    params : dict
+        overrides for specific parameters from the config file
     """
     global IS_INITIALIZED
     global PARAMS
@@ -389,6 +391,11 @@ def initialize_minimal(file=None, logging_level='INFO'):
     else:
         log.workflow('Reading parameters from the user provided '
                      'configuration file: %s', file)
+
+    # Apply code-side manual params overrides
+    if params:
+        for k, v in params.items():
+            cp[k] = v
 
     # Paths
     oggm_static_paths()
@@ -531,7 +538,7 @@ def initialize_minimal(file=None, logging_level='INFO'):
     IS_INITIALIZED = True
 
 
-def initialize(file=None, logging_level='INFO'):
+def initialize(file=None, logging_level='INFO', params=None):
     """Read the configuration file containing the run's parameters.
 
     This should be the first call, before using any of the other OGGM modules
@@ -543,11 +550,13 @@ def initialize(file=None, logging_level='INFO'):
         path to the configuration file (default: OGGM params.cfg)
     logging_level : str
         set a logging level. See :func:`set_logging_config` for options.
+    params : dict
+        overrides for specific parameters from the config file
     """
     global PARAMS
     global DATA
 
-    initialize_minimal(file=file, logging_level=logging_level)
+    initialize_minimal(file=file, logging_level=logging_level, params=params)
 
     # Do not spam
     PARAMS.do_log = False

--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -392,16 +392,24 @@ def initialize_minimal(file=None, logging_level='INFO', params=None):
         log.workflow('Reading parameters from the user provided '
                      'configuration file: %s', file)
 
+    # Static Paths
+    oggm_static_paths()
+
     # Apply code-side manual params overrides
     if params:
         for k, v in params.items():
             cp[k] = v
 
     # Paths
-    oggm_static_paths()
     PATHS['working_dir'] = cp['working_dir']
     PATHS['dem_file'] = cp['dem_file']
     PATHS['climate_file'] = cp['climate_file']
+
+    # Ephemeral paths overrides
+    if os.environ.get('OGGM_WORKDIR') is not None:
+        PATHS['working_dir'] = os.environ.get('OGGM_WORKDIR')
+        log.workflow('Overriding initial working dir with OGGM_WORKDIR: ' +
+                     PATHS['working_dir'])
 
     # Do not spam
     PARAMS.do_log = False

--- a/oggm/cli/benchmark.py
+++ b/oggm/cli/benchmark.py
@@ -63,12 +63,15 @@ def run_benchmark(rgi_version=None, rgi_reg=None, border=None,
     # Module logger
     log = logging.getLogger(__name__)
 
-    # Initialize OGGM and set up the run parameters
-    cfg.initialize(logging_level='WORKFLOW')
+    # Params
+    params = {}
 
     # Local paths
     utils.mkdir(working_dir)
-    cfg.PATHS['working_dir'] = working_dir
+    params['working_dir'] = working_dir
+
+    # Initialize OGGM and set up the run parameters
+    cfg.initialize(logging_level='WORKFLOW', params=params)
 
     # Use multiprocessing?
     cfg.PARAMS['use_multiprocessing'] = True

--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -137,12 +137,15 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
         log.workflow('OGGM prepro_levels is done! Time needed: '
                      '{:02d}:{:02d}:{:02d}'.format(int(h), int(m), int(s)))
 
-    # Initialize OGGM and set up the run parameters
-    cfg.initialize(logging_level=logging_level)
+    # Config Override Params
+    params = {}
 
     # Local paths
     utils.mkdir(working_dir)
-    cfg.PATHS['working_dir'] = working_dir
+    params['working_dir'] = working_dir
+
+    # Initialize OGGM and set up the run parameters
+    cfg.initialize(logging_level=logging_level, params=params)
 
     # Use multiprocessing?
     cfg.PARAMS['use_multiprocessing'] = not disable_mp

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -270,11 +270,14 @@ def _cached_download_helper(cache_obj_name, dl_func, reset=False):
     """
     cache_dir = cfg.PATHS['dl_cache_dir']
     cache_ro = cfg.PARAMS['dl_cache_readonly']
-    try:
+
+    # A lot of logic below could be simplified but it's also not too important
+    wd = cfg.PATHS.get('working_dir')
+    if wd:
         # this is for real runs
-        fb_cache_dir = os.path.join(cfg.PATHS['working_dir'], 'cache')
+        fb_cache_dir = os.path.join(wd, 'cache')
         check_fb_dir = False
-    except KeyError:
+    else:
         # Nothing have been set up yet, this is bad - find a place to write
         # This should happen on read-only cluster only but still
         wd = os.environ.get('OGGM_WORKDIR')


### PR DESCRIPTION
This should avoid the weird corner-case where cfg.initialize relies on config variables the script in question might set later on.

Also implements its use in prepro_cli.