### PR TITLE
change how the length of a glacier is calculated

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -53,6 +53,10 @@ Breaking changes
 - the `vascaling` module has been removed from oggm core (:pull:`1065`). It
   is now available via a separate package (`oggm-vas <https://github.com/OGGM/oggm-vas>`_,
   maintained by Moritz Oberrauch).
+- new options to compute the length of a glacier during a run:
+  `PARAMS['min_ice_thick_for_length']` and `PARAMS['glacier_length_method']`
+  (:pull:`1069`). By `Matthias Dusch <https://github.com/matthiasdusch>`_.
+
 
 Enhancements
 ~~~~~~~~~~~~

--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -516,6 +516,8 @@ def initialize_minimal(file=None, logging_level='INFO', params=None):
     # Flowline model
     k = 'use_shape_factor_for_fluxbasedmodel'
     PARAMS[k] = cp[k]
+    k = 'glacier_length_method'
+    PARAMS[k] = cp[k]
 
     # Delete non-floats
     ltr = ['working_dir', 'dem_file', 'climate_file', 'use_tar_shapefiles',
@@ -533,7 +535,7 @@ def initialize_minimal(file=None, logging_level='INFO', params=None):
            'use_shape_factor_for_fluxbasedmodel', 'baseline_climate',
            'calving_line_extension', 'use_kcalving_for_run', 'lru_maxsize',
            'free_board_marine_terminating', 'use_kcalving_for_inversion',
-           'error_when_glacier_reaches_boundaries']
+           'error_when_glacier_reaches_boundaries', 'glacier_length_method']
     for k in ltr:
         cp.pop(k, None)
 

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -128,12 +128,12 @@ class Flowline(Centerline):
         lt = cfg.PARAMS.get('min_ice_thick_for_length', 0)
         if cfg.PARAMS.get('glacier_length_method') == 'consecutive':
             if (self.thick > lt).all():
-                pok = self.thick
+                nx = len(self.thick)
             else:
-                pok = np.where(self.thick <= lt)[0]
+                nx = np.where(self.thick <= lt)[0][0]
         else:
-            pok = np.where(self.thick > lt)[0]
-        return len(pok) * self.dx_meter
+            nx = len(np.where(self.thick > lt)[0])
+        return nx * self.dx_meter
 
     @property
     def volume_m3(self):

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -88,9 +88,6 @@ class Flowline(Centerline):
         self.rgi_id = rgi_id
         self.water_level = water_level
 
-        self._consecutive_length = cfg.PARAMS['glacier_length_method'] == 'consecutive'
-        self._length_t = cfg.PARAMS['min_ice_thick_for_length']
-
         # volume not yet removed from the flowline
         self.calving_bucket_m3 = 0
 
@@ -128,13 +125,14 @@ class Flowline(Centerline):
     @property
     def length_m(self):
         # TODO: take calving bucket into account for fine tuned length?
-        if self._consecutive_length:
-            if (self.thick > self._length_t).all():
+        lt = cfg.PARAMS.get('min_ice_thick_for_length', 0)
+        if cfg.PARAMS.get('glacier_length_method') == 'consecutive':
+            if (self.thick > lt).all():
                 pok = self.thick
             else:
-                pok = np.where(self.thick <= self._length_t)[0]
+                pok = np.where(self.thick <= lt)[0]
         else:
-            pok = np.where(self.thick > self._length_t)[0]
+            pok = np.where(self.thick > lt)[0]
         return len(pok) * self.dx_meter
 
     @property
@@ -1698,9 +1696,6 @@ class FileModel(object):
 
         self.last_yr = ds.year.values[-1]
         self.dss = dss
-
-        self._consecutive_length = cfg.PARAMS['glacier_length_method'] == 'consecutive'
-        self._length_t = cfg.PARAMS['min_ice_thick_for_length']
 
         # Calving diags
         try:

--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -289,7 +289,7 @@ min_ice_thick_for_length = 0
 # How to calculate the length of a glacier?
 # - 'naive' (the default) computes the length by summing the number of
 #   grid points with an ice thickness above min_ice_thick_for_length
-# - '' computes the length by summing the number of grid
+# - 'consecutive' computes the length by summing the number of grid
 #   points that are dynamically connected to the top of the glacier
 # 'consecutive' better corresponds to what we would intuitively
 # define as glacier length, but it can create large steps in the

--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -279,6 +279,24 @@ cfl_number = 0.02
 cfl_min_dt = 60
 # Allow the glacier to grow larger than domain?
 error_when_glacier_reaches_boundaries = True
+# Glacier length computation
+# Glacier "length" is not as unambiguously done as glacier volume or area
+# Our defaults might not be the best for your use case. Here we provide
+# some options to the user.
+# This option sets an arbitrary limit on how thick (m) a glacier should be
+# to be defined as "glacier" (https://github.com/OGGM/oggm/issues/914)
+min_ice_thick_for_length = 1
+# How to calculate the length of a glacier?
+# - 'naive' (the default) computes the length by summing the number of
+#   grid points with an ice thickness above min_ice_thick_for_length
+# - '' computes the length by summing the number of grid
+#   points that are dynamically connected to the top of the glacier
+# 'consecutive' better corresponds to what we would intuitively
+# define as glacier length, but it can create large steps in the
+# length record in melt scenarios where the tongue gets disconnected
+# (dead ice) or when tributaries are providing ice to the
+# main branch at lower altitudes than the main branch's ice flow.
+glacier_length_method = naive
 
 ### Tidewater glaciers options
 # Should we switch on the k-calving parameterisation for tidewater glaciers?

--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -285,7 +285,7 @@ error_when_glacier_reaches_boundaries = True
 # some options to the user.
 # This option sets an arbitrary limit on how thick (m) a glacier should be
 # to be defined as "glacier" (https://github.com/OGGM/oggm/issues/914)
-min_ice_thick_for_length = 1
+min_ice_thick_for_length = 0
 # How to calculate the length of a glacier?
 # - 'naive' (the default) computes the length by summing the number of
 #   grid points with an ice thickness above min_ice_thick_for_length

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -797,6 +797,7 @@ class TestModelFlowlines():
         widths = bed_h * 0. + 20
         widths[:30] = 40
         widths[-30:] = 10
+        ref_l = 18000
 
         rec = RectangularBedFlowline(line=line, dx=dx, map_dx=map_dx,
                                      surface_h=surface_h, bed_h=bed_h,
@@ -817,6 +818,7 @@ class TestModelFlowlines():
         assert_allclose(rec.section, section)
         assert_allclose(rec.area_m2, area_m2.sum())
         assert_allclose(rec.volume_m3, vol_m3.sum())
+        assert_allclose(rec.length_m, ref_l)
 
         # We set something and everything stays same
         rec.thick = thick
@@ -827,6 +829,7 @@ class TestModelFlowlines():
         assert_allclose(rec.section, section)
         assert_allclose(rec.area_m2, area_m2.sum())
         assert_allclose(rec.volume_m3, vol_m3.sum())
+        assert_allclose(rec.length_m, ref_l)
         rec.section = section
         assert_allclose(rec.thick, thick)
         assert_allclose(rec.surface_h, surface_h)
@@ -835,6 +838,7 @@ class TestModelFlowlines():
         assert_allclose(rec.section, section)
         assert_allclose(rec.area_m2, area_m2.sum())
         assert_allclose(rec.volume_m3, vol_m3.sum())
+        assert_allclose(rec.length_m, ref_l)
         rec.surface_h = surface_h
         assert_allclose(rec.thick, thick)
         assert_allclose(rec.surface_h, surface_h)
@@ -843,6 +847,7 @@ class TestModelFlowlines():
         assert_allclose(rec.section, section)
         assert_allclose(rec.area_m2, area_m2.sum())
         assert_allclose(rec.volume_m3, vol_m3.sum())
+        assert_allclose(rec.length_m, ref_l)
 
         # More adventurous
         rec.section = section / 2

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -1387,7 +1387,8 @@ class TestIO():
 
             np.testing.assert_allclose(fmodel.volume_m3_ts(), vol_ref)
             np.testing.assert_allclose(fmodel.area_m2_ts(), a_ref)
-            np.testing.assert_allclose(fmodel.length_m_ts(), l_ref)
+            with pytest.raises(NotImplementedError):
+                fmodel.length_m_ts()
 
             # Can we start a run from the middle?
             fmodel.run_until(300)
@@ -1397,6 +1398,8 @@ class TestIO():
             fmodel.run_until(500)
             np.testing.assert_allclose(model.fls[0].section,
                                        fmodel.fls[0].section)
+            np.testing.assert_allclose(model.fls[0].thick,
+                                       fmodel.fls[0].thick)
 
     @pytest.mark.slow
     def test_calving_filemodel(self, class_case_dir):
@@ -1427,7 +1430,6 @@ class TestIO():
 
             np.testing.assert_allclose(fmodel.volume_m3_ts(), diag.volume_m3)
             np.testing.assert_allclose(fmodel.area_m2_ts(), diag.area_m2)
-            np.testing.assert_allclose(fmodel.length_m_ts(), diag.length_m)
 
             fmodel.run_until(y1)
             assert_allclose(fmodel.volume_m3 + fmodel.calving_m3_since_y0,
@@ -1510,7 +1512,6 @@ class TestIO():
 
             np.testing.assert_allclose(fmodel.volume_m3_ts(), vol_ref)
             np.testing.assert_allclose(fmodel.area_m2_ts(), a_ref)
-            np.testing.assert_allclose(fmodel.length_m_ts(), l_ref)
 
             # Can we start a run from the middle?
             fmodel.run_until(300)
@@ -2571,22 +2572,12 @@ class TestHEF:
         for path in paths:
             with FileModel(path) as model:
                 vol = model.volume_km3_ts()
-                len = model.length_m_ts()
                 area = model.area_km2_ts()
                 np.testing.assert_allclose(vol.iloc[0], np.mean(vol),
                                            rtol=0.12)
                 np.testing.assert_allclose(area.iloc[0], np.mean(area),
                                            rtol=0.1)
-                if do_plot:
-                    fig, (ax1, ax2, ax3) = plt.subplots(3, 1, figsize=(6, 10))
-                    vol.plot(ax=ax1)
-                    ax1.set_title('Volume')
-                    area.plot(ax=ax2)
-                    ax2.set_title('Area')
-                    len.plot(ax=ax3)
-                    ax3.set_title('Length')
-                    plt.tight_layout()
-                    plt.show()
+
 
     @pytest.mark.slow
     def test_random_sh(self, gdir_sh, hef_gdir):
@@ -2619,22 +2610,11 @@ class TestHEF:
         for path in paths:
             with FileModel(path) as model:
                 vol = model.volume_km3_ts()
-                len = model.length_m_ts()
                 area = model.area_km2_ts()
                 np.testing.assert_allclose(vol.iloc[0], np.mean(vol),
                                            rtol=0.1)
                 np.testing.assert_allclose(area.iloc[0], np.mean(area),
                                            rtol=0.1)
-                if do_plot:
-                    fig, (ax1, ax2, ax3) = plt.subplots(3, 1, figsize=(6, 10))
-                    vol.plot(ax=ax1)
-                    ax1.set_title('Volume')
-                    area.plot(ax=ax2)
-                    ax2.set_title('Area')
-                    len.plot(ax=ax3)
-                    ax3.set_title('Length')
-                    plt.tight_layout()
-                    plt.show()
 
         # Test a SH/NH mix
         init_present_time_glacier(gdir)

--- a/oggm/tests/test_numerics.py
+++ b/oggm/tests/test_numerics.py
@@ -131,6 +131,26 @@ class TestIdealisedCases(unittest.TestCase):
         assert utils.rmsd(surface_h[0], surface_h[2]) < 1.0
         assert utils.rmsd(surface_h[1], surface_h[2]) < 1.0
 
+    def test_length(self):
+
+        mb = LinearMassBalance(2600.)
+        yrs = np.arange(1, 300, 2)
+
+        model = FluxBasedModel(dummy_constant_bed(), mb_model=mb, y0=0.)
+        length_1 = yrs * 0.
+        for i, y in enumerate(yrs):
+            model.run_until(y)
+            length_1[i] = model.length_m
+
+        cfg.PARAMS['glacier_length_method'] = 'consecutive'
+        model = FluxBasedModel(dummy_constant_bed(), mb_model=mb, y0=0.)
+        length_2 = yrs * 0.
+        for i, y in enumerate(yrs):
+            model.run_until(y)
+            length_2[i] = model.length_m
+
+        np.testing.assert_allclose(length_1, length_2)
+
     @pytest.mark.slow
     def test_mass_conservation(self):
 

--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -269,11 +269,9 @@ class TestFullRun(unittest.TestCase):
             with flowline.FileModel(path) as model:
                 vol = model.volume_km3_ts()
                 area = model.area_km2_ts()
-                length = model.length_m_ts()
 
                 self.assertTrue(np.all(np.isfinite(vol) & vol != 0.))
                 self.assertTrue(np.all(np.isfinite(area) & area != 0.))
-                self.assertTrue(np.all(np.isfinite(length) & length != 0.))
 
             ds_diag = gd.get_filepath('model_diagnostics', filesuffix='_test')
             ds_diag = xr.open_dataset(ds_diag)
@@ -282,9 +280,6 @@ class TestFullRun(unittest.TestCase):
             assert_allclose(df.RUN, df.DIAG)
             df = area.to_frame('RUN')
             df['DIAG'] = ds_diag.area_m2.to_series() * 1e-6
-            assert_allclose(df.RUN, df.DIAG)
-            df = length.to_frame('RUN')
-            df['DIAG'] = ds_diag.length_m.to_series()
             assert_allclose(df.RUN, df.DIAG)
 
         # Test output


### PR DESCRIPTION
Currently the `length_m` property of a FlowlineModel calculates the length of the main flowline based on every glaciated grid point.  If this flowline is sperated (ice free) at some point this will still take into account the "dead" ice further downstream.

Problems with current implementation:
If there is long lasting dead ice downstream while the main glaicer retreats this is not (or less) reflected in the length property.
This happens for me in two cases:
i) if two glaciers are merged and one of them behaves quite differently due to wrong calibration. This is a rather individual problem and I could also calculate the glacier length seperately.
ii) Probably more likely: I have also seen this for strongly retreating glaciers with steep slopes above a flat tongue. Here the ice on the slopes might vanish before the tongue is completely melted. 

Proposed fix:
Calculate the glacier length as the continuous ice along the main flowline. 

Problems/Implications of the fix:
E.g. if the flowline seperates for a short time period this could cause strong fluctuations in the time series.

Still to consider:
What about volume? 


A chance to also close #914
I am happy to take suggestions for minimum thickness of a glacier...

- [ ] Tests added/passed
- [ ] Fully documented
- [ ] Entry in `whats-new.rst` 

@fmaussion, @lilianschuster