### PR TITLE
Change default DEM sources for ALL glaciers

### DIFF
--- a/docs/input-data.rst
+++ b/docs/input-data.rst
@@ -317,23 +317,23 @@ Topography data
 ~~~~~~~~~~~~~~~
 
 When creating a :ref:`glacierdir` a suitable topographical data source is
-chosen automatically, depending on the glacier's location. Currently we use:
+chosen automatically, depending on the glacier's location. OGGM supports
+a large number of datasets (almost all of the freely available ones, we
+hope). They are listed on the
+`RGI-TOPO <https://rgitools.readthedocs.io/en/latest/dems.html>`_ website.
 
-- the `Shuttle Radar Topography Mission`_ (SRTM) 90m Digital Elevation Database v4.1
-  for all locations in the [60°S; 60°N] range
-- the `Greenland Mapping Project`_ (GIMP) Digital Elevation Model
-  for mountain glaciers in Greenland (RGI region 05)
-- the `Radarsat Antarctic Mapping Project`_ (RAMP) Digital Elevation Model, Version 2
-  for mountain glaciers in the Antarctic continent
-  (RGI region 19 with the exception of the peripheral islands)
-- the `Viewfinder Panoramas DEM3`_ products
-  elsewhere (most notably: North America, Russia, Iceland, Svalbard)
+The current default is to use the following datasets:
 
+- NASADEM: 60°S-60°N
+- COPDEM: Global, with missing regions (islands, etc.)
+- GIMP, REMA: Regional datasets
+- TANDEM: Global, with artefacts / missing data
+- MAPZEN: Global, when all other things failed
 
-.. _Shuttle Radar Topography Mission: http://srtm.csi.cgiar.org/
-.. _Greenland Mapping Project: https://bpcrc.osu.edu/gdg/data/gimpdem
-.. _Radarsat Antarctic Mapping Project: http://nsidc.org/data/nsidc-0082
-.. _Viewfinder Panoramas DEM3: http://viewfinderpanoramas.org/dem3.html
+These data are chosen in the provided order. If a dataset is not available,
+the next on the list will be tested: if the tested dataset covers
+75% of the glacier area, it is selected. In practice, NASADEM and COPDEM
+are sufficient for all but about 300 of the world's glaciers.
 
 These data are downloaded only when needed (i.e.: during an OGGM run)
 and they are stored in the ``dl_cache_dir``

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -40,6 +40,9 @@ Breaking changes
 - The order of the tasks applied to  the preprocessed levels has
   changed, climate data comes in later (:pull:`1038`).
   By `Fabien Maussion <https://github.com/fmaussion>`_
+- The default DEMS used for each glacier have changed for more modern ones
+  (:pull:`1073`).
+  By `Fabien Maussion <https://github.com/fmaussion>`_
 - The inversion tasks now can invert for trapezoid shapes (:pull:`1045`). This
   has non-trivial consequences for the model workflow. First and foremost,
   the decision about using a trapezoid bed (instead of parabolic when the

--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -46,9 +46,11 @@ CONFIG_MODIFIED = False
 
 # Share state accross processes
 DL_VERIFIED = Manager().dict()
+DEM_SOURCE_TABLE = Manager().dict()
 
 # Machine epsilon
 FLOAT_EPS = np.finfo(float).eps
+
 
 class DocumentedDict(dict):
     """Quick "magic" to document the BASENAMES entries."""

--- a/oggm/core/gis.py
+++ b/oggm/core/gis.py
@@ -310,8 +310,7 @@ def define_glacier_region(gdir, entity=None, source=None):
         raise InvalidDEMError('Source: {} not available for glacier {}'
                               .format(source, gdir.rgi_id))
     dem_list, dem_source = get_topo_file((minlon, maxlon), (minlat, maxlat),
-                                         rgi_region=gdir.rgi_region,
-                                         rgi_subregion=gdir.rgi_subregion,
+                                         rgi_id=gdir.rgi_id,
                                          dx_meter=dx,
                                          source=source)
     log.debug('(%s) DEM source: %s', gdir.rgi_id, dem_source)


### PR DESCRIPTION
<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->

OK let's just do this. 

This PR adds a new file to sample-data which contains all of the glaciers DEM data availability based on RGI-TOPO.

Based on this table, OGGM now decided the DEM by checking which source is available in the following order: 'NASADEM', 'COPDEM', 'GIMP', 'REMA', 'TANDEM', 'MAPZEN'

A source is available is > 75% of the glacier area has valid data.

It is a big change because almost all glaciers will recieve new data. SRTM -> NASADEM, DEM3 -> COPDEM. the other sources are only necessary for a few hundreds of glaciers.

- [x] Tests added/passed
- [x] Fully documented
- [x] Entry in `whats-new.rst` 
