### PR TITLE
Add sanity checks in inversion

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,7 +24,7 @@ jobs:
           - workflow-multi
           - graphics-mpl
         container:
-          - oggm/untested_base:20200723
+          - oggm/untested_base:20201101
           - oggm/untested_base:py36
         include:
           - container: python:3.7-slim

--- a/oggm/core/climate.py
+++ b/oggm/core/climate.py
@@ -11,7 +11,7 @@ import xarray as xr
 import netCDF4
 import pandas as pd
 from scipy import stats
-from scipy import optimize as optimization
+from scipy import optimize
 
 # Optional libs
 try:
@@ -28,6 +28,9 @@ from oggm.exceptions import MassBalanceCalibrationError, InvalidParamsError
 
 # Module logger
 log = logging.getLogger(__name__)
+
+# Parameters
+_brentq_xtol = 2e-12
 
 
 @entity_task(log, writes=['climate_historical'])
@@ -1033,11 +1036,11 @@ def _recursive_mu_star_calibration(gdir, fls, t_star, first_call=True,
 
     if force_mu is None:
         try:
-            mu_star = optimization.brentq(_mu_star_per_minimization,
-                                          cfg.PARAMS['min_mu_star'],
-                                          cfg.PARAMS['max_mu_star'],
-                                          args=(fls, cmb, temp, prcp, widths),
-                                          xtol=1e-5)
+            mu_star = optimize.brentq(_mu_star_per_minimization,
+                                      cfg.PARAMS['min_mu_star'],
+                                      cfg.PARAMS['max_mu_star'],
+                                      args=(fls, cmb, temp, prcp, widths),
+                                      xtol=_brentq_xtol)
         except ValueError:
             # This happens in very rare cases
             _mu_lim = _mu_star_per_minimization(cfg.PARAMS['min_mu_star'],
@@ -1235,27 +1238,22 @@ def apparent_mb_from_linear_mb(gdir, mb_gradient=3., ela_h=None):
     # Now find the ELA till the integrated mb is zero
     from oggm.core.massbalance import LinearMassBalance
 
-    rho = cfg.PARAMS['ice_density']
-    fls = gdir.read_pickle('inversion_flowlines')
-    # Reset flux
-    for fl in fls:
-        fl.flux = np.zeros(len(fl.surface_h))
-
     def to_minimize(ela_h):
         mbmod = LinearMassBalance(ela_h, grad=mb_gradient)
         smb = mbmod.get_specific_mb(heights=h, widths=w)
         return smb - cmb
 
     if ela_h is None:
-        ela_h = optimization.brentq(to_minimize, -1e5, 1e5, xtol=1e-5)
-
-    mbmod = LinearMassBalance(ela_h, grad=mb_gradient)
+        ela_h = optimize.brentq(to_minimize, -1e5, 1e5, xtol=_brentq_xtol)
 
     # For each flowline compute the apparent MB
+    rho = cfg.PARAMS['ice_density']
+    fls = gdir.read_pickle('inversion_flowlines')
     # Reset flux
     for fl in fls:
         fl.flux = np.zeros(len(fl.surface_h))
     # Flowlines in order to be sure
+    mbmod = LinearMassBalance(ela_h, grad=mb_gradient)
     for fl in fls:
         mbz = mbmod.get_annual_mb(fl.surface_h) * cfg.SEC_IN_YEAR * rho
         fl.set_apparent_mb(mbz)
@@ -1305,7 +1303,7 @@ def apparent_mb_from_any_mb(gdir, mb_model=None, mb_years=None):
         smb = np.mean(smb) + residual
         return smb - cmb
 
-    residual = optimization.brentq(to_minimize, -1e5, 1e5, xtol=1e-5)
+    residual = optimize.brentq(to_minimize, -1e5, 1e5, xtol=_brentq_xtol)
 
     # Reset flux
     for fl in fls:

--- a/oggm/core/inversion.py
+++ b/oggm/core/inversion.py
@@ -93,6 +93,10 @@ def prepare_for_inversion(gdir, add_debug_var=False,
             log.info('(%s) has negative flux somewhere', gdir.rgi_id)
         utils.clip_min(flux, 0, out=flux)
 
+        if np.sum(flux <= 0) > 1:
+            raise RuntimeError("More than one grid point has zero or "
+                               "negative flux: this should not happen.")
+
         if fl.flows_to is None and gdir.inversion_calving_rate == 0:
             if not np.allclose(flux[-1], 0., atol=0.1):
                 # TODO: this test doesn't seem meaningful here
@@ -524,6 +528,11 @@ def mass_conservation_inversion(gdir, glen_a=None, fs=None, write=True,
                     is_rect[i] = True
                     is_trap[i] = False
                     volume[i] = out_thick[i] * w[i] * cl['dx']
+
+        # Sanity check
+        if np.any(out_thick <= 0):
+            raise RuntimeError("Found zero or negative thickness: "
+                               "this should not happen.")
 
         if write:
             cl['is_trapezoid'] = is_trap

--- a/oggm/core/inversion.py
+++ b/oggm/core/inversion.py
@@ -115,6 +115,10 @@ def prepare_for_inversion(gdir, add_debug_var=False,
             # task afterwards
             flux[-1] = flux[-2] / 3  # this is totally arbitrary
 
+        if fl.flows_to is not None and flux[-1] <= 0:
+            # Same for tributaries
+            flux[-1] = flux[-2] / 3  # this is totally arbitrary
+
         # Shape
         is_rectangular = fl.is_rectangular
         if not invert_with_rectangular:

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -1817,7 +1817,7 @@ class TestIdealisedInversion():
 
         fls = []
         for fl in model.fls:
-            pg = np.where(fl.thick > 0)
+            pg = np.where((fl.thick > 0) & (fl.widths_m > 1))
             line = shpg.LineString([fl.line.coords[int(p)] for p in pg[0]])
             flo = centerlines.Centerline(line, dx=fl.dx,
                                          surface_h=fl.surface_h[pg])
@@ -1898,7 +1898,7 @@ class TestIdealisedInversion():
 
         fls = []
         for fl in model.fls:
-            pg = np.where(fl.thick > 0)
+            pg = np.where((fl.thick > 0) & (fl.widths_m > 1))
             line = shpg.LineString([fl.line.coords[int(p)] for p in pg[0]])
             flo = centerlines.Centerline(line, dx=fl.dx,
                                          surface_h=fl.surface_h[pg])
@@ -1958,7 +1958,7 @@ class TestIdealisedInversion():
 
         fls = []
         for fl in model.fls:
-            pg = np.where(fl.thick > 0)
+            pg = np.where((fl.thick > 0) & (fl.widths_m > 1))
             line = shpg.LineString([fl.line.coords[int(p)] for p in pg[0]])
             flo = centerlines.Centerline(line, dx=fl.dx,
                                          surface_h=fl.surface_h[pg])
@@ -2014,7 +2014,7 @@ class TestIdealisedInversion():
 
         fls = []
         for fl in model.fls:
-            pg = np.where(fl.thick > 0)
+            pg = np.where((fl.thick > 0) & (fl.widths_m > 1))
             line = shpg.LineString([fl.line.coords[int(p)] for p in pg[0]])
             sh = fl.surface_h[pg]
             flo = centerlines.Centerline(line, dx=fl.dx,
@@ -2043,7 +2043,7 @@ class TestIdealisedInversion():
         model.run_until_equilibrium()
         fls = []
         for fl in model.fls:
-            pg = np.where(fl.thick > 0)
+            pg = np.where((fl.thick > 0) & (fl.widths_m > 1))
             line = shpg.LineString([fl.line.coords[int(p)] for p in pg[0]])
             sh = fl.surface_h[pg]
             flo = centerlines.Centerline(line, dx=fl.dx,
@@ -2078,7 +2078,7 @@ class TestIdealisedInversion():
         model.run_until_equilibrium()
         fls = []
         for fl in model.fls:
-            pg = np.where(fl.thick > 0)
+            pg = np.where((fl.thick > 0) & (fl.widths_m > 1))
             line = shpg.LineString([fl.line.coords[int(p)] for p in pg[0]])
             sh = fl.surface_h[pg]
             flo = centerlines.Centerline(line, dx=fl.dx,
@@ -2116,7 +2116,7 @@ class TestIdealisedInversion():
         model.run_until_equilibrium()
         fls = []
         for fl in model.fls:
-            pg = np.where(fl.thick > 0)
+            pg = np.where((fl.thick > 0) & (fl.widths_m > 1))
             line = shpg.LineString([fl.line.coords[int(p)] for p in pg[0]])
             sh = fl.surface_h[pg]
             flo = centerlines.Centerline(line, dx=fl.dx,
@@ -2146,7 +2146,7 @@ class TestIdealisedInversion():
         model.run_until_equilibrium()
         fls = []
         for fl in model.fls:
-            pg = np.where(fl.thick > 0)
+            pg = np.where((fl.thick > 0) & (fl.widths_m > 1))
             line = shpg.LineString([fl.line.coords[int(p)] for p in pg[0]])
             sh = fl.surface_h[pg]
             flo = centerlines.Centerline(line, dx=fl.dx,
@@ -2179,7 +2179,7 @@ class TestIdealisedInversion():
         model.run_until_equilibrium()
         fls = []
         for fl in model.fls:
-            pg = np.where(fl.thick > 0)
+            pg = np.where((fl.thick > 0) & (fl.widths_m > 1))
             line = shpg.LineString([fl.line.coords[int(p)] for p in pg[0]])
             sh = fl.surface_h[pg]
             flo = centerlines.Centerline(line, dx=fl.dx,
@@ -2216,7 +2216,7 @@ class TestIdealisedInversion():
         model.run_until_equilibrium()
         fls = []
         for fl in model.fls:
-            pg = np.where(fl.thick > 0)
+            pg = np.where((fl.thick > 0) & (fl.widths_m > 1))
             line = shpg.LineString([fl.line.coords[int(p)] for p in pg[0]])
             sh = fl.surface_h[pg]
             flo = centerlines.Centerline(line, dx=fl.dx,
@@ -2247,7 +2247,7 @@ class TestIdealisedInversion():
 
         fls = []
         for fl in model.fls:
-            pg = np.where(fl.thick > 0)
+            pg = np.where((fl.thick > 0) & (fl.widths_m > 1))
             line = shpg.LineString([fl.line.coords[int(p)] for p in pg[0]])
             sh = fl.surface_h[pg]
             flo = centerlines.Centerline(line, dx=fl.dx,
@@ -2286,7 +2286,7 @@ class TestIdealisedInversion():
 
         fls = []
         for fl in model.fls:
-            pg = np.where(fl.thick > 0)
+            pg = np.where((fl.thick > 0) & (fl.widths_m > 1))
             line = shpg.LineString([fl.line.coords[int(p)] for p in pg[0]])
             sh = fl.surface_h[pg]
             flo = centerlines.Centerline(line, dx=fl.dx,
@@ -2327,7 +2327,7 @@ class TestIdealisedInversion():
 
         fls = []
         for fl in model.fls:
-            pg = np.where(fl.thick > 0)
+            pg = np.where((fl.thick > 0) & (fl.widths_m > 1))
             line = shpg.LineString([fl.line.coords[int(p)] for p in pg[0]])
             sh = fl.surface_h[pg]
             flo = centerlines.Centerline(line, dx=fl.dx,
@@ -2365,7 +2365,7 @@ class TestIdealisedInversion():
 
         fls = []
         for fl in model.fls:
-            pg = np.where(fl.thick > 0)
+            pg = np.where((fl.thick > 0) & (fl.widths_m > 1))
             line = shpg.LineString([fl.line.coords[int(p)] for p in pg[0]])
             sh = fl.surface_h[pg]
             flo = centerlines.Centerline(line, dx=fl.dx,
@@ -2396,7 +2396,7 @@ class TestIdealisedInversion():
         model.run_until_equilibrium()
         fls = []
         for fl in model.fls:
-            pg = np.where(fl.thick > 0)
+            pg = np.where((fl.thick > 0) & (fl.widths_m > 1))
             line = shpg.LineString([fl.line.coords[int(p)] for p in pg[0]])
             sh = fl.surface_h[pg]
             flo = centerlines.Centerline(line, dx=fl.dx,


### PR DESCRIPTION


<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->

This now prevents ice thickness to be non-zero after inversion by raising an error if this happens.

If this error happens, we have to find out why and address the issue upstream (the flux computation)
