### PR TITLE
Monster lockdown push PR: ERA5, calving, and more

### DIFF
--- a/docs/run_examples/_code/mb_crossval.py
+++ b/docs/run_examples/_code/mb_crossval.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 rgi_version = '62'
 
 # Initialize OGGM and set up the run parameters
-cfg.initialize(logging_level='WORKFLOW')
+cfg.initialize(logging_level='ERROR')
 
 # Local paths (where to find the OGGM run output)
 dirname = 'OGGM_ref_mb_RGIV{}_OGGM{}'.format(rgi_version, oggm.__version__)

--- a/docs/run_examples/_code/run_errors.py
+++ b/docs/run_examples/_code/run_errors.py
@@ -13,7 +13,7 @@ start = time.time()
 log = logging.getLogger(__name__)
 
 # Initialize OGGM and set up the default run parameters
-cfg.initialize(logging_level='WORKFLOW')
+cfg.initialize(logging_level='ERROR')
 
 # Here we override some of the default parameters
 # How many grid points around the glacier?

--- a/docs/run_examples/_code/run_inversion.py
+++ b/docs/run_examples/_code/run_inversion.py
@@ -16,7 +16,7 @@ start = time.time()
 log = logging.getLogger(__name__)
 
 # Initialize OGGM and set up the default run parameters
-cfg.initialize(logging_level='WORKFLOW')
+cfg.initialize(logging_level='ERROR')
 rgi_version = '61'
 rgi_region = '11'  # Region Central Europe
 

--- a/docs/run_examples/_code/run_reference_mb_glaciers.py
+++ b/docs/run_examples/_code/run_reference_mb_glaciers.py
@@ -26,7 +26,7 @@ rgi_version = '62'
 reset = False
 
 # Initialize OGGM and set up the run parameters
-cfg.initialize(logging_level='WORKFLOW')
+cfg.initialize(logging_level='ERROR')
 
 # Local paths (where to write the OGGM run output)
 dirname = 'OGGM_ref_mb_RGIV{}_OGGM{}'.format(rgi_version, oggm.__version__)

--- a/docs/run_examples/_code/run_rgi_region.py
+++ b/docs/run_examples/_code/run_rgi_region.py
@@ -17,7 +17,7 @@ start = time.time()
 log = logging.getLogger(__name__)
 
 # Initialize OGGM and set up the default run parameters
-cfg.initialize(logging_level='WORKFLOW')
+cfg.initialize(logging_level='ERROR')
 rgi_version = '61'
 rgi_region = '11'  # Region Central Europe
 

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -4,7 +4,7 @@
 Version history
 ===============
 
-v1.3.X (unreleased)
+v1.4.0 (unreleased)
 -------------------
 
 Breaking changes
@@ -59,6 +59,9 @@ Breaking changes
 - new options to compute the length of a glacier during a run:
   `PARAMS['min_ice_thick_for_length']` and `PARAMS['glacier_length_method']`
   (:pull:`1069`). By `Matthias Dusch <https://github.com/matthiasdusch>`_.
+- several further important changes to be documented later in
+  (:pull:`1099`). By `Fabien Maussion <https://github.com/fmaussion>`_.
+
 
 
 Enhancements

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -78,7 +78,7 @@ Enhancements
   :py:func:`tasks.elevation_band_flowline` and
   :py:func:`tasks.fixed_dx_elevation_band_flowline`.
   By `Fabien Maussion <https://github.com/fmaussion>`_
-- Added a `calibrate_inversion_from_consensus_estimate` global task which
+- Added a `calibrate_inversion_from_consensus` global task which
   calibrates Glen A so that the volume of glaciers in a selection is
   matched (:pull:`1043`).
   By `Fabien Maussion <https://github.com/fmaussion>`_

--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -304,11 +304,12 @@ def set_logging_config(logging_level='INFO'):
     WARNING
         Indication that something unexpected happened on a glacier,
         but that OGGM is still working on this glacier.
+    ERROR
+        Print workflow messages and errors only, e.g. when a glacier cannot
+        run properly.
     WORKFLOW
         Print only high level, workflow information (typically, one message
-        per task). Errors and warnings will still be printed.
-    ERROR
-        Print errors only, e.g. when a glacier cannot run properly.
+        per task). Errors and warnings will NOT be printed.
     CRITICAL
         Print nothing but fatal errors.
 
@@ -321,15 +322,15 @@ def set_logging_config(logging_level='INFO'):
     """
 
     # Add a custom level - just for us
-    logging.addLevelName(25, 'WORKFLOW')
+    logging.addLevelName(45, 'WORKFLOW')
 
     def workflow(self, message, *args, **kws):
         """Standard log message with a custom level."""
-        if self.isEnabledFor(25):
+        if self.isEnabledFor(45):
             # Yes, logger takes its '*args' as 'args'.
-            self._log(25, message, args, **kws)
+            self._log(45, message, args, **kws)
 
-    logging.WORKFLOW = 25
+    logging.WORKFLOW = 45
     logging.Logger.workflow = workflow
 
     # Remove all handlers associated with the root logger object.

--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -533,7 +533,8 @@ def initialize_minimal(file=None, logging_level='INFO', params=None):
            'use_shape_factor_for_fluxbasedmodel', 'baseline_climate',
            'calving_line_extension', 'use_kcalving_for_run', 'lru_maxsize',
            'free_board_marine_terminating', 'use_kcalving_for_inversion',
-           'error_when_glacier_reaches_boundaries', 'glacier_length_method']
+           'error_when_glacier_reaches_boundaries', 'glacier_length_method',
+           'use_inversion_params_for_run']
     for k in ltr:
         cp.pop(k, None)
 

--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -45,8 +45,10 @@ CONFIG_FILE = os.path.join(os.path.expanduser('~'), '.oggm_config')
 CONFIG_MODIFIED = False
 
 # Share state accross processes
-DL_VERIFIED = Manager().dict()
-DEM_SOURCE_TABLE = Manager().dict()
+# DL_VERIFIED = Manager().dict()
+# DEM_SOURCE_TABLE = Manager().dict()
+DL_VERIFIED = dict()
+DEM_SOURCE_TABLE = dict()
 
 # Machine epsilon
 FLOAT_EPS = np.finfo(float).eps

--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -578,7 +578,7 @@ def initialize_minimal(file=None, logging_level='INFO', params=None,
     IS_INITIALIZED = True
 
 
-def initialize(file=None, logging_level='INFO', params=None):
+def initialize(file=None, logging_level='INFO', params=None, future=False):
     """Read the configuration file containing the run's parameters.
 
     This should be the first call, before using any of the other OGGM modules
@@ -592,11 +592,14 @@ def initialize(file=None, logging_level='INFO', params=None):
         set a logging level. See :func:`set_logging_config` for options.
     params : dict
         overrides for specific parameters from the config file
+    future : bool
+        use the new behavior of logging='WORKFLOW'.
     """
     global PARAMS
     global DATA
 
-    initialize_minimal(file=file, logging_level=logging_level, params=params)
+    initialize_minimal(file=file, logging_level=logging_level, params=params,
+                       future=future)
 
     # Do not spam
     PARAMS.do_log = False

--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -489,7 +489,8 @@ def initialize_minimal(file=None, logging_level='INFO', params=None):
     PARAMS['use_kcalving_for_run'] = cp.as_bool('use_kcalving_for_run')
     PARAMS['calving_use_limiter'] = cp.as_bool('calving_use_limiter')
     PARAMS['use_inversion_params_for_run'] = cp.as_bool('use_inversion_params_for_run')
-    PARAMS['error_when_glacier_reaches_boundaries'] = cp.as_bool('error_when_glacier_reaches_boundaries')
+    k = 'error_when_glacier_reaches_boundaries'
+    PARAMS[k] = cp.as_bool(k)
 
     # Climate
     PARAMS['baseline_climate'] = cp['baseline_climate'].strip().upper()
@@ -502,6 +503,8 @@ def initialize_minimal(file=None, logging_level='INFO', params=None):
     k = 'temp_local_gradient_bounds'
     PARAMS[k] = [float(vk) for vk in cp.as_list(k)]
     k = 'tstar_search_window'
+    PARAMS[k] = [int(vk) for vk in cp.as_list(k)]
+    k = 'ref_mb_valid_window'
     PARAMS[k] = [int(vk) for vk in cp.as_list(k)]
     PARAMS['use_bias_for_run'] = cp.as_bool('use_bias_for_run')
     k = 'free_board_marine_terminating'
@@ -534,7 +537,7 @@ def initialize_minimal(file=None, logging_level='INFO', params=None):
            'calving_line_extension', 'use_kcalving_for_run', 'lru_maxsize',
            'free_board_marine_terminating', 'use_kcalving_for_inversion',
            'error_when_glacier_reaches_boundaries', 'glacier_length_method',
-           'use_inversion_params_for_run']
+           'use_inversion_params_for_run', 'ref_mb_valid_window']
     for k in ltr:
         cp.pop(k, None)
 

--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -129,8 +129,8 @@ class ParamsLoggingDict(ResettingOrderedDict):
                                          'in your call to '
                                          '`process_climate_data`.')
 
-            log.warning('WARNING: adding an unknown parameter '
-                        '`{}`:`{}` to PARAMS.'.format(key, value))
+            log.workflow('WARNING: adding an unknown parameter '
+                         '`{}`:`{}` to PARAMS.'.format(key, value))
             return
 
         if prev == value:

--- a/oggm/cli/benchmark.py
+++ b/oggm/cli/benchmark.py
@@ -71,7 +71,7 @@ def run_benchmark(rgi_version=None, rgi_reg=None, border=None,
     params['working_dir'] = working_dir
 
     # Initialize OGGM and set up the run parameters
-    cfg.initialize(logging_level='WORKFLOW', params=params)
+    cfg.initialize(logging_level='WORKFLOW', params=params, future=True)
 
     # Use multiprocessing?
     cfg.PARAMS['use_multiprocessing'] = True

--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -159,7 +159,8 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
 
     # Initialize OGGM and set up the run parameters
     cfg.initialize(file=params_file, params=params,
-                   logging_level=logging_level)
+                   logging_level=logging_level,
+                   future=True)
 
     # Use multiprocessing?
     cfg.PARAMS['use_multiprocessing'] = not disable_mp

--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -218,7 +218,7 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
 
         # For greenland we omit connectivity level 2
         if rgi_reg == '05':
-            rgidf = rgidf.loc[rgidf['Connect'] == 2]
+            rgidf = rgidf.loc[rgidf['Connect'] != 2]
 
         # For all regions let's also omit nominal glaciers
         rgidf = rgidf.loc[rgidf['Status'] != 2]

--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -10,6 +10,7 @@ import sys
 import argparse
 import time
 import logging
+import pandas as pd
 import numpy as np
 import geopandas as gpd
 
@@ -161,8 +162,13 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
     # takes a long time, so deactivating this can make sense
     cfg.PARAMS['dl_verify'] = not disable_dl_verify
 
-    # For statistics
-    climate_periods = [1920, 1960, 2000]
+    # Log the parameters
+    msg = '# OGGM Run parameters:'
+    for k, v in cfg.PARAMS.items():
+        if type(v) in [pd.DataFrame, dict]:
+            continue
+        msg += '\n    {}: {}'.format(k, v)
+    log.workflow(msg)
 
     if rgi_version is None:
         rgi_version = cfg.PARAMS['rgi_version']
@@ -339,8 +345,7 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
     opath = os.path.join(sum_dir, 'glacier_statistics_{}.csv'.format(rgi_reg))
     utils.compile_glacier_statistics(gdirs, path=opath)
     opath = os.path.join(sum_dir, 'climate_statistics_{}.csv'.format(rgi_reg))
-    utils.compile_climate_statistics(gdirs, add_climate_period=climate_periods,
-                                     path=opath)
+    utils.compile_climate_statistics(gdirs, path=opath)
 
     # L3 OK - compress all in output directory
     l_base_dir = os.path.join(base_dir, 'L3')

--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -416,7 +416,7 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
         for gdir in gdirs:
             try:
                 df = gdir.read_json('local_mustar')
-                gdir.add_to_diagnostics('bias_before_zemp', df['bias'])
+                gdir.add_to_diagnostics('mb_bias_before_zemp', df['bias'])
                 df['bias'] = df['bias'] - residual
                 gdir.write_json(df, 'local_mustar')
             except FileNotFoundError:
@@ -505,9 +505,12 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
     opath = os.path.join(sum_dir, 'historical_run_output_{}.nc'.format(rgi_reg))
     utils.compile_run_output(gdirs, path=opath, input_filesuffix='_historical')
 
+    # Glacier statistics we recompute here for error analysis
+    opath = os.path.join(sum_dir, 'glacier_statistics_{}.csv'.format(rgi_reg))
+    utils.compile_glacier_statistics(gdirs, path=opath)
+
     # Other stats for consistency
-    for bn in ['glacier_statistics', 'climate_statistics',
-               'fixed_geometry_mass_balance']:
+    for bn in ['climate_statistics', 'fixed_geometry_mass_balance']:
         ipath = os.path.join(sum_dir_L3, bn + '_{}.csv'.format(rgi_reg))
         opath = os.path.join(sum_dir, bn + '_{}.csv'.format(rgi_reg))
         shutil.copyfile(ipath, opath)

--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -213,35 +213,15 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
             'RGI60-09.00958',
             'RGI60-09.00957',
         ]
-
-        # Curated list of large (> 50 km2) glaciers that don't run
-        # (CFL error) mostly because the centerlines are crap
-        # This is a really temporary fix until we have some better
-        # solution here
-        ids_to_ice_cap.extend(
-            ['RGI60-01.13696', 'RGI60-03.01710', 'RGI60-01.13635',
-             'RGI60-01.14443', 'RGI60-03.01678', 'RGI60-03.03274',
-             'RGI60-01.17566', 'RGI60-03.02849', 'RGI60-01.16201',
-             'RGI60-01.14683', 'RGI60-07.01506', 'RGI60-07.01559',
-             'RGI60-03.02687', 'RGI60-17.00172', 'RGI60-01.23649',
-             'RGI60-09.00077', 'RGI60-03.00994', 'RGI60-01.26738',
-             'RGI60-03.00283', 'RGI60-01.16121', 'RGI60-01.27108',
-             'RGI60-09.00132', 'RGI60-13.43483', 'RGI60-09.00069',
-             'RGI60-14.04404', 'RGI60-17.01218', 'RGI60-17.15877',
-             'RGI60-13.30888', 'RGI60-17.13796', 'RGI60-17.15825',
-             'RGI60-01.09783'])
         rgidf.loc[rgidf.RGIId.isin(ids_to_ice_cap), 'Form'] = '1'
 
-        # In AA almost all large ice bodies
-        # are actually ice caps
-        # As of now ice caps are "squeezed" flowlines
+        # In AA almost all large ice bodies are actually ice caps
         if rgi_reg == '19':
             rgidf.loc[rgidf.Area > 100, 'Form'] = '1'
 
         # For greenland we omit connectivity level 2
         if rgi_reg == '05':
             rgidf = rgidf.loc[rgidf['Connect'] != 2]
-
     else:
         rgidf = test_rgidf
         cfg.set_intersects_db(test_intersects_file)
@@ -338,6 +318,22 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
         gdirs_cent = gdirs
     else:
         # Default is to mix
+        # Curated list of large (> 50 km2) glaciers that don't run
+        # (CFL error) mostly because the centerlines are crap
+        # This is a really temporary fix until we have some better
+        # solution here
+        ids_to_bands = [
+            'RGI60-01.13696', 'RGI60-03.01710', 'RGI60-01.13635',
+            'RGI60-01.14443', 'RGI60-03.01678', 'RGI60-03.03274',
+            'RGI60-01.17566', 'RGI60-03.02849', 'RGI60-01.16201',
+            'RGI60-01.14683', 'RGI60-07.01506', 'RGI60-07.01559',
+            'RGI60-03.02687', 'RGI60-17.00172', 'RGI60-01.23649',
+            'RGI60-09.00077', 'RGI60-03.00994', 'RGI60-01.26738',
+            'RGI60-03.00283', 'RGI60-01.16121', 'RGI60-01.27108',
+            'RGI60-09.00132', 'RGI60-13.43483', 'RGI60-09.00069',
+            'RGI60-14.04404', 'RGI60-17.01218', 'RGI60-17.15877',
+            'RGI60-13.30888', 'RGI60-17.13796', 'RGI60-17.15825',
+            'RGI60-01.09783']
         if rgi_reg == '19':
             gdirs_band = gdirs
             gdirs_cent = []
@@ -345,7 +341,7 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
             gdirs_band = []
             gdirs_cent = []
             for gdir in gdirs:
-                if gdir.is_icecap:
+                if gdir.is_icecap or gdir.rgi_id in ids_to_bands:
                     gdirs_band.append(gdir)
                 else:
                     gdirs_cent.append(gdir)

--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -216,6 +216,13 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
         if rgi_reg == '19':
             rgidf.loc[rgidf.Area > 100, 'Form'] = '1'
 
+        # For greenland we omit connectivity level 2
+        if rgi_reg == '05':
+            rgidf = rgidf.loc[rgidf['Connect'] == 2]
+
+        # For all regions let's also omit nominal glaciers
+        rgidf = rgidf.loc[rgidf['Status'] != 2]
+
     else:
         rgidf = test_rgidf
         cfg.set_intersects_db(test_intersects_file)
@@ -401,8 +408,8 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
         area_zemp = df.loc[int(rgi_reg), 'Area']
         smb_zemp = df.loc[int(rgi_reg), 'SMB'] * 1000
         if not np.allclose(area_oggm, area_zemp, rtol=0.05):
-            log.warning('OGGM regional area and Zemp regional area differ '
-                        'by more than 5%.')
+            log.workflow('WARNING: OGGM regional area and Zemp regional area '
+                         'differ by more than 5%.')
         residual = smb_zemp - smb_oggm
         log.workflow('Shifting regional bias by {}'.format(residual))
         for gdir in gdirs:

--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -527,6 +527,16 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
         opath = os.path.join(sum_dir, bn + '_{}.csv'.format(rgi_reg))
         shutil.copyfile(ipath, opath)
 
+    # Add the extended files
+    pf = os.path.join(sum_dir, 'historical_run_output_{}.nc'.format(rgi_reg))
+    mf = os.path.join(sum_dir, 'fixed_geometry_mass_balance_{}.csv'.format(rgi_reg))
+    sf = os.path.join(sum_dir, 'climate_statistics_{}.csv'.format(rgi_reg))
+    opath = os.path.join(sum_dir, 'historical_run_output_extended_{}.nc'.format(rgi_reg))
+    utils.extend_past_climate_run(past_run_file=pf,
+                                  fixed_geometry_mb_file=mf,
+                                  glacier_statistics_file=sf,
+                                  path=opath)
+
     # L5 OK - compress all in output directory
     log.workflow('L5 done. Writing to tar...')
     level_base_dir = os.path.join(output_base_dir, 'L5')

--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -334,7 +334,8 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
         workflow.execute_entity_task(task, gdirs)
 
     # We match the consensus
-    workflow.calibrate_inversion_from_consensus_estimate(gdirs)
+    workflow.calibrate_inversion_from_consensus(gdirs,
+                                                apply_fs_on_mismatch=True)
 
     # We get ready for modelling
     workflow.execute_entity_task(tasks.init_present_time_glacier, gdirs)

--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -416,6 +416,7 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
         for gdir in gdirs:
             try:
                 df = gdir.read_json('local_mustar')
+                gdir.add_to_diagnostics('bias_before_zemp', df['bias'])
                 df['bias'] = df['bias'] - residual
                 gdir.write_json(df, 'local_mustar')
             except FileNotFoundError:

--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -319,15 +319,19 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
     # L3 - Tasks
     task_list = [
         tasks.process_climate_data,
+        tasks.historical_climate_qc,
         tasks.local_t_star,
         tasks.mu_star_calibration,
         tasks.prepare_for_inversion,
-        tasks.mass_conservation_inversion,
-        tasks.filter_inversion_output,
-        tasks.init_present_time_glacier,
     ]
     for task in task_list:
         workflow.execute_entity_task(task, gdirs)
+
+    # We match the consensus
+    workflow.calibrate_inversion_from_consensus_estimate(gdirs)
+
+    # We get ready for modelling
+    workflow.execute_entity_task(tasks.init_present_time_glacier, gdirs)
 
     # Glacier stats
     sum_dir = os.path.join(base_dir, 'L3', 'summary')

--- a/oggm/core/centerlines.py
+++ b/oggm/core/centerlines.py
@@ -2313,5 +2313,9 @@ def fixed_dx_elevation_band_flowline(gdir, bin_variables=None,
     fl.is_rectangular = np.zeros(nx, dtype=bool)
     fl.is_trapezoid = np.ones(nx, dtype=bool)
 
+    if gdir.is_tidewater:
+        fl.is_rectangular[-5:] = True
+        fl.is_trapezoid[-5:] = False
+
     gdir.write_pickle([fl], 'inversion_flowlines')
     gdir.add_to_diagnostics('flowline_type', 'elevation_band')

--- a/oggm/core/centerlines.py
+++ b/oggm/core/centerlines.py
@@ -1331,18 +1331,17 @@ def _point_width(normals, point, centerline, poly, poly_no_nunataks):
     return width, line
 
 
-def _filter_small_slopes(hgt, dx, min_slope=0):
+def _filter_small_slopes(hgt, dx, min_slope_rad=0):
     """Masks out slopes with NaN until the slope if all valid points is at
-    least min_slope (in degrees).
+    least min_slope (in radians).
     """
 
-    min_slope = np.deg2rad(min_slope)
     slope = np.arctan(-np.gradient(hgt, dx))  # beware the minus sign
     # slope at the end always OK
-    slope[-1] = min_slope
+    slope[-1] = min_slope_rad
 
     # Find the locs where it doesn't work and expand till we got everything
-    slope_mask = np.where(slope >= min_slope, slope, np.NaN)
+    slope_mask = np.where(slope >= min_slope_rad, slope, np.NaN)
     r, nr = label(~np.isfinite(slope_mask))
     for objs in find_objects(r):
         obj = objs[0]
@@ -1355,7 +1354,7 @@ def _filter_small_slopes(hgt, dx, min_slope=0):
             ngap = obj.stop - i0 - 1
             nhgt = hgt[[i0, obj.stop]]
             current_slope = np.arctan(-np.gradient(nhgt, ngap * dx))
-            if i0 <= 0 or current_slope[0] >= min_slope:
+            if i0 <= 0 or current_slope[0] >= min_slope_rad:
                 break
         slope_mask[i0:obj.stop] = np.NaN
     out = hgt.copy()
@@ -1626,6 +1625,7 @@ def initialize_flowlines(gdir):
     # Initialise the flowlines
     dx = cfg.PARAMS['flowline_dx']
     do_filter = cfg.PARAMS['filter_min_slope']
+    min_slope = np.deg2rad(cfg.PARAMS['min_slope'])
     lid = int(cfg.PARAMS['flowline_junction_pix'])
     fls = []
 
@@ -1674,7 +1674,8 @@ def initialize_flowlines(gdir):
         # Check for min slope issues and correct if needed
         if do_filter:
             # Correct only where glacier
-            hgts = _filter_small_slopes(hgts, dx*gdir.grid.dx)
+            hgts = _filter_small_slopes(hgts, dx*gdir.grid.dx,
+                                        min_slope_rad=min_slope)
             isfin = np.isfinite(hgts)
             if not np.any(isfin):
                 raise GeometryError('This centerline has no positive slopes')

--- a/oggm/core/centerlines.py
+++ b/oggm/core/centerlines.py
@@ -2204,7 +2204,7 @@ def elevation_band_flowline(gdir, bin_variables=None, preserve_totals=True):
     df = df.dropna()
 
     # Check for binned vars
-    for var, data, in_total, do_p in zip(bin_variables,  out_vars, out_totals,
+    for var, data, in_total, do_p in zip(bin_variables, out_vars, out_totals,
                                          preserve_totals):
         if do_p:
             out_total = np.nansum(df[var] * df['area'])

--- a/oggm/core/centerlines.py
+++ b/oggm/core/centerlines.py
@@ -1712,6 +1712,7 @@ def initialize_flowlines(gdir):
 
     # Write the data
     gdir.write_pickle(fls, 'inversion_flowlines')
+    gdir.add_to_diagnostics('flowline_type', 'centerlines')
     if do_filter:
         out = diag_n_bad_slopes/diag_n_pix
         gdir.add_to_diagnostics('perc_invalid_flowline', out)
@@ -2240,3 +2241,4 @@ def fixed_dx_elevation_band_flowline(gdir):
     fl.is_trapezoid = np.ones(nx, dtype=bool)
 
     gdir.write_pickle([fl], 'inversion_flowlines')
+    gdir.add_to_diagnostics('flowline_type', 'elevation_band')

--- a/oggm/core/centerlines.py
+++ b/oggm/core/centerlines.py
@@ -2276,6 +2276,8 @@ def fixed_dx_elevation_band_flowline(gdir, bin_variables=None,
 
     # Additional vars
     if bin_variables is not None:
+        bin_variables = utils.tolist(bin_variables)
+
         # Check if there and do not raise when not available
         keep = []
         for var in bin_variables:
@@ -2286,7 +2288,6 @@ def fixed_dx_elevation_band_flowline(gdir, bin_variables=None,
                             ''.format(gdir.rgi_id, var))
         bin_variables = keep
 
-        bin_variables = utils.tolist(bin_variables)
         preserve_totals = utils.tolist(preserve_totals,
                                        length=len(bin_variables))
         odf = pd.DataFrame(index=dis_along_flowline)

--- a/oggm/core/climate.py
+++ b/oggm/core/climate.py
@@ -1358,10 +1358,6 @@ def apparent_mb_from_any_mb(gdir, mb_model=None, mb_years=None):
 def compute_ref_t_stars(gdirs):
     """ Detects the best t* for the reference glaciers and writes them to disk
 
-    This task will be needed for mass balance calibration of custom climate
-    data. For CRU and HISTALP baseline climate a precalibrated list is
-    available and should be used instead.
-
     Parameters
     ----------
     gdirs : list of :py:class:`oggm.GlacierDirectory` objects

--- a/oggm/core/climate.py
+++ b/oggm/core/climate.py
@@ -721,7 +721,8 @@ def glacier_mu_candidates(gdir):
 
 
 @entity_task(log)
-def t_star_from_refmb(gdir, mbdf=None, glacierwide=None):
+def t_star_from_refmb(gdir, mbdf=None, glacierwide=None,
+                      min_mu_star=None, max_mu_star=None):
     """Computes the ref t* for the glacier, given a series of MB measurements.
 
     Parameters
@@ -746,6 +747,12 @@ def t_star_from_refmb(gdir, mbdf=None, glacierwide=None):
     # Reference time series
     if mbdf is None:
         mbdf = gdir.get_ref_mb_data()['ANNUAL_BALANCE']
+
+    # mu* constraints
+    if min_mu_star is None:
+        min_mu_star = cfg.PARAMS['min_mu_star']
+    if max_mu_star is None:
+        max_mu_star = cfg.PARAMS['max_mu_star']
 
     # which years to look at
     ref_years = mbdf.index.values
@@ -805,7 +812,9 @@ def t_star_from_refmb(gdir, mbdf=None, glacierwide=None):
             try:
                 # TODO: this is slow and can be highly optimised
                 # it reads the same data over and over again
-                _recursive_mu_star_calibration(gdir, fls, y, first_call=True)
+                _recursive_mu_star_calibration(gdir, fls, y, first_call=True,
+                                               min_mu_star=min_mu_star,
+                                               max_mu_star=max_mu_star)
                 # Compute the MB with it
                 mb_mod = MultipleFlowlineMassBalance(gdir, fls, bias=0,
                                                      check_calib_params=False)
@@ -880,7 +889,8 @@ def _fallback_local_t_star(gdir):
 
 @entity_task(log, writes=['local_mustar', 'climate_info'],
              fallback=_fallback_local_t_star)
-def local_t_star(gdir, *, ref_df=None, tstar=None, bias=None):
+def local_t_star(gdir, *, ref_df=None, tstar=None, bias=None,
+                 clip_mu_star=None, min_mu_star=None, max_mu_star=None):
     """Compute the local t* and associated glacier-wide mu*.
 
     If ``tstar`` and ``bias`` are not provided, they will be interpolated from
@@ -899,6 +909,12 @@ def local_t_star(gdir, *, ref_df=None, tstar=None, bias=None):
         the year where the glacier should be equilibrium
     bias: float, optional
         the associated reference bias
+    clip_mu_star: bool, optional
+        defaults to cfg.PARAMS['clip_mu_star']
+    min_mu_star: bool, optional
+        defaults to cfg.PARAMS['min_mu_star']
+    max_mu_star: bool, optional
+        defaults to cfg.PARAMS['max_mu_star']
     """
 
     # Relevant mb params
@@ -980,12 +996,20 @@ def local_t_star(gdir, *, ref_df=None, tstar=None, bias=None):
         raise MassBalanceCalibrationError('{} has a non finite '
                                           'mu'.format(gdir.rgi_id))
 
+    # mu* constraints
+    if clip_mu_star is None:
+        clip_mu_star = cfg.PARAMS['clip_mu_star']
+    if min_mu_star is None:
+        min_mu_star = cfg.PARAMS['min_mu_star']
+    if max_mu_star is None:
+        max_mu_star = cfg.PARAMS['max_mu_star']
+
     # Clip it?
-    if cfg.PARAMS['clip_mu_star']:
-        mustar = utils.clip_min(mustar, 0)
+    if clip_mu_star:
+        mustar = utils.clip_min(mustar, min_mu_star)
 
     # If mu out of bounds, raise
-    if not (cfg.PARAMS['min_mu_star'] <= mustar <= cfg.PARAMS['max_mu_star']):
+    if not (min_mu_star <= mustar <= max_mu_star):
         raise MassBalanceCalibrationError('{}: mu* out of specified bounds: '
                                           '{:.2f}'.format(gdir.rgi_id, mustar))
 
@@ -1033,7 +1057,8 @@ def _mu_star_per_minimization(x, fls, cmb, temp, prcp, widths):
 
 
 def _recursive_mu_star_calibration(gdir, fls, t_star, first_call=True,
-                                   force_mu=None):
+                                   force_mu=None, min_mu_star=None,
+                                   max_mu_star=None):
 
     # Do we have a calving glacier? This is only for the first call!
     # The calving mass-balance is distributed over the valid tributaries of the
@@ -1058,16 +1083,15 @@ def _recursive_mu_star_calibration(gdir, fls, t_star, first_call=True,
     if force_mu is None:
         try:
             mu_star = optimize.brentq(_mu_star_per_minimization,
-                                      cfg.PARAMS['min_mu_star'],
-                                      cfg.PARAMS['max_mu_star'],
+                                      min_mu_star, max_mu_star,
                                       args=(fls, cmb, temp, prcp, widths),
                                       xtol=_brentq_xtol)
         except ValueError:
             # This happens in very rare cases
-            _mu_lim = _mu_star_per_minimization(cfg.PARAMS['min_mu_star'],
-                                                fls, cmb, temp, prcp, widths)
-            if _mu_lim < 0 and np.allclose(_mu_lim, 0):
-                mu_star = 0.
+            _mu_lim = _mu_star_per_minimization(min_mu_star, fls, cmb, temp,
+                                                prcp, widths)
+            if _mu_lim < min_mu_star and np.allclose(_mu_lim, min_mu_star):
+                mu_star = min_mu_star
             else:
                 raise MassBalanceCalibrationError('{} mu* out of specified '
                                                   'bounds.'.format(gdir.rgi_id)
@@ -1109,7 +1133,9 @@ def _recursive_mu_star_calibration(gdir, fls, t_star, first_call=True,
             # We find a new mu for these in a recursive call
             # TODO: this is where a flux kwarg can passed to tributaries
             _recursive_mu_star_calibration(gdir, inflows, t_star,
-                                           first_call=False)
+                                           first_call=False,
+                                           min_mu_star=min_mu_star,
+                                           max_mu_star=max_mu_star)
 
             # At this stage we should be ok
             assert np.all([~ fl.flux_needs_correction for fl in inflows])
@@ -1118,7 +1144,9 @@ def _recursive_mu_star_calibration(gdir, fls, t_star, first_call=True,
 
             # After the above are OK we have to recalibrate all below
             _recursive_mu_star_calibration(gdir, fls, t_star,
-                                           first_call=first_call)
+                                           first_call=first_call,
+                                           min_mu_star=min_mu_star,
+                                           max_mu_star=max_mu_star)
 
     # At this stage we are good
     for fl in fls:
@@ -1150,7 +1178,7 @@ def _fallback_mu_star_calibration(gdir):
 
 @entity_task(log, writes=['inversion_flowlines'],
              fallback=_fallback_mu_star_calibration)
-def mu_star_calibration(gdir):
+def mu_star_calibration(gdir, min_mu_star=None, max_mu_star=None):
     """Compute the flowlines' mu* and the associated apparent mass-balance.
 
     If low lying tributaries have a non-physically consistent Mass-balance
@@ -1161,6 +1189,10 @@ def mu_star_calibration(gdir):
     ----------
     gdir : :py:class:`oggm.GlacierDirectory`
         the glacier directory to process
+    min_mu_star: bool, optional
+        defaults to cfg.PARAMS['min_mu_star']
+    max_mu_star: bool, optional
+        defaults to cfg.PARAMS['max_mu_star']
     """
 
     # Interpolated data
@@ -1168,16 +1200,24 @@ def mu_star_calibration(gdir):
     t_star = df['t_star']
     bias = df['bias']
 
+    # mu* constraints
+    if min_mu_star is None:
+        min_mu_star = cfg.PARAMS['min_mu_star']
+    if max_mu_star is None:
+        max_mu_star = cfg.PARAMS['max_mu_star']
+
     # For each flowline compute the apparent MB
     fls = gdir.read_pickle('inversion_flowlines')
     # If someone calls the task a second time we need to reset this
     for fl in fls:
         fl.mu_star_is_valid = False
 
-    force_mu = 0 if df['mu_star_glacierwide'] == 0 else None
+    force_mu = min_mu_star if df['mu_star_glacierwide'] == min_mu_star else None
 
     # Let's go
-    _recursive_mu_star_calibration(gdir, fls, t_star, force_mu=force_mu)
+    _recursive_mu_star_calibration(gdir, fls, t_star, force_mu=force_mu,
+                                   min_mu_star=min_mu_star,
+                                   max_mu_star=max_mu_star)
 
     # If the user wants to filter the bad ones we remove them and start all
     # over again until all tributaries are physically consistent with one mu

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -942,7 +942,7 @@ class FlowlineModel(object):
         diag_ds['volume_m3'] = ('time', np.zeros(nm) * np.NaN)
         diag_ds['volume_m3'].attrs['description'] = 'Total glacier volume'
         diag_ds['volume_m3'].attrs['unit'] = 'm 3'
-        if self.is_marine_terminating:
+        if getattr(self, 'do_calving', False):
             diag_ds['volume_bsl_m3'] = ('time', np.zeros(nm) * np.NaN)
             diag_ds['volume_bsl_m3'].attrs['description'] = ('Glacier volume '
                                                              'below '
@@ -964,7 +964,7 @@ class FlowlineModel(object):
         diag_ds['ela_m'].attrs['description'] = ('Annual Equilibrium Line '
                                                  'Altitude  (ELA)')
         diag_ds['ela_m'].attrs['unit'] = 'm a.s.l'
-        if self.is_tidewater:
+        if getattr(self, 'do_calving', False):
             diag_ds['calving_m3'] = ('time', np.zeros(nm) * np.NaN)
             diag_ds['calving_m3'].attrs['description'] = ('Total accumulated '
                                                           'calving flux')
@@ -1000,7 +1000,7 @@ class FlowlineModel(object):
                 # We really don't want to stop the model for some ELA issues
                 diag_ds['ela_m'].data[i] = np.NaN
 
-            if self.is_tidewater:
+            if getattr(self, 'do_calving', False):
                 diag_ds['calving_m3'].data[i] = self.calving_m3_since_y0
                 diag_ds['calving_rate_myr'].data[i] = self.calving_rate_myr
                 if self.is_marine_terminating:
@@ -1024,7 +1024,7 @@ class FlowlineModel(object):
                                             coords=varcoords)
             ds['ts_width_m'] = xr.DataArray(w, dims=('time', 'x'),
                                             coords=varcoords)
-            if self.is_tidewater:
+            if getattr(self, 'do_calving', False):
                 ds['ts_calving_bucket_m3'] = xr.DataArray(b, dims=('time', ),
                                                           coords=varcoords)
             run_ds.append(ds)

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -47,7 +47,6 @@ log = logging.getLogger(__name__)
 class Flowline(Centerline):
     """Common logic for different types of flowlines used as input to the model
 
-
     """
 
     def __init__(self, line=None, dx=1, map_dx=None,

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -912,7 +912,7 @@ class FlowlineModel(object):
         nm = len(monthly_time)
         sects = [(np.zeros((ny, fl.nx)) * np.NaN) for fl in self.fls]
         widths = [(np.zeros((ny, fl.nx)) * np.NaN) for fl in self.fls]
-        bucket = [(np.zeros(ny) * np.NaN) for _ in self.fls]
+        bucket = [np.zeros(ny) for _ in self.fls]
         diag_ds = xr.Dataset()
 
         # Global attributes
@@ -943,36 +943,40 @@ class FlowlineModel(object):
         diag_ds['volume_m3'] = ('time', np.zeros(nm) * np.NaN)
         diag_ds['volume_m3'].attrs['description'] = 'Total glacier volume'
         diag_ds['volume_m3'].attrs['unit'] = 'm 3'
-        if getattr(self, 'do_calving', False):
-            diag_ds['volume_bsl_m3'] = ('time', np.zeros(nm) * np.NaN)
-            diag_ds['volume_bsl_m3'].attrs['description'] = ('Glacier volume '
-                                                             'below '
-                                                             'sea-level')
-            diag_ds['volume_bsl_m3'].attrs['unit'] = 'm 3'
-            diag_ds['volume_bwl_m3'] = ('time', np.zeros(nm) * np.NaN)
-            diag_ds['volume_bwl_m3'].attrs['description'] = ('Glacier volume '
-                                                             'below '
-                                                             'water-level')
-            diag_ds['volume_bwl_m3'].attrs['unit'] = 'm 3'
+
+        diag_ds['volume_bsl_m3'] = ('time', np.zeros(nm) * np.NaN)
+        diag_ds['volume_bsl_m3'].attrs['description'] = ('Glacier volume '
+                                                         'below '
+                                                         'sea-level')
+        diag_ds['volume_bsl_m3'].attrs['unit'] = 'm 3'
+
+        diag_ds['volume_bwl_m3'] = ('time', np.zeros(nm) * np.NaN)
+        diag_ds['volume_bwl_m3'].attrs['description'] = ('Glacier volume '
+                                                         'below '
+                                                         'water-level')
+        diag_ds['volume_bwl_m3'].attrs['unit'] = 'm 3'
 
         diag_ds['area_m2'] = ('time', np.zeros(nm) * np.NaN)
         diag_ds['area_m2'].attrs['description'] = 'Total glacier area'
         diag_ds['area_m2'].attrs['unit'] = 'm 2'
+
         diag_ds['length_m'] = ('time', np.zeros(nm) * np.NaN)
         diag_ds['length_m'].attrs['description'] = 'Glacier length'
         diag_ds['length_m'].attrs['unit'] = 'm 3'
+
         diag_ds['ela_m'] = ('time', np.zeros(nm) * np.NaN)
         diag_ds['ela_m'].attrs['description'] = ('Annual Equilibrium Line '
                                                  'Altitude  (ELA)')
         diag_ds['ela_m'].attrs['unit'] = 'm a.s.l'
-        if getattr(self, 'do_calving', False):
-            diag_ds['calving_m3'] = ('time', np.zeros(nm) * np.NaN)
-            diag_ds['calving_m3'].attrs['description'] = ('Total accumulated '
-                                                          'calving flux')
-            diag_ds['calving_m3'].attrs['unit'] = 'm 3'
-            diag_ds['calving_rate_myr'] = ('time', np.zeros(nm) * np.NaN)
-            diag_ds['calving_rate_myr'].attrs['description'] = 'Calving rate'
-            diag_ds['calving_rate_myr'].attrs['unit'] = 'm yr-1'
+
+        diag_ds['calving_m3'] = ('time', np.zeros(nm) * np.NaN)
+        diag_ds['calving_m3'].attrs['description'] = ('Total accumulated '
+                                                      'calving flux')
+        diag_ds['calving_m3'].attrs['unit'] = 'm 3'
+
+        diag_ds['calving_rate_myr'] = ('time', np.zeros(nm) * np.NaN)
+        diag_ds['calving_rate_myr'].attrs['description'] = 'Calving rate'
+        diag_ds['calving_rate_myr'].attrs['unit'] = 'm yr-1'
 
         # Run
         j = 0
@@ -989,10 +993,12 @@ class FlowlineModel(object):
                         except AttributeError:
                             pass
                 j += 1
+
             # Diagnostics
             diag_ds['volume_m3'].data[i] = self.volume_m3
             diag_ds['area_m2'].data[i] = self.area_m2
             diag_ds['length_m'].data[i] = self.length_m
+
             try:
                 ela_m = self.mb_model.get_ela(year=yr, fls=self.fls,
                                               fl_id=len(self.fls)-1)
@@ -1001,12 +1007,10 @@ class FlowlineModel(object):
                 # We really don't want to stop the model for some ELA issues
                 diag_ds['ela_m'].data[i] = np.NaN
 
-            if getattr(self, 'do_calving', False):
-                diag_ds['calving_m3'].data[i] = self.calving_m3_since_y0
-                diag_ds['calving_rate_myr'].data[i] = self.calving_rate_myr
-                if self.is_marine_terminating:
-                    diag_ds['volume_bsl_m3'].data[i] = self.volume_bsl_m3
-                    diag_ds['volume_bwl_m3'].data[i] = self.volume_bwl_m3
+            diag_ds['calving_m3'].data[i] = self.calving_m3_since_y0
+            diag_ds['calving_rate_myr'].data[i] = self.calving_rate_myr
+            diag_ds['volume_bsl_m3'].data[i] = self.volume_bsl_m3
+            diag_ds['volume_bwl_m3'].data[i] = self.volume_bwl_m3
 
         # to datasets
         run_ds = []
@@ -1025,9 +1029,8 @@ class FlowlineModel(object):
                                             coords=varcoords)
             ds['ts_width_m'] = xr.DataArray(w, dims=('time', 'x'),
                                             coords=varcoords)
-            if getattr(self, 'do_calving', False):
-                ds['ts_calving_bucket_m3'] = xr.DataArray(b, dims=('time', ),
-                                                          coords=varcoords)
+            ds['ts_calving_bucket_m3'] = xr.DataArray(b, dims=('time', ),
+                                                      coords=varcoords)
             run_ds.append(ds)
 
         # write output?

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -1699,7 +1699,12 @@ class FileModel(object):
             ds.load()
             dss.append(ds)
 
-        self.last_yr = ds.year.values[-1]
+        try:
+            self.last_yr = ds.year.values[-1]
+        except AttributeError:
+            raise InvalidWorkflowError('The provided model output file is '
+                                       'incomplete (likely when the previous '
+                                       'run failed) or corrupt.')
         self.dss = dss
 
         # Calving diags

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -2130,8 +2130,8 @@ def flowline_model_run(gdir, output_filesuffix=None, mb_model=None,
 
     if cfg.PARAMS['use_inversion_params_for_run']:
         diag = gdir.get_diagnostics()
-        fs = diag['inversion_fs']
-        glen_a = diag['inversion_glen_a']
+        fs = diag.get('inversion_fs', cfg.PARAMS['fs'])
+        glen_a = diag.get('inversion_glen_a', cfg.PARAMS['glen_a'])
     else:
         fs = cfg.PARAMS['fs']
         glen_a = cfg.PARAMS['glen_a']

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -1382,7 +1382,9 @@ class FluxBasedModel(FlowlineModel):
                         raise RuntimeError(
                             'CFL error: required time step smaller '
                             'than the minimum allowed: '
-                            '{:.1f}s vs {:.1f}s.'.format(cfl_dt, self.min_dt))
+                            '{:.1f}s vs {:.1f}s. Happening at '
+                            'simulation year {:.1f} and fl_id {}.'
+                            ''.format(cfl_dt, self.min_dt, self.yr, fl_id))
 
             # Since we are in this loop, reset the tributary flux
             trib_flux[:] = 0

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -2095,8 +2095,8 @@ def init_present_time_glacier(gdir):
 
 
 def robust_model_run(*args, **kwargs):
-    warnings.warn('The task `robust_model_run` is deprecated. It should '
-                  'only be used for testing.', DeprecationWarning)
+    warnings.warn('The task `robust_model_run` is deprecated.',
+                  DeprecationWarning)
     return flowline_model_run(*args, **kwargs)
 
 

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -924,6 +924,8 @@ class FlowlineModel(object):
                                                   gmtime())
         diag_ds.attrs['hemisphere'] = self.mb_model.hemisphere
         diag_ds.attrs['water_level'] = self.water_level
+        diag_ds.attrs['glen_a'] = self.glen_a
+        diag_ds.attrs['fs'] = self.fs
 
         # Coordinates
         diag_ds.coords['time'] = ('time', monthly_time)

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -1721,7 +1721,7 @@ class FileModel(object):
         """Reset the initial model time"""
 
         if y0 is None:
-            y0 = self.dss[0].time[0]
+            y0 = float(self.dss[0].time[0])
         self.y0 = y0
         self.yr = y0
 
@@ -1851,7 +1851,8 @@ def glacier_from_netcdf(path):
 
 def calving_glacier_downstream_line(line, n_points):
     """Extends a calving glacier flowline past the terminus."""
-
+    if line is None:
+        return None
     x, y = line.coords.xy
     dx = x[-1] - x[-2]
     dy = y[-1] - y[-2]
@@ -2333,7 +2334,7 @@ def run_constant_climate(gdir, nyears=1000, y0=None, halfsize=15,
 
 
 @entity_task(log)
-def run_from_climate_data(gdir, ys=None, ye=None, min_ys=None,
+def run_from_climate_data(gdir, ys=None, ye=None, min_ys=None, max_ys=None,
                           store_monthly_step=False,
                           climate_filename='climate_historical',
                           climate_input_filesuffix='', output_filesuffix='',
@@ -2357,7 +2358,10 @@ def run_from_climate_data(gdir, ys=None, ye=None, min_ys=None,
         end year of the model run (no default: needs to be set)
     min_ys : int
         if you want to impose a minimum start year, regardless if the glacier
-        inventory date is later.
+        inventory date is earlier (e.g. if climate data does not reach).
+    max_ys : int
+        if you want to impose a maximum start year, regardless if the glacier
+        inventory date is later (e.g. if climate data does not reach).
     store_monthly_step : bool
         whether to store the diagnostic data at a monthly time step or not
         (default is yearly)
@@ -2401,7 +2405,9 @@ def run_from_climate_data(gdir, ys=None, ye=None, min_ys=None,
     if ye is None:
         raise InvalidParamsError('Need to set the `ye` kwarg!')
     if min_ys is not None:
-        ys = ys if ys < min_ys else min_ys
+        ys = ys if ys > min_ys else min_ys
+    if max_ys is not None:
+        ys = ys if ys < max_ys else max_ys
 
     if init_model_filesuffix is not None:
         fp = gdir.get_filepath('model_run', filesuffix=init_model_filesuffix)

--- a/oggm/core/gcm_climate.py
+++ b/oggm/core/gcm_climate.py
@@ -297,8 +297,8 @@ def process_cmip5_data(gdir, filesuffix='', fpath_temp=None,
     glat = gdir.cenlat
 
     # Read the GCM files
-    with xr.open_dataset(fpath_temp, decode_times=True) as tempds, \
-          xr.open_dataset(fpath_precip, decode_times=True) as precipds:
+    with xr.open_dataset(fpath_temp, use_cftime=True) as tempds, \
+          xr.open_dataset(fpath_precip, use_cftime=True) as precipds:
 
         # Check longitude conventions
         if tempds.lon.min() >= 0 and glon <= 0:

--- a/oggm/core/gcm_climate.py
+++ b/oggm/core/gcm_climate.py
@@ -298,7 +298,7 @@ def process_cmip5_data(gdir, filesuffix='', fpath_temp=None,
 
     # Read the GCM files
     with xr.open_dataset(fpath_temp, use_cftime=True) as tempds, \
-          xr.open_dataset(fpath_precip, use_cftime=True) as precipds:
+            xr.open_dataset(fpath_precip, use_cftime=True) as precipds:
 
         # Check longitude conventions
         if tempds.lon.min() >= 0 and glon <= 0:

--- a/oggm/core/gis.py
+++ b/oggm/core/gis.py
@@ -1073,9 +1073,8 @@ def gridded_attributes(gdir):
     glen_n = cfg.PARAMS['glen_n']
     sy, sx = np.gradient(topo_smoothed, dx, dx)
     slope = np.arctan(np.sqrt(sy**2 + sx**2))
-    slope_factor = utils.clip_array(slope,
-                                    np.deg2rad(cfg.PARAMS['min_slope']),
-                                    np.pi/2)
+    min_slope = np.deg2rad(cfg.PARAMS['distributed_inversion_min_slope'])
+    slope_factor = utils.clip_array(slope, min_slope, np.pi/2)
     slope_factor = 1 / slope_factor**(glen_n / (glen_n+2))
 
     aspect = np.arctan2(-sx, sy)

--- a/oggm/core/gis.py
+++ b/oggm/core/gis.py
@@ -1074,7 +1074,7 @@ def gridded_attributes(gdir):
     sy, sx = np.gradient(topo_smoothed, dx, dx)
     slope = np.arctan(np.sqrt(sy**2 + sx**2))
     slope_factor = utils.clip_array(slope,
-                                    np.deg2rad(cfg.PARAMS['min_slope']*4),
+                                    np.deg2rad(cfg.PARAMS['min_slope']),
                                     np.pi/2)
     slope_factor = 1 / slope_factor**(glen_n / (glen_n+2))
 

--- a/oggm/core/inversion.py
+++ b/oggm/core/inversion.py
@@ -1183,7 +1183,8 @@ def find_inversion_calving(gdir, water_level=None, fixed_water_depth=None,
         try:
             climate.local_t_star(gdir, clip_mu_star=False,
                                  min_mu_star=min_mu_star,
-                                 continue_on_error=False)
+                                 continue_on_error=False,
+                                 add_to_log_file=False)
             df = gdir.read_json('local_mustar')
         except MassBalanceCalibrationError as e:
             assert 'mu* out of specified bounds' in str(e)

--- a/oggm/core/inversion.py
+++ b/oggm/core/inversion.py
@@ -288,8 +288,6 @@ def sia_thickness(slope, width, flux, shape='rectangular',
     glen_a : Glen A, defaults to PARAMS
     fs : sliding, defaults to PARAMS
     shape_factor: for lateral drag
-    min_slope: sensitive parameter. could be different for ice caps, here
-               we use cfg.PARAMS['min_slope']
 
     Returns
     -------
@@ -1098,6 +1096,12 @@ def find_inversion_calving(gdir, water_level=None, fixed_water_depth=None,
     cls = gdir.read_pickle('inversion_input')[-1]
     slope = cls['slope_angle'][-1]
     width = cls['width'][-1]
+
+    # Stupidly enough the slope is clipped in the OGGM inversion, not
+    # in prepro - clip here
+    min_slope = 'min_slope_ice_caps' if gdir.is_icecap else 'min_slope'
+    min_slope = np.deg2rad(cfg.PARAMS[min_slope])
+    slope = utils.clip_array(slope, min_slope, np.pi / 2.)
 
     # Check that water level is within given bounds
     if water_level is None:

--- a/oggm/core/inversion.py
+++ b/oggm/core/inversion.py
@@ -308,11 +308,11 @@ def sia_thickness(slope, width, flux, shape='rectangular',
     fd = 2. / (cfg.PARAMS['glen_n']+2) * glen_a
     rho = cfg.PARAMS['ice_density']
 
-    # Clip the slope, in degrees
-    clip_angle = cfg.PARAMS['min_slope']
+    # Clip the slope, in rad
+    clip_angle = np.deg2rad(cfg.PARAMS['min_slope'])
 
     # Clip slope to avoid negative and small slopes
-    slope = utils.clip_array(slope, np.deg2rad(clip_angle), np.pi / 2.)
+    slope = utils.clip_array(slope, clip_angle, np.pi / 2.)
 
     # Convert the flux to m2 s-1 (averaged to represent the sections center)
     flux_a0 = 1 if shape == 'rectangular' else 1.5
@@ -455,8 +455,8 @@ def mass_conservation_inversion(gdir, glen_a=None, fs=None, write=True,
     elif use_sf == 'Huss':
         sf_func = utils.shape_factor_huss
 
-    # Clip the slope, in degrees
-    clip_angle = cfg.PARAMS['min_slope']
+    # Clip the slope, in rad
+    clip_angle = np.deg2rad(cfg.PARAMS['min_slope'])
 
     out_volume = 0.
 
@@ -464,7 +464,7 @@ def mass_conservation_inversion(gdir, glen_a=None, fs=None, write=True,
     for cl in cls:
         # Clip slope to avoid negative and small slopes
         slope = cl['slope_angle']
-        slope = utils.clip_array(slope, np.deg2rad(clip_angle), np.pi/2.)
+        slope = utils.clip_array(slope, clip_angle, np.pi/2.)
 
         # Glacier width
         w = cl['width']

--- a/oggm/core/inversion.py
+++ b/oggm/core/inversion.py
@@ -94,8 +94,8 @@ def prepare_for_inversion(gdir, add_debug_var=False,
         utils.clip_min(flux, 0, out=flux)
 
         if np.sum(flux <= 0) > 1 and len(fls) == 1:
-            raise log.warning("More than one grid point has zero or "
-                              "negative flux: this should not happen.")
+            log.warning("More than one grid point has zero or "
+                        "negative flux: this should not happen.")
 
         if fl.flows_to is None and gdir.inversion_calving_rate == 0:
             if not np.allclose(flux[-1], 0., atol=0.1):
@@ -532,8 +532,8 @@ def mass_conservation_inversion(gdir, glen_a=None, fs=None, write=True,
 
         # Sanity check
         if np.any(out_thick <= 0):
-            raise log.warning("Found zero or negative thickness: "
-                              "this should not happen.")
+            log.warning("Found zero or negative thickness: "
+                        "this should not happen.")
 
         if write:
             cl['is_trapezoid'] = is_trap

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -1103,10 +1103,16 @@ class MultipleFlowlineMassBalance(MassBalanceModel):
 
         mbs = []
         widths = []
-        for fl, mb_mod in zip(self.fls, self.flowline_mb_models):
-            mb = mb_mod.get_annual_mb(fl.surface_h, year=year)
+        for i, (fl, mb_mod) in enumerate(zip(self.fls, self.flowline_mb_models)):
+            _widths = fl.widths
+            try:
+                # For rect and parabola don't compute spec mb
+                _widths = np.where(fl.thick > 0, _widths, 0)
+            except AttributeError:
+                pass
+            widths = np.append(widths, _widths)
+            mb = mb_mod.get_annual_mb(fl.surface_h, year=year, fls=fls, fl_id=i)
             mbs = np.append(mbs, mb * SEC_IN_YEAR * mb_mod.rho)
-            widths = np.append(widths, fl.widths)
 
         return np.average(mbs, weights=widths)
 
@@ -1132,6 +1138,7 @@ class MultipleFlowlineMassBalance(MassBalanceModel):
 @entity_task(log)
 def fixed_geometry_mass_balance(gdir, ys=None, ye=None, years=None,
                                 monthly_step=False,
+                                use_inversion_flowlines=True,
                                 climate_filename='climate_historical',
                                 climate_input_filesuffix=''):
     """Computes the mass-balance with climate input from e.g. CRU or a GCM.
@@ -1150,6 +1157,8 @@ def fixed_geometry_mass_balance(gdir, ys=None, ye=None, years=None,
     monthly_step : bool
         whether to store the diagnostic data at a monthly time step or not
         (default is yearly)
+    use_inversion_flowlines : bool
+        whether to use the inversion flowlines or the model flowlines
     climate_filename : str
         name of the climate file, e.g. 'climate_historical' (default) or
         'gcm_data'
@@ -1160,15 +1169,10 @@ def fixed_geometry_mass_balance(gdir, ys=None, ye=None, years=None,
     if monthly_step:
         raise NotImplementedError('monthly_step not implemented yet')
 
-    try:
-        mb = MultipleFlowlineMassBalance(gdir, mb_model_class=PastMassBalance,
-                                         filename=climate_filename,
-                                         input_filesuffix=climate_input_filesuffix)
-    except InvalidWorkflowError:
-        mb = MultipleFlowlineMassBalance(gdir, mb_model_class=PastMassBalance,
-                                         filename=climate_filename,
-                                         use_inversion_flowlines=True,
-                                         input_filesuffix=climate_input_filesuffix)
+    mb = MultipleFlowlineMassBalance(gdir, mb_model_class=PastMassBalance,
+                                     filename=climate_filename,
+                                     use_inversion_flowlines=use_inversion_flowlines,
+                                     input_filesuffix=climate_input_filesuffix)
 
     if years is None:
         if ys is None:

--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -250,11 +250,15 @@ inversion_fs = 0.
 fs = 0.
 
 ### INVERSION params
-# Clip the slope, in degrees
+# Clip the flowline slope, in degrees
 # This will affect several aspects of the processing chain:
-# flowline filtering, inversion, distributed inversion.
+# flowline filtering (slopes along the true model flowline below this
+# threshold are prevented), 1D inversion.
 # This is quite a sensitive parameter!
 min_slope = 2
+# This is for the interpolation of the 1D inversion back to 2D
+# It should be higher than min_slope
+distributed_inversion_min_slope = 6
 
 # Do you want to use shape factors to account for lateral drag?
 # Allowed is empty, "Adhikari", "Nye" (equivalent to "Adhikari") or "Huss"

--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -329,7 +329,7 @@ use_kcalving_for_run = True
 # units yr-1. This one is for the ice thickness inversion
 # Oerlemans and Nick (2005) use 2.4 yr-1, but qualitative tests and
 # Recinos et al., (2019) indicate that is should be much smaller.
-# We set it to 1 arbitrarily for a start
+# We set it to 0.6 according to Recinos et al 2019 for a start
 inversion_calving_k = 0.6
 # And this one is for the forward model
 calving_k = 0.6

--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -178,6 +178,12 @@ hydro_month_sh = 4
 # data space)
 tstar_search_window = 0, 0
 mu_star_halfperiod = 15
+# Reference data from WGMS is available since the 50s for some glaciers
+# The default is to use ALL the data for calibration (as long as there is
+# climate data for it), but it could be that you prefer to limit this space
+# as well: either because your data is of bad quality, or to allow more
+# meaningful comparisons.
+ref_mb_valid_window = 0, 0
 # For reference glaciers, t* can be searched according to the glacier-wide mu
 # or the per-flowline mu. The latter is more accurate, but also much slower.
 # Default is fast but slightly less accurate.

--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -251,7 +251,10 @@ fs = 0.
 
 ### INVERSION params
 # Clip the slope, in degrees
-min_slope = 1.5
+# This will affect several aspects of the processing chain:
+# flowline filtering, inversion, distributed inversion.
+# This is quite a sensitive parameter!
+min_slope = 5
 
 # Do you want to use shape factors to account for lateral drag?
 # Allowed is empty, "Adhikari", "Nye" (equivalent to "Adhikari") or "Huss"

--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -254,7 +254,7 @@ fs = 0.
 # This will affect several aspects of the processing chain:
 # flowline filtering, inversion, distributed inversion.
 # This is quite a sensitive parameter!
-min_slope = 5
+min_slope = 3
 
 # Do you want to use shape factors to account for lateral drag?
 # Allowed is empty, "Adhikari", "Nye" (equivalent to "Adhikari") or "Huss"

--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -213,10 +213,14 @@ run_mb_calibration = False
 climate_qc_months = 3
 # Bounds on mu*
 # Values out of these limits are considered bad and will lead to an error
-min_mu_star = 1.
+min_mu_star = 5.
 max_mu_star = 10000.
-# Whether to clip mu to a min of zero (only recommended for calving exps)
+# Whether to clip mu to a min of min_mu_star (only recommended for calving exps)
 clip_mu_star = False
+# fraction of the original (non-calving) mu* for this glacier that
+# you are ready to allow for. Totally arbitrary.
+calving_min_mu_star_frac = 0.5
+
 # For some glacier geometries, having one mu* for the entire glacier implies
 # that some tributaries should not exist and have a negative mass flux
 # at the terminus of their flowline.

--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -254,7 +254,7 @@ fs = 0.
 # This will affect several aspects of the processing chain:
 # flowline filtering, inversion, distributed inversion.
 # This is quite a sensitive parameter!
-min_slope = 3
+min_slope = 2
 
 # Do you want to use shape factors to account for lateral drag?
 # Allowed is empty, "Adhikari", "Nye" (equivalent to "Adhikari") or "Huss"

--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -219,7 +219,7 @@ max_mu_star = 10000.
 clip_mu_star = False
 # fraction of the original (non-calving) mu* for this glacier that
 # you are ready to allow for. Totally arbitrary.
-calving_min_mu_star_frac = 0.5
+calving_min_mu_star_frac = 0.7
 
 # For some glacier geometries, having one mu* for the entire glacier implies
 # that some tributaries should not exist and have a negative mass flux
@@ -330,9 +330,9 @@ use_kcalving_for_run = True
 # Oerlemans and Nick (2005) use 2.4 yr-1, but qualitative tests and
 # Recinos et al., (2019) indicate that is should be much smaller.
 # We set it to 1 arbitrarily for a start
-inversion_calving_k = 1
+inversion_calving_k = 0.6
 # And this one is for the forward model
-calving_k = 1
+calving_k = 0.6
 # Should we use a flux limiter for the calving model? It creates
 # quite high frontal thicknesses, but helps to keep the numerics stable
 calving_use_limiter = True

--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -255,7 +255,7 @@ fs = 0.
 # flowline filtering (slopes along the true model flowline below this
 # threshold are prevented), 1D inversion.
 # This is quite a sensitive parameter!
-min_slope = 2
+min_slope = 1.5
 min_slope_ice_caps = 1.5
 # This is for the interpolation of the 1D inversion back to 2D
 # It should be higher than min_slope

--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -256,6 +256,7 @@ fs = 0.
 # threshold are prevented), 1D inversion.
 # This is quite a sensitive parameter!
 min_slope = 2
+min_slope_ice_caps = 1.5
 # This is for the interpolation of the 1D inversion back to 2D
 # It should be higher than min_slope
 distributed_inversion_min_slope = 6

--- a/oggm/shop/bedtopo.py
+++ b/oggm/shop/bedtopo.py
@@ -6,13 +6,8 @@ try:
     import salem
 except ImportError:
     pass
-try:
-    import rasterio
-except ImportError:
-    pass
 
 from oggm import utils
-from oggm.exceptions import InvalidWorkflowError
 
 # Module logger
 log = logging.getLogger(__name__)
@@ -20,14 +15,19 @@ log = logging.getLogger(__name__)
 default_base_url = 'https://cluster.klima.uni-bremen.de/~fmaussion/icevol/composite/'
 
 
-@utils.entity_task(log)
-def reproject_thickness(gdir, base_url=None):
-    """Dummy docs
+@utils.entity_task(log, writes=['gridded_data'])
+def add_consensus_thickness(gdir, base_url=None):
+    """Add the consensus thickness estimate to the gridded_data file.
+
+    varname: consensus_ice_thickness
 
     Parameters
     ----------
-    gdir
-    dem_source
+    gdir ::py:class:`oggm.GlacierDirectory`
+        the glacier directory to process
+    base_url : str
+        where to find the thickness data. Default is
+        https://cluster.klima.uni-bremen.de/~fmaussion/icevol/composite
     """
 
     if base_url is None:
@@ -38,187 +38,33 @@ def reproject_thickness(gdir, base_url=None):
     rgi_str = gdir.rgi_id
     rgi_reg_str = rgi_str[:8]
 
-    url = base_url + rgi_reg_str  + '/' + rgi_str + '_thickness.tif'
+    url = base_url + rgi_reg_str + '/' + rgi_str + '_thickness.tif'
     input_file = utils.file_downloader(url)
 
-    base_dir = os.path.join(output_dir, 'thickness', rgi_reg_str)
-    mkdir(base_dir)
-    output_file = os.path.join(base_dir, rgi_str + '_thickness.tif')
-    if os.path.exists(output_file):
-        os.remove(output_file)
+    dsb = salem.GeoTiff(input_file)
+    thick = utils.clip_min(dsb.get_vardata(), 0)
+    in_volume = thick.sum() * dsb.grid.dx ** 2
+    thick = gdir.grid.map_gridded_data(thick, dsb.grid, interp='linear')
 
-    with rasterio.open(input_file) as src:
+    # Correct for volume
+    thick = utils.clip_min(thick.filled(0), 0)
+    out_volume = thick.sum() * gdir.grid.dx ** 2
+    if out_volume > 0:
+        thick *= in_volume / out_volume
 
-        kwargs = src.meta.copy()
-        data = src.read(1)
-        in_volume = np.sum(data * src.transform.a**2)
-
-        with rasterio.open(gdir.get_filepath('dem')) as tpl:
-
-            kwargs.update({
-                'crs': tpl.crs,
-                'transform': tpl.transform,
-                'width': tpl.width,
-                'height': tpl.height
-            })
-
-            with rasterio.open(output_file, 'w', **kwargs) as dst:
-                for i in range(1, src.count + 1):
-
-                    dest = np.zeros(shape=(tpl.height, tpl.width), dtype=data.dtype)
-
-                    reproject(
-                        source=rasterio.band(src, i),
-                        destination=dest,
-                        src_transform=src.transform,
-                        src_crs=src.crs,
-                        dst_transform=tpl.transform,
-                        dst_crs=tpl.crs,
-                        resampling=Resampling.bilinear)
-
-                    # Correct for volume
-                    dest = clip_min(dest, 0)
-                    out_volume = np.sum(dest * dst.transform.a**2)
-                    if in_volume > 0:
-                        dest = dest * out_volume / in_volume
-
-                    dst.write(dest, indexes=i)
-
-
-def _reproject_and_scale(gdir, do_error=False):
-    """Reproject and scale itslive data, avoid code duplication for error"""
-
-
-    reg = find_region(gdir)
-    if reg is None:
-        raise InvalidWorkflowError('There does not seem to be its_live data '
-                                   'available for this glacier')
-
-    vnx = 'vx'
-    vny = 'vy'
-    if do_error:
-        vnx += '_err'
-        vny += '_err'
-
-    with utils.get_lock():
-        fx = utils.file_downloader(region_files[reg][vnx])
-        fy = utils.file_downloader(region_files[reg][vny])
-
-    # Open the files
-    dsx = salem.GeoTiff(fx)
-    dsy = salem.GeoTiff(fy)
-    # subset them to our map
-    grid_gla = gdir.grid.center_grid
-    proj_vel = dsx.grid.proj
-    x0, x1, y0, y1 = grid_gla.extent_in_crs(proj_vel)
-    dsx.set_subset(corners=((x0, y0), (x1, y1)), crs=proj_vel, margin=4)
-    dsy.set_subset(corners=((x0, y0), (x1, y1)), crs=proj_vel, margin=4)
-    grid_vel = dsx.grid.center_grid
-
-    # TODO: this should be taken care of by salem
-    # https://github.com/fmaussion/salem/issues/171
-    with rasterio.Env():
-        with rasterio.open(fx) as src:
-            nodata = getattr(src, 'nodata', -32767.0)
-
-    # Error files are wrong
-    if nodata == 0:
-        nodata = -32767.0
-
-    # Get the coords at t0
-    xx0, yy0 = grid_vel.center_grid.xy_coordinates
-
-    # Compute coords at t1
-    xx1 = dsx.get_vardata()
-    yy1 = dsy.get_vardata()
-    non_valid = (xx1 == nodata) | (yy1 == nodata)
-    xx1[non_valid] = np.NaN
-    yy1[non_valid] = np.NaN
-    orig_vel = np.sqrt(xx1**2 + yy1**2)
-    xx1 += xx0
-    yy1 += yy0
-
-    # Transform both to glacier proj
-    xx0, yy0 = salem.transform_proj(proj_vel, grid_gla.proj, xx0, yy0)
-    xx1, yy1 = salem.transform_proj(proj_vel, grid_gla.proj, xx1, yy1)
-
-    # Correct no data after proj as well (inf)
-    xx1[non_valid] = np.NaN
-    yy1[non_valid] = np.NaN
-
-    # Compute velocities from there
-    vx = xx1 - xx0
-    vy = yy1 - yy0
-
-    # Scale back velocities - https://github.com/OGGM/oggm/issues/1014
-    new_vel = np.sqrt(vx**2 + vy**2)
-    p_ok = new_vel > 1e-5  # avoid div by zero
-    vx[p_ok] = vx[p_ok] * orig_vel[p_ok] / new_vel[p_ok]
-    vy[p_ok] = vy[p_ok] * orig_vel[p_ok] / new_vel[p_ok]
-
-    # And transform to local map
-    vx = grid_gla.map_gridded_data(vx, grid=grid_vel, interp='linear')
-    vy = grid_gla.map_gridded_data(vy, grid=grid_vel, interp='linear')
+    # We mask zero ice as nodata
+    thick = np.where(thick == 0, np.NaN, thick)
 
     # Write
     with utils.ncDataset(gdir.get_filepath('gridded_data'), 'a') as nc:
-        vn = 'obs_icevel_x'
-        if do_error:
-            vn = vn.replace('obs', 'err')
+
+        vn = 'consensus_ice_thickness'
         if vn in nc.variables:
             v = nc.variables[vn]
         else:
             v = nc.createVariable(vn, 'f4', ('y', 'x', ), zlib=True)
-        v.units = 'm yr-1'
-        ln = 'ITS LIVE velocity data in x map direction'
-        if do_error:
-            ln = 'Uncertainty of ' + ln
+        v.units = 'm'
+        ln = 'Ice thickness from the consensus estimate'
         v.long_name = ln
-        v[:] = vx.filled(np.nan)
-
-        vn = 'obs_icevel_y'
-        if do_error:
-            vn = vn.replace('obs', 'err')
-        if vn in nc.variables:
-            v = nc.variables[vn]
-        else:
-            v = nc.createVariable(vn, 'f4', ('y', 'x', ), zlib=True)
-        v.units = 'm yr-1'
-        ln = 'ITS LIVE velocity data in y map direction'
-        if do_error:
-            ln = 'Uncertainty of ' + ln
-        v.long_name = ln
-        v[:] = vy.filled(np.nan)
-
-
-@utils.entity_task(log, writes=['gridded_data'])
-def velocity_to_gdir(gdir, add_error=False):
-    """Reproject the its_live files to the given glacier directory.
-
-    Variables are added to the gridded_data nc file.
-
-    Reprojecting velocities from one map proj to another is done
-    reprojecting the vector distances. In this process, absolute velocities
-    might change as well because map projections do not always preserve
-    distances -> we scale them back to the original velocities as per the
-    ITS_LIVE documentation that states that velocities are given in
-    ground units, i.e. absolute velocities.
-
-    We use bilinear interpolation to reproject the velocities to the local
-    glacier map.
-
-    Parameters
-    ----------
-    gdir : :py:class:`oggm.GlacierDirectory`
-        where to write the data
-    add_error : bool
-        also reproject and scale the error data
-    """
-
-    if not gdir.has_file('gridded_data'):
-        raise InvalidWorkflowError('Please run `glacier_masks` before running '
-                                   'this task')
-
-    _reproject_and_scale(gdir, do_error=False)
-    if add_error:
-        _reproject_and_scale(gdir, do_error=True)
+        v.base_url = base_url
+        v[:] = thick

--- a/oggm/shop/bedtopo.py
+++ b/oggm/shop/bedtopo.py
@@ -1,0 +1,224 @@
+import logging
+
+import numpy as np
+
+try:
+    import salem
+except ImportError:
+    pass
+try:
+    import rasterio
+except ImportError:
+    pass
+
+from oggm import utils
+from oggm.exceptions import InvalidWorkflowError
+
+# Module logger
+log = logging.getLogger(__name__)
+
+default_base_url = 'https://cluster.klima.uni-bremen.de/~fmaussion/icevol/composite/'
+
+
+@utils.entity_task(log)
+def reproject_thickness(gdir, base_url=None):
+    """Dummy docs
+
+    Parameters
+    ----------
+    gdir
+    dem_source
+    """
+
+    if base_url is None:
+        base_url = default_base_url
+    if not base_url.endswith('/'):
+        base_url += '/'
+
+    rgi_str = gdir.rgi_id
+    rgi_reg_str = rgi_str[:8]
+
+    url = base_url + rgi_reg_str  + '/' + rgi_str + '_thickness.tif'
+    input_file = utils.file_downloader(url)
+
+    base_dir = os.path.join(output_dir, 'thickness', rgi_reg_str)
+    mkdir(base_dir)
+    output_file = os.path.join(base_dir, rgi_str + '_thickness.tif')
+    if os.path.exists(output_file):
+        os.remove(output_file)
+
+    with rasterio.open(input_file) as src:
+
+        kwargs = src.meta.copy()
+        data = src.read(1)
+        in_volume = np.sum(data * src.transform.a**2)
+
+        with rasterio.open(gdir.get_filepath('dem')) as tpl:
+
+            kwargs.update({
+                'crs': tpl.crs,
+                'transform': tpl.transform,
+                'width': tpl.width,
+                'height': tpl.height
+            })
+
+            with rasterio.open(output_file, 'w', **kwargs) as dst:
+                for i in range(1, src.count + 1):
+
+                    dest = np.zeros(shape=(tpl.height, tpl.width), dtype=data.dtype)
+
+                    reproject(
+                        source=rasterio.band(src, i),
+                        destination=dest,
+                        src_transform=src.transform,
+                        src_crs=src.crs,
+                        dst_transform=tpl.transform,
+                        dst_crs=tpl.crs,
+                        resampling=Resampling.bilinear)
+
+                    # Correct for volume
+                    dest = clip_min(dest, 0)
+                    out_volume = np.sum(dest * dst.transform.a**2)
+                    if in_volume > 0:
+                        dest = dest * out_volume / in_volume
+
+                    dst.write(dest, indexes=i)
+
+
+def _reproject_and_scale(gdir, do_error=False):
+    """Reproject and scale itslive data, avoid code duplication for error"""
+
+
+    reg = find_region(gdir)
+    if reg is None:
+        raise InvalidWorkflowError('There does not seem to be its_live data '
+                                   'available for this glacier')
+
+    vnx = 'vx'
+    vny = 'vy'
+    if do_error:
+        vnx += '_err'
+        vny += '_err'
+
+    with utils.get_lock():
+        fx = utils.file_downloader(region_files[reg][vnx])
+        fy = utils.file_downloader(region_files[reg][vny])
+
+    # Open the files
+    dsx = salem.GeoTiff(fx)
+    dsy = salem.GeoTiff(fy)
+    # subset them to our map
+    grid_gla = gdir.grid.center_grid
+    proj_vel = dsx.grid.proj
+    x0, x1, y0, y1 = grid_gla.extent_in_crs(proj_vel)
+    dsx.set_subset(corners=((x0, y0), (x1, y1)), crs=proj_vel, margin=4)
+    dsy.set_subset(corners=((x0, y0), (x1, y1)), crs=proj_vel, margin=4)
+    grid_vel = dsx.grid.center_grid
+
+    # TODO: this should be taken care of by salem
+    # https://github.com/fmaussion/salem/issues/171
+    with rasterio.Env():
+        with rasterio.open(fx) as src:
+            nodata = getattr(src, 'nodata', -32767.0)
+
+    # Error files are wrong
+    if nodata == 0:
+        nodata = -32767.0
+
+    # Get the coords at t0
+    xx0, yy0 = grid_vel.center_grid.xy_coordinates
+
+    # Compute coords at t1
+    xx1 = dsx.get_vardata()
+    yy1 = dsy.get_vardata()
+    non_valid = (xx1 == nodata) | (yy1 == nodata)
+    xx1[non_valid] = np.NaN
+    yy1[non_valid] = np.NaN
+    orig_vel = np.sqrt(xx1**2 + yy1**2)
+    xx1 += xx0
+    yy1 += yy0
+
+    # Transform both to glacier proj
+    xx0, yy0 = salem.transform_proj(proj_vel, grid_gla.proj, xx0, yy0)
+    xx1, yy1 = salem.transform_proj(proj_vel, grid_gla.proj, xx1, yy1)
+
+    # Correct no data after proj as well (inf)
+    xx1[non_valid] = np.NaN
+    yy1[non_valid] = np.NaN
+
+    # Compute velocities from there
+    vx = xx1 - xx0
+    vy = yy1 - yy0
+
+    # Scale back velocities - https://github.com/OGGM/oggm/issues/1014
+    new_vel = np.sqrt(vx**2 + vy**2)
+    p_ok = new_vel > 1e-5  # avoid div by zero
+    vx[p_ok] = vx[p_ok] * orig_vel[p_ok] / new_vel[p_ok]
+    vy[p_ok] = vy[p_ok] * orig_vel[p_ok] / new_vel[p_ok]
+
+    # And transform to local map
+    vx = grid_gla.map_gridded_data(vx, grid=grid_vel, interp='linear')
+    vy = grid_gla.map_gridded_data(vy, grid=grid_vel, interp='linear')
+
+    # Write
+    with utils.ncDataset(gdir.get_filepath('gridded_data'), 'a') as nc:
+        vn = 'obs_icevel_x'
+        if do_error:
+            vn = vn.replace('obs', 'err')
+        if vn in nc.variables:
+            v = nc.variables[vn]
+        else:
+            v = nc.createVariable(vn, 'f4', ('y', 'x', ), zlib=True)
+        v.units = 'm yr-1'
+        ln = 'ITS LIVE velocity data in x map direction'
+        if do_error:
+            ln = 'Uncertainty of ' + ln
+        v.long_name = ln
+        v[:] = vx.filled(np.nan)
+
+        vn = 'obs_icevel_y'
+        if do_error:
+            vn = vn.replace('obs', 'err')
+        if vn in nc.variables:
+            v = nc.variables[vn]
+        else:
+            v = nc.createVariable(vn, 'f4', ('y', 'x', ), zlib=True)
+        v.units = 'm yr-1'
+        ln = 'ITS LIVE velocity data in y map direction'
+        if do_error:
+            ln = 'Uncertainty of ' + ln
+        v.long_name = ln
+        v[:] = vy.filled(np.nan)
+
+
+@utils.entity_task(log, writes=['gridded_data'])
+def velocity_to_gdir(gdir, add_error=False):
+    """Reproject the its_live files to the given glacier directory.
+
+    Variables are added to the gridded_data nc file.
+
+    Reprojecting velocities from one map proj to another is done
+    reprojecting the vector distances. In this process, absolute velocities
+    might change as well because map projections do not always preserve
+    distances -> we scale them back to the original velocities as per the
+    ITS_LIVE documentation that states that velocities are given in
+    ground units, i.e. absolute velocities.
+
+    We use bilinear interpolation to reproject the velocities to the local
+    glacier map.
+
+    Parameters
+    ----------
+    gdir : :py:class:`oggm.GlacierDirectory`
+        where to write the data
+    add_error : bool
+        also reproject and scale the error data
+    """
+
+    if not gdir.has_file('gridded_data'):
+        raise InvalidWorkflowError('Please run `glacier_masks` before running '
+                                   'this task')
+
+    _reproject_and_scale(gdir, do_error=False)
+    if add_error:
+        _reproject_and_scale(gdir, do_error=True)

--- a/oggm/tasks.py
+++ b/oggm/tasks.py
@@ -42,6 +42,7 @@ from oggm.core.inversion import filter_inversion_output
 from oggm.core.inversion import distribute_thickness_per_altitude
 from oggm.core.inversion import distribute_thickness_interp
 from oggm.core.inversion import find_inversion_calving
+from oggm.core.inversion import get_inversion_volume
 from oggm.core.flowline import init_present_time_glacier
 from oggm.core.flowline import run_random_climate
 from oggm.core.flowline import run_from_climate_data

--- a/oggm/tests/funcs.py
+++ b/oggm/tests/funcs.py
@@ -409,7 +409,7 @@ def init_hef(reset=False, border=40, logging_level='INFO'):
 
 def init_columbia(reset=False):
 
-    from oggm.core import gis, climate, centerlines
+    from oggm.core import gis, centerlines
     import geopandas as gpd
 
     # test directory
@@ -439,6 +439,38 @@ def init_columbia(reset=False):
     centerlines.catchment_intersections(gdir)
     centerlines.catchment_width_geom(gdir)
     centerlines.catchment_width_correction(gdir)
+    tasks.process_dummy_cru_file(gdir, seed=0)
+    return gdir
+
+
+def init_columbia_eb(reset=False):
+
+    from oggm.core import gis, centerlines
+    import geopandas as gpd
+
+    # test directory
+    testdir = os.path.join(get_test_dir(), 'tmp_columbia_eb')
+    if not os.path.exists(testdir):
+        os.makedirs(testdir)
+        reset = True
+
+    # Init
+    cfg.initialize()
+    cfg.PATHS['working_dir'] = testdir
+    cfg.PARAMS['use_intersects'] = False
+    cfg.PATHS['dem_file'] = get_demo_file('dem_Columbia.tif')
+    cfg.PARAMS['border'] = 10
+
+    entity = gpd.read_file(get_demo_file('01_rgi60_Columbia.shp')).iloc[0]
+    gdir = oggm.GlacierDirectory(entity, reset=reset)
+    if gdir.has_file('climate_historical'):
+        return gdir
+
+    gis.define_glacier_region(gdir)
+    gis.simple_glacier_masks(gdir)
+    centerlines.elevation_band_flowline(gdir)
+    centerlines.fixed_dx_elevation_band_flowline(gdir)
+    centerlines.compute_downstream_line(gdir)
     tasks.process_dummy_cru_file(gdir, seed=0)
     return gdir
 

--- a/oggm/tests/test_benchmarks.py
+++ b/oggm/tests/test_benchmarks.py
@@ -222,7 +222,7 @@ class TestSouthGlacier(unittest.TestCase):
 
         # Loose tests based on correlations
         cf = df.corr()
-        assert cf.loc['slope', 'slope_factor'] < -0.9
+        assert cf.loc['slope', 'slope_factor'] < -0.85
         assert cf.loc['slope', 'thick'] < -0.4
         assert cf.loc['dis_from_border', 'thick'] > 0.2
         assert cf.loc['oggm_mb_above_z', 'thick'] > 0.5

--- a/oggm/tests/test_benchmarks.py
+++ b/oggm/tests/test_benchmarks.py
@@ -423,6 +423,7 @@ class TestSouthGlacier(unittest.TestCase):
         execute_entity_task(tasks.filter_inversion_output, gdirs)
 
         df = utils.compile_glacier_statistics(gdirs)
+        df['inv_thickness_m'] = df['inv_volume_km3'] / df['rgi_area_km2'] * 1e3
         assert df.inv_thickness_m[0] < 100
 
         df = utils.compile_fixed_geometry_mass_balance(gdirs)

--- a/oggm/tests/test_graphics.py
+++ b/oggm/tests/test_graphics.py
@@ -369,6 +369,7 @@ def test_ice_cap():
     df = gpd.read_file(get_demo_file('divides_RGI50-05.08389.shp'))
     df['Area'] = df.Area * 1e-6  # cause it was in m2
     df['RGIId'] = ['RGI50-05.08389_d{:02d}'.format(d+1) for d in df.index]
+    df['GlacType'] = '1099'  # Make an ice cap
 
     gdirs = workflow.init_glacier_directories(df)
     workflow.gis_prepro_tasks(gdirs)

--- a/oggm/tests/test_graphics.py
+++ b/oggm/tests/test_graphics.py
@@ -354,7 +354,7 @@ def test_chhota_shigri():
 
 
 @pytest.mark.graphic
-@mpl_image_compare()
+@mpl_image_compare(multi=True)
 def test_ice_cap():
 
     testdir = os.path.join(get_test_dir(), 'tmp_icecap')

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -2901,7 +2901,7 @@ class TestHEF:
         assert out[3].volume.min() > out[2].volume.min()
         assert out[3].volume.max() < out[2].volume.max()
 
-        if do_plot
+        if do_plot:
             plt.figure()
             for ds, lab in zip(out, feedbacks):
                 (ds.volume*1e-9).plot(label=lab)

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -2810,6 +2810,15 @@ class TestHEF:
             np.testing.assert_allclose(fmod.area_km2, area, rtol=0.05)
             np.testing.assert_allclose(fmod.volume_km3, vol, rtol=0.05)
 
+        # Again to check that time is correct
+        run_from_climate_data(hef_gdir, ys=None, ye=None,
+                              init_model_filesuffix='_1',
+                              output_filesuffix='_4')
+        fp = hef_gdir.get_filepath('model_run', filesuffix='_4')
+        with FileModel(fp) as fmod:
+            assert fmod.y0 == 2002
+            assert fmod.last_yr == 2003
+
     @pytest.mark.slow
     def test_cesm(self, hef_gdir):
 

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -2859,8 +2859,8 @@ class TestHEF:
                               output_filesuffix='_afterspinup')
         ds3 = utils.compile_run_output([gdir], path=False,
                                        input_filesuffix='_afterspinup')
-        assert (ds1.volume.isel(rgi_id=0, time=-1) <
-                0.7*ds3.volume.isel(rgi_id=0, time=-1))
+        assert (ds1.volume.isel(rgi_id=0, time=-1).data <
+                0.75*ds3.volume.isel(rgi_id=0, time=-1).data)
         ds3.close()
 
         # Try the compile optimisation
@@ -2897,10 +2897,11 @@ class TestHEF:
         assert_allclose(out[0].volume, out[1].volume, rtol=0.05)
         assert_allclose(out[0].volume, out[2].volume, rtol=0.05)
         assert_allclose(out[1].volume, out[2].volume, rtol=0.05)
-        # Except for "never", where things are different
-        assert out[3].volume.mean() < out[2].volume.mean()
+        # Except for "never", where things are different and less variable
+        assert out[3].volume.min() > out[2].volume.min()
+        assert out[3].volume.max() < out[2].volume.max()
 
-        if do_plot:
+        if do_plot
             plt.figure()
             for ds, lab in zip(out, feedbacks):
                 (ds.volume*1e-9).plot(label=lab)

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -2727,17 +2727,17 @@ class TestHEF:
                                  input_filesuffix='_def',
                                  tmp_file_size=1)
 
-        # This DOESNT because bad programming
-        # cfg.PARAMS['use_kcalving_for_run'] = True
-        # init_present_time_glacier(hef_gdir)
-        # init_present_time_glacier(gdir_calving)
-        # run_constant_climate(hef_gdir, nyears=10,
-        #                      bias=0, output_filesuffix='_def')
-        # run_constant_climate(gdir_calving, nyears=10, water_level=0,
-        #                      bias=0, output_filesuffix='_def')
-        # utils.compile_run_output([gdir_calving, hef_gdir],
-        #                          input_filesuffix='_def',
-        #                          tmp_file_size=1)
+        # This should work although one calves the other not
+        cfg.PARAMS['use_kcalving_for_run'] = True
+        init_present_time_glacier(hef_gdir)
+        init_present_time_glacier(gdir_calving)
+        run_constant_climate(hef_gdir, nyears=10,
+                             bias=0, output_filesuffix='_def')
+        run_constant_climate(gdir_calving, nyears=10, water_level=0,
+                             bias=0, output_filesuffix='_def')
+        utils.compile_run_output([gdir_calving, hef_gdir],
+                                 input_filesuffix='_def',
+                                 tmp_file_size=1)
 
     def test_start_from_spinup(self, hef_gdir):
 

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -2640,7 +2640,6 @@ class TestHEF:
                 np.testing.assert_allclose(area.iloc[0], np.mean(area),
                                            rtol=0.1)
 
-
     @pytest.mark.slow
     def test_random_sh(self, gdir_sh, hef_gdir):
 
@@ -2730,7 +2729,7 @@ class TestHEF:
             np.testing.assert_allclose(fmod.area_km2, area)
             np.testing.assert_allclose(fmod.volume_km3, vol)
 
-    def test_start_from_spinup_min_ys(self, hef_gdir):
+    def test_start_from_spinup_minmax_ys(self, hef_gdir):
 
         init_present_time_glacier(hef_gdir)
 
@@ -2743,7 +2742,7 @@ class TestHEF:
         assert hef_gdir.rgi_date == 2003
 
         # Make a dummy run for 0 years
-        run_from_climate_data(hef_gdir, ye=2002, min_ys=2002,
+        run_from_climate_data(hef_gdir, ye=2002, max_ys=2002,
                               output_filesuffix='_1')
 
         fp = hef_gdir.get_filepath('model_run', filesuffix='_1')
@@ -2753,10 +2752,19 @@ class TestHEF:
             np.testing.assert_allclose(fmod.volume_km3, vol)
 
         # Again
-        run_from_climate_data(hef_gdir, ys=2002, ye=2003,
-                              init_model_filesuffix='_1',
+        run_from_climate_data(hef_gdir, ye=2005, min_ys=2005,
                               output_filesuffix='_2')
         fp = hef_gdir.get_filepath('model_run', filesuffix='_2')
+        with FileModel(fp) as fmod:
+            fmod.run_until(fmod.last_yr)
+            np.testing.assert_allclose(fmod.area_km2, area)
+            np.testing.assert_allclose(fmod.volume_km3, vol)
+
+        # Again
+        run_from_climate_data(hef_gdir, ys=2002, ye=2003,
+                              init_model_filesuffix='_1',
+                              output_filesuffix='_3')
+        fp = hef_gdir.get_filepath('model_run', filesuffix='_3')
         with FileModel(fp) as fmod:
             fmod.run_until(fmod.last_yr)
             np.testing.assert_allclose(fmod.area_km2, area, rtol=0.05)

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -1663,6 +1663,7 @@ def inversion_gdir(class_case_dir):
 
     # Init
     cfg.initialize()
+    cfg.PARAMS['min_slope'] = 2
     cfg.set_intersects_db(get_demo_file('rgi_intersect_oetztal.shp'))
     cfg.PATHS['dem_file'] = get_demo_file('hef_srtm.tif')
     cfg.PATHS['climate_file'] = get_demo_file('histalp_merged_hef.nc')

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -1663,7 +1663,6 @@ def inversion_gdir(class_case_dir):
 
     # Init
     cfg.initialize()
-    cfg.PARAMS['min_slope'] = 2
     cfg.set_intersects_db(get_demo_file('rgi_intersect_oetztal.shp'))
     cfg.PATHS['dem_file'] = get_demo_file('hef_srtm.tif')
     cfg.PATHS['climate_file'] = get_demo_file('histalp_merged_hef.nc')

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -2748,7 +2748,8 @@ class TestCoxeCalving(unittest.TestCase):
         inversion.mass_conservation_inversion(gdir)
         fls1 = gdir.read_pickle('inversion_flowlines')
         cls1 = gdir.read_pickle('inversion_output')
-
+        # Increase calving for this one
+        cfg.PARAMS['inversion_calving_k'] = 1
         out = inversion.find_inversion_calving(gdir)
         fls2 = gdir.read_pickle('inversion_flowlines')
         cls2 = gdir.read_pickle('inversion_output')
@@ -2895,7 +2896,7 @@ class TestColumbiaCalving(unittest.TestCase):
         mu_bef = gdir.get_diagnostics()['mu_star_before_calving']
         frac = cfg.PARAMS['calving_min_mu_star_frac']
         assert df['calving_mu_star'] == mu_bef * frac
-        assert df['calving_flux'] > 1
+        assert df['calving_flux'] > 0.5
 
         # Test that new MB equal flux
         mbmod = massbalance.MultipleFlowlineMassBalance

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -2301,7 +2301,7 @@ class TestInversion(unittest.TestCase):
         df = workflow.calibrate_inversion_from_consensus_estimate(gdir,
                                                                   a_bounds=a,
                                                                   error_on_mismatch=False)
-        np.testing.assert_allclose(df.vol_itmix_m3, df.vol_oggm_m3, rtol=0.06)
+        np.testing.assert_allclose(df.vol_itmix_m3, df.vol_oggm_m3, rtol=0.07)
 
     def test_invert_hef_shapes(self):
 
@@ -2836,7 +2836,7 @@ class TestColumbiaCalving(unittest.TestCase):
         cfg.PARAMS['inversion_calving_k'] = 0.2
         df = inversion.find_inversion_calving(gdir)
 
-        assert df['calving_flux'] > 0.5
+        assert df['calving_flux'] > 0.2
         assert df['calving_flux'] < 1
         assert df['calving_mu_star'] > 0
 

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -1119,7 +1119,7 @@ class TestGeometry(unittest.TestCase):
         centerlines.initialize_flowlines(gdir)
 
         fls = gdir.read_pickle('inversion_flowlines')
-        min_slope = np.deg2rad(cfg.PARAMS['min_slope'])
+        min_slope = np.deg2rad(cfg.PARAMS['min_slope'] - 0.5)
         for fl in fls:
             dx = fl.dx * gdir.grid.dx
             slope = np.arctan(-np.gradient(fl.surface_h, dx))
@@ -2243,7 +2243,7 @@ class TestInversion(unittest.TestCase):
             if _max > maxs:
                 maxs = _max
             v += np.nansum(cl['volume'])
-        np.testing.assert_allclose(242, maxs, atol=25)
+        np.testing.assert_allclose(242, maxs, atol=40)
         np.testing.assert_allclose(ref_v, v)
 
         # Sanity check - velocities
@@ -2266,12 +2266,6 @@ class TestInversion(unittest.TestCase):
         inv = gdir.read_pickle('inversion_output')[-1]
 
         np.testing.assert_allclose(velocity, inv['u_integrated'])
-
-        # In the middle section the velocities look OK and should be close
-        # to the no sliding assumption
-        np.testing.assert_allclose(inv['u_surface'][20:60],
-                                   inv['u_integrated'][20:60] / 0.8,
-                                   rtol=0.17)
 
     def test_invert_hef_from_consensus(self):
 
@@ -2462,7 +2456,7 @@ class TestInversion(unittest.TestCase):
             if _max > maxs:
                 maxs = _max
             v += np.nansum(cl['volume'])
-        np.testing.assert_allclose(242, maxs, atol=25)
+        np.testing.assert_allclose(242, maxs, atol=50)
         np.testing.assert_allclose(ref_v, v)
 
     def test_invert_hef_from_any_mb(self):

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -2303,6 +2303,12 @@ class TestInversion(unittest.TestCase):
             workflow.calibrate_inversion_from_consensus_estimate(gdir,
                                                                  a_bounds=a)
 
+        a = (0.1, 5)
+        df = workflow.calibrate_inversion_from_consensus_estimate(gdir,
+                                                                  a_bounds=a,
+                                                                  error_on_mismatch=False)
+        np.testing.assert_allclose(df.vol_itmix_m3, df.vol_oggm_m3, rtol=0.06)
+
     def test_invert_hef_shapes(self):
 
         hef_file = get_demo_file('Hintereisferner_RGI5.shp')

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -2297,6 +2297,11 @@ class TestInversion(unittest.TestCase):
         inversion.prepare_for_inversion(gdir)
         df = workflow.calibrate_inversion_from_consensus_estimate(gdir)
         np.testing.assert_allclose(df.vol_itmix_m3, df.vol_oggm_m3, rtol=0.01)
+        # Make it fail
+        with pytest.raises(ValueError):
+            a = (0.1, 3)
+            workflow.calibrate_inversion_from_consensus_estimate(gdir,
+                                                                 a_bounds=a)
 
     def test_invert_hef_shapes(self):
 

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -2289,19 +2289,26 @@ class TestInversion(unittest.TestCase):
         climate.local_t_star(gdir, tstar=t_star, bias=bias)
         climate.mu_star_calibration(gdir)
         inversion.prepare_for_inversion(gdir)
-        df = workflow.calibrate_inversion_from_consensus_estimate(gdir)
+        df = workflow.calibrate_inversion_from_consensus(gdir)
         np.testing.assert_allclose(df.vol_itmix_m3, df.vol_oggm_m3, rtol=0.01)
         # Make it fail
         with pytest.raises(ValueError):
             a = (0.1, 3)
-            workflow.calibrate_inversion_from_consensus_estimate(gdir,
-                                                                 a_bounds=a)
+            workflow.calibrate_inversion_from_consensus(gdir,
+                                                        a_bounds=a)
 
         a = (0.1, 5)
-        df = workflow.calibrate_inversion_from_consensus_estimate(gdir,
-                                                                  a_bounds=a,
-                                                                  error_on_mismatch=False)
+        df = workflow.calibrate_inversion_from_consensus(gdir,
+                                                         a_bounds=a,
+                                                         error_on_mismatch=False)
         np.testing.assert_allclose(df.vol_itmix_m3, df.vol_oggm_m3, rtol=0.07)
+
+        # With fs it can work
+        a = (0.1, 3)
+        df = workflow.calibrate_inversion_from_consensus(gdir,
+                                                         a_bounds=a,
+                                                         apply_fs_on_mismatch=True)
+        np.testing.assert_allclose(df.vol_itmix_m3, df.vol_oggm_m3, rtol=0.01)
 
     def test_invert_hef_shapes(self):
 

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -1119,7 +1119,7 @@ class TestGeometry(unittest.TestCase):
         centerlines.initialize_flowlines(gdir)
 
         fls = gdir.read_pickle('inversion_flowlines')
-        min_slope = np.deg2rad(cfg.PARAMS['min_slope'] - 0.5)
+        min_slope = np.deg2rad(cfg.PARAMS['min_slope'])
         for fl in fls:
             dx = fl.dx * gdir.grid.dx
             slope = np.arctan(-np.gradient(fl.surface_h, dx))

--- a/oggm/tests/test_shop.py
+++ b/oggm/tests/test_shop.py
@@ -455,8 +455,9 @@ class Test_bedtopo:
         np.testing.assert_allclose(my_vol, ref_vol)
 
         # Now check the rest of the workflow
+        # Check that no error when var not there
         vn = 'consensus_ice_thickness'
-        centerlines.elevation_band_flowline(gdir, bin_variables=vn)
+        centerlines.elevation_band_flowline(gdir, bin_variables=[vn, 'foo'])
 
         # Check vol
         df = pd.read_csv(gdir.get_filepath('elevation_band_flowline'),
@@ -464,7 +465,8 @@ class Test_bedtopo:
         my_vol = (df[vn] * df['area']).sum()
         np.testing.assert_allclose(my_vol, ref_vol)
 
-        centerlines.fixed_dx_elevation_band_flowline(gdir, bin_variables=vn)
+        centerlines.fixed_dx_elevation_band_flowline(gdir,
+                                                     bin_variables=[vn, 'foo'])
         fdf = pd.read_csv(gdir.get_filepath('elevation_band_flowline',
                                             filesuffix='_fixed_dx'),
                           index_col=0)

--- a/oggm/tests/test_shop.py
+++ b/oggm/tests/test_shop.py
@@ -3,11 +3,6 @@ import warnings
 warnings.filterwarnings("once", category=DeprecationWarning)  # noqa: E402
 
 import pytest
-pytest.importorskip('geopandas')
-pytest.importorskip('rasterio')
-pytest.importorskip('salem')
-
-
 salem = pytest.importorskip('salem')
 gpd = pytest.importorskip('geopandas')
 
@@ -17,8 +12,8 @@ import numpy as np
 import pandas as pd
 from oggm import utils
 from oggm.utils import get_demo_file
-from oggm.shop import its_live, rgitopo
-from oggm.core import gis
+from oggm.shop import its_live, rgitopo, bedtopo
+from oggm.core import gis, centerlines
 from oggm import cfg, tasks, workflow
 
 pytestmark = pytest.mark.test_env("utils")
@@ -407,3 +402,73 @@ class Test_climate_datasets:
             # Fake tests, the plots look plausible
             np.testing.assert_allclose(d2.gradient.mean(), -0.0058, atol=.001)
             np.testing.assert_allclose(d2.temp_std.mean(), 3.35, atol=0.1)
+
+
+class Test_bedtopo:
+
+    def test_add_consensus(self, class_case_dir, monkeypatch):
+
+        # Init
+        cfg.initialize()
+        cfg.PARAMS['use_intersects'] = False
+        cfg.PATHS['working_dir'] = class_case_dir
+        cfg.PATHS['dem_file'] = get_demo_file('hef_srtm.tif')
+
+        entity = gpd.read_file(get_demo_file('Hintereisferner_RGI5.shp'))
+        entity['RGIId'] = 'RGI60-11.00897'
+        gdir = workflow.init_glacier_directories(entity)[0]
+        tasks.define_glacier_region(gdir)
+        tasks.glacier_masks(gdir)
+
+        ft = utils.get_demo_file('RGI60-11.00897_thickness.tif')
+        monkeypatch.setattr(utils, 'file_downloader', lambda x: ft)
+        bedtopo.add_consensus_thickness(gdir)
+
+        # Check with rasterio
+        cfg.add_to_basenames('consensus', 'consensus.tif')
+        gis.rasterio_to_gdir(gdir, ft, 'consensus', resampling='bilinear')
+
+        with xr.open_dataset(gdir.get_filepath('gridded_data')) as ds:
+            mine = ds.consensus_ice_thickness
+
+        with xr.open_rasterio(gdir.get_filepath('consensus')) as ds:
+            ref = ds.isel(band=0)
+
+        # Check area
+        my_area = np.sum(np.isfinite(mine.data)) * gdir.grid.dx**2
+        np.testing.assert_allclose(my_area, gdir.rgi_area_m2, rtol=0.07)
+
+        rio_area = np.sum(ref.data > 0) * gdir.grid.dx**2
+        np.testing.assert_allclose(rio_area, gdir.rgi_area_m2, rtol=0.15)
+        np.testing.assert_allclose(my_area, rio_area, rtol=0.15)
+
+        # They are not same:
+        # - interpolation not 1to1 same especially at borders
+        # - we preserve total volume
+        np.testing.assert_allclose(mine.sum(), ref.sum(), rtol=0.01)
+        assert utils.rmsd(ref, mine) < 2
+
+        # Check vol
+        cdf = pd.read_hdf(utils.get_demo_file('rgi62_itmix_df.h5'))
+        ref_vol = cdf.loc[gdir.rgi_id].vol_itmix_m3
+        my_vol = mine.sum() * gdir.grid.dx**2
+        np.testing.assert_allclose(my_vol, ref_vol)
+
+        # Now check the rest of the workflow
+        vn = 'consensus_ice_thickness'
+        centerlines.elevation_band_flowline(gdir, bin_variables=vn)
+
+        # Check vol
+        df = pd.read_csv(gdir.get_filepath('elevation_band_flowline'),
+                         index_col=0)
+        my_vol = (df[vn] * df['area']).sum()
+        np.testing.assert_allclose(my_vol, ref_vol)
+
+        centerlines.fixed_dx_elevation_band_flowline(gdir, bin_variables=vn)
+        fdf = pd.read_csv(gdir.get_filepath('elevation_band_flowline',
+                                            filesuffix='_fixed_dx'),
+                          index_col=0)
+
+        # Check vol
+        my_vol = (fdf[vn] * fdf['area_m2']).sum()
+        np.testing.assert_allclose(my_vol, ref_vol)

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -978,6 +978,26 @@ class TestPreproCLI(unittest.TestCase):
             # We can't create this because the glacier dir is mini
             tasks.init_present_time_glacier(gdir)
 
+        # Extended file
+        fp = os.path.join(odir, 'RGI61', 'b_020', 'L5', 'summary',
+                          'historical_run_output_extended_11.nc')
+        with xr.open_dataset(fp) as ods:
+
+            ref = ods.volume_ext
+            new = ods.volume_fixed_geom_ext
+            np.testing.assert_allclose(new.isel(time=-1),
+                                       ref.isel(time=-1),
+                                       rtol=0.02)
+
+            vn = 'volume'
+            np.testing.assert_allclose(ods[vn + '_ext'].sel(time=1990),
+                                       ods[vn + '_ext'].sel(time=2015),
+                                       rtol=0.2)
+
+            # We pick symmetry around rgi date so show that somehow it works
+            for vn in ['calving', 'volume_bsl', 'volume_bwl']:
+                np.testing.assert_allclose(ods[vn+'_ext'].sel(time=1990), 0)
+
     @pytest.mark.slow
     def test_elev_bands_run(self):
 

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -863,6 +863,7 @@ class TestPreproCLI(unittest.TestCase):
         utils.mkdir(wdir)
         odir = os.path.join(self.testdir, 'my_levs')
         topof = utils.get_demo_file('srtm_oetztal.tif')
+        np.random.seed(0)
         run_prepro_levels(rgi_version=None, rgi_reg='11', border=20,
                           output_folder=odir, working_dir=wdir, is_test=True,
                           test_rgidf=rgidf, test_intersects_file=inter,
@@ -957,6 +958,7 @@ class TestPreproCLI(unittest.TestCase):
         utils.mkdir(wdir)
         odir = os.path.join(self.testdir, 'my_levs')
         topof = utils.get_demo_file('srtm_oetztal.tif')
+        np.random.seed(0)
         run_prepro_levels(rgi_version=None, rgi_reg='11', border=20,
                           output_folder=odir, working_dir=wdir, is_test=True,
                           test_rgidf=rgidf, test_intersects_file=inter,
@@ -1035,6 +1037,7 @@ class TestPreproCLI(unittest.TestCase):
         utils.mkdir(wdir)
         odir = os.path.join(self.testdir, 'my_levs')
         topof = utils.get_demo_file('srtm_oetztal.tif')
+        np.random.seed(0)
         run_prepro_levels(rgi_version=None, rgi_reg='11', border=20,
                           output_folder=odir, working_dir=wdir, is_test=True,
                           test_rgidf=rgidf, test_intersects_file=inter,
@@ -1194,6 +1197,7 @@ class TestBenchmarkCLI(unittest.TestCase):
         utils.mkdir(wdir)
         odir = os.path.join(self.testdir, 'my_levs')
         topof = utils.get_demo_file('srtm_oetztal.tif')
+        np.random.seed(0)
         run_benchmark(rgi_version=None, rgi_reg='11', border=80,
                       output_folder=odir, working_dir=wdir, is_test=True,
                       test_rgidf=rgidf, test_intersects_file=inter,

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -762,7 +762,7 @@ class TestPreproCLI(unittest.TestCase):
         assert not kwargs['is_test']
         assert kwargs['demo']
         assert not kwargs['disable_mp']
-        assert kwargs['max_level'] == 4
+        assert kwargs['max_level'] == 5
 
         kwargs = prepro_levels.parse_args(['--rgi-reg', '1',
                                            '--map-border', '160',
@@ -914,11 +914,11 @@ class TestPreproCLI(unittest.TestCase):
         assert os.path.isdir(os.path.join(odir, 'RGI61', 'b_020', 'L2'))
         assert os.path.isdir(os.path.join(odir, 'RGI61', 'b_020', 'L3'))
         assert os.path.isdir(os.path.join(odir, 'RGI61', 'b_020', 'L4'))
-        assert not os.path.isdir(os.path.join(odir, 'RGI61', 'b_020', 'L5'))
+        assert os.path.isdir(os.path.join(odir, 'RGI61', 'b_020', 'L5'))
 
         # See if we can start from all levs
         from oggm import tasks
-        from oggm.core.flowline import FlowlineModel
+        from oggm.core.flowline import FlowlineModel, FileModel
         cfg.PARAMS['continue_on_error'] = False
         rid = df.index[0]
         entity = rgidf.loc[rgidf.RGIId == rid].iloc[0]
@@ -957,6 +957,19 @@ class TestPreproCLI(unittest.TestCase):
         model = tasks.run_random_climate(gdir, nyears=10)
         assert isinstance(model, FlowlineModel)
         with pytest.raises(FileNotFoundError):
+            tasks.init_present_time_glacier(gdir)
+
+        # L5
+        tarf = os.path.join(odir, 'RGI61', 'b_020', 'L5',
+                            rid[:8], rid[:11], rid + '.tar.gz')
+        assert not os.path.isfile(tarf)
+        gdir = oggm.GlacierDirectory(entity, from_tar=tarf)
+        model = FileModel(gdir.get_filepath('model_run',
+                                            filesuffix='_historical'))
+        assert model.y0 == 2004
+        assert model.last_yr == 2015
+        with pytest.raises(FileNotFoundError):
+            # We can't create this because the glacier dir is mini
             tasks.init_present_time_glacier(gdir)
 
     @pytest.mark.slow
@@ -1009,11 +1022,11 @@ class TestPreproCLI(unittest.TestCase):
         assert os.path.isdir(os.path.join(odir, 'RGI61', 'b_020', 'L2'))
         assert os.path.isdir(os.path.join(odir, 'RGI61', 'b_020', 'L3'))
         assert os.path.isdir(os.path.join(odir, 'RGI61', 'b_020', 'L4'))
-        assert not os.path.isdir(os.path.join(odir, 'RGI61', 'b_020', 'L5'))
+        assert os.path.isdir(os.path.join(odir, 'RGI61', 'b_020', 'L5'))
 
         # See if we can start from L3 and L4
         from oggm import tasks
-        from oggm.core.flowline import FlowlineModel
+        from oggm.core.flowline import FlowlineModel, FileModel
         cfg.PARAMS['continue_on_error'] = False
         rid = df.rgi_id.iloc[0]
         entity = rgidf.loc[rgidf.RGIId == rid].iloc[0]
@@ -1034,6 +1047,20 @@ class TestPreproCLI(unittest.TestCase):
         model = tasks.run_random_climate(gdir, nyears=10)
         assert isinstance(model, FlowlineModel)
         with pytest.raises(FileNotFoundError):
+            # We can't create this because the glacier dir is mini
+            tasks.init_present_time_glacier(gdir)
+
+        # L5
+        tarf = os.path.join(odir, 'RGI61', 'b_020', 'L5',
+                            rid[:8], rid[:11], rid + '.tar.gz')
+        assert not os.path.isfile(tarf)
+        gdir = oggm.GlacierDirectory(entity, from_tar=tarf)
+        model = FileModel(gdir.get_filepath('model_run',
+                                            filesuffix='_historical'))
+        assert model.y0 == 2004
+        assert model.last_yr == 2015
+        with pytest.raises(FileNotFoundError):
+            # We can't create this because the glacier dir is mini
             tasks.init_present_time_glacier(gdir)
 
     def test_source_run(self):

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -981,7 +981,7 @@ class TestPreproCLI(unittest.TestCase):
         assert 'inv_volume_km3' in df
         df = pd.read_csv(os.path.join(odir, 'RGI61', 'b_020', 'L3', 'summary',
                                       'climate_statistics_11.csv'))
-        assert '1945-1975_avg_prcp' in df
+        assert '1980-2010_avg_prcp' in df
 
         assert os.path.isfile(os.path.join(odir, 'RGI61', 'b_020',
                                            'package_versions.txt'))

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -13,6 +13,7 @@ from unittest import mock
 
 import numpy as np
 import pandas as pd
+import xarray as xr
 from numpy.testing import assert_array_equal, assert_allclose
 
 salem = pytest.importorskip('salem')
@@ -956,6 +957,9 @@ class TestPreproCLI(unittest.TestCase):
         gdir = oggm.GlacierDirectory(entity, from_tar=tarf)
         model = tasks.run_random_climate(gdir, nyears=10)
         assert isinstance(model, FlowlineModel)
+        with xr.open_dataset(gdir.get_filepath('model_diagnostics')) as ds:
+            # cannot be the same after tuning
+            assert ds.glen_a != cfg.PARAMS['glen_a']
         with pytest.raises(FileNotFoundError):
             tasks.init_present_time_glacier(gdir)
 

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -809,7 +809,7 @@ class TestPreproCLI(unittest.TestCase):
                                            '--output', '/local/out',
                                            '--elev-bands',
                                            '--centerlines-only',
-                                           '--match-zemp',
+                                           '--match-geodetic-mb',
                                            '--working-dir', '/local/work',
                                            ])
 

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -886,7 +886,7 @@ class TestPreproCLI(unittest.TestCase):
         assert 'inv_volume_km3' in df
         df = pd.read_csv(os.path.join(odir, 'RGI61', 'b_020', 'L3', 'summary',
                                       'climate_statistics_11.csv'))
-        assert '1945-1975_avg_prcp' in df
+        assert '1980-2010_avg_prcp' in df
 
         assert os.path.isfile(os.path.join(odir, 'RGI61', 'b_020',
                                            'package_versions.txt'))

--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -197,8 +197,8 @@ class TestFullRun(unittest.TestCase):
     def test_calibrate_inversion_from_consensus(self):
 
         gdirs = up_to_inversion()
-        df = workflow.calibrate_inversion_from_consensus_estimate(gdirs,
-                                                                  ignore_missing=True)
+        df = workflow.calibrate_inversion_from_consensus(gdirs,
+                                                         ignore_missing=True)
         df = df.dropna()
         np.testing.assert_allclose(df.vol_itmix_m3.sum(),
                                    df.vol_oggm_m3.sum(),

--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -307,7 +307,7 @@ class TestFullRun(unittest.TestCase):
         assert ds.isel(rgi_id=0).volume_bwl[-1] > 0
         assert ds.isel(rgi_id=1).calving[-1] > 0
         assert ds.isel(rgi_id=1).calving_rate[-1] > 0
-        assert not np.isfinite(ds.isel(rgi_id=1).volume_bsl[-1])
+        assert ds.isel(rgi_id=1).volume_bsl[-1] == 0
 
 
 @pytest.mark.slow

--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -298,6 +298,7 @@ class TestFullRun(unittest.TestCase):
         df['y0_len'] = ds.length.sel(rgi_id=df.index, time=0)
         assert_allclose(df['rgi_area_km2'], df['y0_area'], 0.06)
         assert_allclose(df['inv_volume_km3'], df['y0_vol'], 0.04)
+        assert_allclose(df['inv_volume_bsl_km3'], 0)
         assert_allclose(df['main_flowline_length'], df['y0_len'])
 
         # Calving stuff

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -71,7 +71,7 @@ logger = logging.getLogger('.'.join(__name__.split('.')[:-1]))
 # The given commit will be downloaded from github and used as source for
 # all sample data
 SAMPLE_DATA_GH_REPO = 'OGGM/oggm-sample-data'
-SAMPLE_DATA_COMMIT = '0a922c30bafe1aa269b321cab99196196bb4b2e8'
+SAMPLE_DATA_COMMIT = '62f2a6ff090bd077966bf8ee2a06f425b0f17045'
 
 GDIR_URL = 'https://cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.1/'
 DEMO_GDIR_URL = 'https://cluster.klima.uni-bremen.de/~oggm/demo_gdirs/'

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -71,7 +71,7 @@ logger = logging.getLogger('.'.join(__name__.split('.')[:-1]))
 # The given commit will be downloaded from github and used as source for
 # all sample data
 SAMPLE_DATA_GH_REPO = 'OGGM/oggm-sample-data'
-SAMPLE_DATA_COMMIT = '438bddb20a2b1c24208b263a959b352c6f7d52e4'
+SAMPLE_DATA_COMMIT = 'cf08f50c68dc5d260fe8ecc6d2848c1f07f15884'
 
 GDIR_URL = 'https://cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.1/'
 DEMO_GDIR_URL = 'https://cluster.klima.uni-bremen.de/~oggm/demo_gdirs/'

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -71,7 +71,7 @@ logger = logging.getLogger('.'.join(__name__.split('.')[:-1]))
 # The given commit will be downloaded from github and used as source for
 # all sample data
 SAMPLE_DATA_GH_REPO = 'OGGM/oggm-sample-data'
-SAMPLE_DATA_COMMIT = '62f2a6ff090bd077966bf8ee2a06f425b0f17045'
+SAMPLE_DATA_COMMIT = '93b5aa374fa544b42c9cd496626e5dd4623b9ac7'
 
 GDIR_URL = 'https://cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.1/'
 DEMO_GDIR_URL = 'https://cluster.klima.uni-bremen.de/~oggm/demo_gdirs/'

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -2366,10 +2366,10 @@ def get_ref_mb_glaciers(gdirs, y0=None, y1=None):
         list of glaciers to check for valid reference mass balance data
     y0 : int
         override the default behavior which is to check the available
-        climate data and decide from there
+        climate data (or PARAMS['ref_mb_valid_window']) and decide
     y1 : int
         override the default behavior which is to check the available
-        climate data and decide from there
+        climate data (or PARAMS['ref_mb_valid_window']) and decide
 
     Returns
     -------

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -71,7 +71,7 @@ logger = logging.getLogger('.'.join(__name__.split('.')[:-1]))
 # The given commit will be downloaded from github and used as source for
 # all sample data
 SAMPLE_DATA_GH_REPO = 'OGGM/oggm-sample-data'
-SAMPLE_DATA_COMMIT = 'ba02d98307438368f8c7e0692755de5fbed5302d'
+SAMPLE_DATA_COMMIT = 'aab60d1832c44c700e0c89d0d15cd669078d721d'
 
 GDIR_URL = 'https://cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.1/'
 DEMO_GDIR_URL = 'https://cluster.klima.uni-bremen.de/~oggm/demo_gdirs/'

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -71,7 +71,7 @@ logger = logging.getLogger('.'.join(__name__.split('.')[:-1]))
 # The given commit will be downloaded from github and used as source for
 # all sample data
 SAMPLE_DATA_GH_REPO = 'OGGM/oggm-sample-data'
-SAMPLE_DATA_COMMIT = 'd83a0a43c53eaec694c26df5f468331320b5d8a1'
+SAMPLE_DATA_COMMIT = 'ec43edc48dc7f32ccbc77f89a59621b1913a630d'
 
 GDIR_URL = 'https://cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.1/'
 DEMO_GDIR_URL = 'https://cluster.klima.uni-bremen.de/~oggm/demo_gdirs/'

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -2352,7 +2352,7 @@ def get_ref_mb_glaciers_candidates(rgi_version=None):
     return cfg.DATA[key]
 
 
-def get_ref_mb_glaciers(gdirs):
+def get_ref_mb_glaciers(gdirs, y0=None, y1=None):
     """Get the list of glaciers we have valid mass balance measurements for.
 
     To be valid glaciers must have more than 5 years of measurements and
@@ -2364,6 +2364,12 @@ def get_ref_mb_glaciers(gdirs):
     ----------
     gdirs : list of :py:class:`oggm.GlacierDirectory` objects
         list of glaciers to check for valid reference mass balance data
+    y0 : int
+        override the default behavior which is to check the available
+        climate data and decide from there
+    y1 : int
+        override the default behavior which is to check the available
+        climate data and decide from there
 
     Returns
     -------
@@ -2384,7 +2390,7 @@ def get_ref_mb_glaciers(gdirs):
         if g.rgi_id not in ref_ids or g.is_tidewater:
             continue
         try:
-            mbdf = g.get_ref_mb_data()
+            mbdf = g.get_ref_mb_data(y0=y0, y1=y1)
             if len(mbdf) >= 5:
                 ref_gdirs.append(g)
         except RuntimeError as e:

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -71,7 +71,7 @@ logger = logging.getLogger('.'.join(__name__.split('.')[:-1]))
 # The given commit will be downloaded from github and used as source for
 # all sample data
 SAMPLE_DATA_GH_REPO = 'OGGM/oggm-sample-data'
-SAMPLE_DATA_COMMIT = 'ec43edc48dc7f32ccbc77f89a59621b1913a630d'
+SAMPLE_DATA_COMMIT = '9bce0367684c038ecee9a92523aa39034c956453'
 
 GDIR_URL = 'https://cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.1/'
 DEMO_GDIR_URL = 'https://cluster.klima.uni-bremen.de/~oggm/demo_gdirs/'

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -71,7 +71,7 @@ logger = logging.getLogger('.'.join(__name__.split('.')[:-1]))
 # The given commit will be downloaded from github and used as source for
 # all sample data
 SAMPLE_DATA_GH_REPO = 'OGGM/oggm-sample-data'
-SAMPLE_DATA_COMMIT = 'd6f23678780a118db2f6a8e86109dd1b0ac11634'
+SAMPLE_DATA_COMMIT = 'd83a0a43c53eaec694c26df5f468331320b5d8a1'
 
 GDIR_URL = 'https://cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.1/'
 DEMO_GDIR_URL = 'https://cluster.klima.uni-bremen.de/~oggm/demo_gdirs/'

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -71,7 +71,7 @@ logger = logging.getLogger('.'.join(__name__.split('.')[:-1]))
 # The given commit will be downloaded from github and used as source for
 # all sample data
 SAMPLE_DATA_GH_REPO = 'OGGM/oggm-sample-data'
-SAMPLE_DATA_COMMIT = '93b5aa374fa544b42c9cd496626e5dd4623b9ac7'
+SAMPLE_DATA_COMMIT = 'ba02d98307438368f8c7e0692755de5fbed5302d'
 
 GDIR_URL = 'https://cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.1/'
 DEMO_GDIR_URL = 'https://cluster.klima.uni-bremen.de/~oggm/demo_gdirs/'

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -71,7 +71,7 @@ logger = logging.getLogger('.'.join(__name__.split('.')[:-1]))
 # The given commit will be downloaded from github and used as source for
 # all sample data
 SAMPLE_DATA_GH_REPO = 'OGGM/oggm-sample-data'
-SAMPLE_DATA_COMMIT = 'aab60d1832c44c700e0c89d0d15cd669078d721d'
+SAMPLE_DATA_COMMIT = '438bddb20a2b1c24208b263a959b352c6f7d52e4'
 
 GDIR_URL = 'https://cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.1/'
 DEMO_GDIR_URL = 'https://cluster.klima.uni-bremen.de/~oggm/demo_gdirs/'

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -71,7 +71,7 @@ logger = logging.getLogger('.'.join(__name__.split('.')[:-1]))
 # The given commit will be downloaded from github and used as source for
 # all sample data
 SAMPLE_DATA_GH_REPO = 'OGGM/oggm-sample-data'
-SAMPLE_DATA_COMMIT = '9bce0367684c038ecee9a92523aa39034c956453'
+SAMPLE_DATA_COMMIT = '0a922c30bafe1aa269b321cab99196196bb4b2e8'
 
 GDIR_URL = 'https://cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.1/'
 DEMO_GDIR_URL = 'https://cluster.klima.uni-bremen.de/~oggm/demo_gdirs/'

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -2492,7 +2492,7 @@ class GlacierDirectory(object):
                                            'before call')
             y0 = ci['baseline_hydro_yr_0'] if y0 is None else y0
             y1 = ci['baseline_hydro_yr_1'] if y1 is None else y1
-        
+
         if len(self._mbdf) > 1:
             out = self._mbdf.loc[y0:y1]
         else:

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -452,10 +452,14 @@ class entity_task(object):
 
         @wraps(task_func)
         def _entity_task(gdir, *, reset=None, print_log=True,
-                         return_value=True, **kwargs):
+                         return_value=True, continue_on_error=None,
+                         **kwargs):
 
             if reset is None:
                 reset = not cfg.PARAMS['auto_skip_task']
+
+            if continue_on_error is None:
+                continue_on_error = cfg.PARAMS['continue_on_error']
 
             task_name = task_func.__name__
 
@@ -495,7 +499,7 @@ class entity_task(object):
                     self.log.error('%s occurred during task %s on %s: %s',
                                    type(err).__name__, task_name,
                                    gdir.rgi_id, str(err))
-                if not cfg.PARAMS['continue_on_error']:
+                if not continue_on_error:
                     raise
 
                 if self.fallback is not None:

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -211,21 +211,21 @@ def show_versions(logger=None):
     the output string
     """
 
-    _print = print if logger is None else logger.workflow
-
     sys_info = get_sys_info()
     deps_blob = get_env_info()
 
-    out = ["# System info:"]
+    out = ['# OGGM environment: ']
+    out.append("## System info:")
     for k, stat in sys_info:
-        out.append("%s: %s" % (k, stat))
-    out.append("# Packages info:")
+        out.append("    %s: %s" % (k, stat))
+    out.append("## Packages info:")
     for k, stat in deps_blob:
-        out.append("%s: %s" % (k, stat))
-    out.append("# OGGM git identifier:")
-    out.append(get_git_ident())
-    for l in out:
-        _print(l)
+        out.append("    %s: %s" % (k, stat))
+    out.append("    OGGM git identifier: " + get_git_ident())
+
+    if logger is not None:
+        logger.workflow('\n'.join(out))
+
     return '\n'.join(out)
 
 

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -2737,13 +2737,13 @@ def copy_to_basedir(gdir, base_dir=None, setup='run'):
     if setup == 'run':
         paths = ['model_flowlines', 'inversion_params', 'outlines',
                  'local_mustar', 'climate_historical',
-                 'gcm_data', 'climate_info']
+                 'gcm_data', 'climate_info', 'diagnostics']
         paths = ('*' + p + '*' for p in paths)
         shutil.copytree(gdir.dir, new_dir,
                         ignore=include_patterns(*paths))
     elif setup == 'inversion':
         paths = ['inversion_params', 'downstream_line', 'outlines',
-                 'inversion_flowlines', 'glacier_grid',
+                 'inversion_flowlines', 'glacier_grid', 'diagnostics',
                  'local_mustar', 'climate_historical', 'gridded_data',
                  'gcm_data', 'climate_info']
         paths = ('*' + p + '*' for p in paths)

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -1767,6 +1767,7 @@ class GlacierDirectory(object):
         self.is_tidewater = self.terminus_type in ['Marine-terminating',
                                                    'Lake-terminating']
         self.is_lake_terminating = self.terminus_type == 'Lake-terminating'
+        self.is_marine_terminating = self.terminus_type == 'Marine-terminating'
         self.is_nominal = self.status == 'Nominal glacier'
         self.inversion_calving_rate = 0.
         self.is_icecap = self.glacier_type == 'Ice cap'

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -632,9 +632,9 @@ class compile_to_netcdf(object):
                 if path is not True:
                     raise InvalidParamsError('With glaciers from both '
                                              'hemispheres, set `path=True`.')
-                self.log.warning('compile_*: you gave me a list of gdirs from '
-                                 'both hemispheres. I am going to write two '
-                                 'files out of it with _sh and _nh suffixes.')
+                self.log.workflow('compile_*: you gave me a list of gdirs from '
+                                  'both hemispheres. I am going to write two '
+                                  'files out of it with _sh and _nh suffixes.')
                 _gdirs = [gd for gd in gdirs if gd.hemisphere == 'sh']
                 _compile_to_netcdf(_gdirs,
                                    input_filesuffix=input_filesuffix,

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -2475,16 +2475,22 @@ class GlacierDirectory(object):
         ----------
         y0 : int
             override the default behavior which is to check the available
-            climate data and decide from there
+            climate data (or PARAMS['ref_mb_valid_window']) and decide
         y1 : int
             override the default behavior which is to check the available
-            climate data and decide from there
+            climate data (or PARAMS['ref_mb_valid_window']) and decide
         """
 
         if self._mbdf is None:
             self.set_ref_mb_data()
 
         # logic for period
+        t0, t1 = cfg.PARAMS['ref_mb_valid_window']
+        if t0 > 0 and y0 is None:
+            y0 = t0
+        if t1 > 0 and y1 is None:
+            y1 = t1
+
         if y0 is None or y1 is None:
             ci = self.get_climate_info()
             if 'baseline_hydro_yr_0' not in ci:

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -817,8 +817,10 @@ def compile_run_output(gdirs, path=True, input_filesuffix='',
 
     # To xarray
     for vn, var in out_2d.items():
-        # Backwards compatibility to remove one day...
-        vn = vn.replace('_m3', '').replace('_m2', '').replace('_m', '')
+        # Backwards compatibility - to remove one day...
+        for r in ['_m3', '_m2', '_myr', '_m']:
+            # Order matters
+            vn = vn.replace(r, '')
         ds[vn] = (('time', 'rgi_id'), var['data'])
         ds[vn].attrs = var['attrs']
     for vn, var in out_1d.items():

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -1269,6 +1269,7 @@ def compile_glacier_statistics(gdirs, filesuffix='', path=True,
 
 
 def compile_fixed_geometry_mass_balance(gdirs, filesuffix='', path=True,
+                                        use_inversion_flowlines=True,
                                         ys=None, ye=None, years=None):
     """Compiles a table of specific mass-balance timeseries for all glaciers.
 
@@ -1281,6 +1282,8 @@ def compile_fixed_geometry_mass_balance(gdirs, filesuffix='', path=True,
     path : str, bool
         Set to "True" in order  to store the info in the working directory
         Set to a path to store the file to your chosen location
+    use_inversion_flowlines : bool
+        whether to use the inversion flowlines or the model flowlines
     ys : int
         start year of the model run (default: from the climate file)
         date)
@@ -1293,6 +1296,7 @@ def compile_fixed_geometry_mass_balance(gdirs, filesuffix='', path=True,
     from oggm.core.massbalance import fixed_geometry_mass_balance
 
     out_df = execute_entity_task(fixed_geometry_mass_balance, gdirs,
+                                 use_inversion_flowlines=use_inversion_flowlines,
                                  ys=ys, ye=ye, years=years)
 
     for idx, s in enumerate(out_df):

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -1765,9 +1765,11 @@ class GlacierDirectory(object):
         self.terminus_type = ttkeys[gtype[1]]
         self.status = stkeys['{}'.format(gstatus)]
         self.is_tidewater = self.terminus_type in ['Marine-terminating',
-                                                   'Lake-terminating']
+                                                   'Lake-terminating',
+                                                   'Shelf-terminating']
         self.is_lake_terminating = self.terminus_type == 'Lake-terminating'
         self.is_marine_terminating = self.terminus_type == 'Marine-terminating'
+        self.is_shelf_terminating = self.terminus_type == 'Shelf-terminating'
         self.is_nominal = self.status == 'Nominal glacier'
         self.inversion_calving_rate = 0.
         self.is_icecap = self.glacier_type == 'Ice cap'

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -1107,14 +1107,21 @@ def glacier_statistics(gdir, inversion_only=False):
             # Inversion
             if gdir.has_file('inversion_output'):
                 vol = []
+                vol_bsl = []
+                vol_bwl = []
                 cl = gdir.read_pickle('inversion_output')
                 for c in cl:
                     vol.extend(c['volume'])
+                    vol_bsl.extend(c.get('volume_bsl', [0]))
+                    vol_bwl.extend(c.get('volume_bwl', [0]))
                 d['inv_volume_km3'] = np.nansum(vol) * 1e-9
                 area = gdir.rgi_area_km2
                 d['inv_thickness_m'] = d['inv_volume_km3'] / area * 1000
                 d['vas_volume_km3'] = 0.034 * (area ** 1.375)
                 d['vas_thickness_m'] = d['vas_volume_km3'] / area * 1000
+                # BSL / BWL
+                d['inv_volume_bsl_km3'] = np.nansum(vol_bsl) * 1e-9
+                d['inv_volume_bwl_km3'] = np.nansum(vol_bwl) * 1e-9
         except BaseException:
             pass
 

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -1782,7 +1782,10 @@ class GlacierDirectory(object):
         self.is_icecap = self.glacier_type == 'Ice cap'
 
         # Hemisphere
-        self.hemisphere = 'sh' if self.cenlat < 0 else 'nh'
+        if self.cenlat < 0 or self.rgi_region == '16':
+            self.hemisphere = 'sh'
+        else:
+            self.hemisphere = 'nh'
 
         # convert the date
         rgi_date = int(rgi_datestr[0:4])

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -2466,22 +2466,33 @@ class GlacierDirectory(object):
         mb_df.index.name = 'YEAR'
         self._mbdf = mb_df
 
-    def get_ref_mb_data(self):
+    def get_ref_mb_data(self, y0=None, y1=None):
         """Get the reference mb data from WGMS (for some glaciers only!).
 
         Raises an Error if it isn't a reference glacier at all.
+
+        Parameters
+        ----------
+        y0 : int
+            override the default behavior which is to check the available
+            climate data and decide from there
+        y1 : int
+            override the default behavior which is to check the available
+            climate data and decide from there
         """
 
         if self._mbdf is None:
             self.set_ref_mb_data()
 
         # logic for period
-        ci = self.get_climate_info()
-        if 'baseline_hydro_yr_0' not in ci:
-            raise InvalidWorkflowError('Please process some climate data '
-                                       'before call')
-        y0 = ci['baseline_hydro_yr_0']
-        y1 = ci['baseline_hydro_yr_1']
+        if y0 is None or y1 is None:
+            ci = self.get_climate_info()
+            if 'baseline_hydro_yr_0' not in ci:
+                raise InvalidWorkflowError('Please process some climate data '
+                                           'before call')
+            y0 = ci['baseline_hydro_yr_0'] if y0 is None else y0
+            y1 = ci['baseline_hydro_yr_1'] if y1 is None else y1
+        
         if len(self._mbdf) > 1:
             out = self._mbdf.loc[y0:y1]
         else:

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -411,7 +411,7 @@ class entity_task(object):
     exceptions, logging, and (some day) database for job-controlling.
     """
 
-    def __init__(self, log, writes=[], fallback=None):
+    def __init__(self, log, writes=[], fallback=None, return_value=True):
         """Decorator syntax: ``@oggm_task(log, writes=['dem', 'outlines'])``
 
         Parameters
@@ -423,10 +423,16 @@ class entity_task(object):
             available in ``cfg.BASENAMES``)
         fallback: python function
             will be executed on gdir if entity_task fails
+        return_value: bool
+            whether the return value from the task should be passed over
+            to the caller or not. In general you will always want this to
+            be true, but sometimes the task return things which are not
+            useful in production and my use a lot of memory, etc,
         """
         self.log = log
         self.writes = writes
         self.fallback = fallback
+        self.return_value = return_value
 
         cnt = ['    Notes']
         cnt += ['    -----']
@@ -494,7 +500,8 @@ class entity_task(object):
 
                 if self.fallback is not None:
                     self.fallback(gdir)
-            return out
+            if self.return_value:
+                return out
 
         _entity_task.__dict__['is_entity_task'] = True
         return _entity_task

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -1221,8 +1221,11 @@ def glacier_statistics(gdir, inversion_only=False):
             d['flowline_mean_elev'] = np.average(h, weights=widths)
             d['flowline_max_elev'] = np.max(h)
             d['flowline_min_elev'] = np.min(h)
-            d['flowline_avg_width'] = np.mean(widths)
             d['flowline_avg_slope'] = np.mean(slope)
+            d['flowline_avg_width'] = np.mean(widths)
+            d['flowline_last_width'] = fls[-1].widths[-1] * gdir.grid.dx
+            d['flowline_last_5_widths'] = np.mean(fls[-1].widths[-5:] *
+                                                  gdir.grid.dx)
         except BaseException:
             pass
 

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -500,7 +500,7 @@ class entity_task(object):
 
                 if self.fallback is not None:
                     self.fallback(gdir)
-            if self.return_value:
+            if return_value:
                 return out
 
         _entity_task.__dict__['is_entity_task'] = True

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -1511,7 +1511,7 @@ def extend_past_climate_run(past_run_file=None,
             raise NotImplementedError('Currently only supporting annual outputs')
         y0_clim = int(fixed_geometry_mb_df.index[0])
         y1_clim = int(fixed_geometry_mb_df.index[-1])
-        if y0_clim >= y0_run or y1_clim < y0_run:
+        if y0_clim > y0_run or y1_clim < y0_run:
             raise InvalidWorkflowError('Dates do not match.')
         if y1_clim != y1_run - 1:
             raise InvalidWorkflowError('Dates do not match.')
@@ -1552,6 +1552,10 @@ def extend_past_climate_run(past_run_file=None,
             mb_ts = df.values[:, i]
             orig_vol_ts = ods.volume_ext.data[:, i]
             if not (np.isfinite(mb_ts[-1]) and np.isfinite(orig_vol_ts[-1])):
+                # Not a valid glacier
+                continue
+            if np.isfinite(orig_vol_ts[0]):
+                # Nothing to extend, really
                 continue
             orig_area_ts = ods.area_ext.data[:, i]
             orig_calv_ts = ods.calving_ext.data[:, i]

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -1253,7 +1253,7 @@ def compile_glacier_statistics(gdirs, filesuffix='', path=True,
     from oggm.workflow import execute_entity_task
 
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category = RuntimeWarning)
+        warnings.filterwarnings("ignore", category=RuntimeWarning)
         out_df = execute_entity_task(glacier_statistics, gdirs,
                                      inversion_only=inversion_only)
 
@@ -1460,7 +1460,7 @@ def compile_climate_statistics(gdirs, filesuffix='', path=True,
     from oggm.workflow import execute_entity_task
 
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category = RuntimeWarning)
+        warnings.filterwarnings("ignore", category=RuntimeWarning)
         out_df = execute_entity_task(climate_statistics, gdirs,
                                      add_climate_period=add_climate_period)
 

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -411,7 +411,7 @@ class entity_task(object):
     exceptions, logging, and (some day) database for job-controlling.
     """
 
-    def __init__(self, log, writes=[], fallback=None, return_value=True):
+    def __init__(self, log, writes=[], fallback=None):
         """Decorator syntax: ``@oggm_task(log, writes=['dem', 'outlines'])``
 
         Parameters
@@ -432,7 +432,6 @@ class entity_task(object):
         self.log = log
         self.writes = writes
         self.fallback = fallback
-        self.return_value = return_value
 
         cnt = ['    Notes']
         cnt += ['    -----']
@@ -452,7 +451,8 @@ class entity_task(object):
         task_func.__doc__ = '\n'.join((task_func.__doc__, self.iodoc))
 
         @wraps(task_func)
-        def _entity_task(gdir, *, reset=None, print_log=True, **kwargs):
+        def _entity_task(gdir, *, reset=None, print_log=True,
+                         return_value=True, **kwargs):
 
             if reset is None:
                 reset = not cfg.PARAMS['auto_skip_task']

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -1252,8 +1252,10 @@ def compile_glacier_statistics(gdirs, filesuffix='', path=True,
     """
     from oggm.workflow import execute_entity_task
 
-    out_df = execute_entity_task(glacier_statistics, gdirs,
-                                 inversion_only=inversion_only)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category = RuntimeWarning)
+        out_df = execute_entity_task(glacier_statistics, gdirs,
+                                     inversion_only=inversion_only)
 
     out = pd.DataFrame(out_df).set_index('rgi_id')
     if path:
@@ -1457,8 +1459,10 @@ def compile_climate_statistics(gdirs, filesuffix='', path=True,
     """
     from oggm.workflow import execute_entity_task
 
-    out_df = execute_entity_task(climate_statistics, gdirs,
-                                 add_climate_period=add_climate_period)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category = RuntimeWarning)
+        out_df = execute_entity_task(climate_statistics, gdirs,
+                                     add_climate_period=add_climate_period)
 
     out = pd.DataFrame(out_df).set_index('rgi_id')
     if path:

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -657,8 +657,8 @@ def calibrate_inversion_from_consensus(gdirs, ignore_missing=True,
         return odf.dropna()
 
     def to_minimize(x):
-        log.info('Consensus estimate optimisation with '
-                 'A factor: {} and fs: {}'.format(x, fs))
+        log.workflow('Consensus estimate optimisation with '
+                     'A factor: {} and fs: {}'.format(x, fs))
         odf = compute_vol(x)
         return odf.vol_itmix_m3.sum() - odf.oggm.sum()
 

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -652,7 +652,7 @@ def calibrate_inversion_from_consensus(gdirs, ignore_missing=True,
 
     def to_minimize(x):
         log.info('Consensus estimate optimisation with '
-                 'A factor: {}'.format(x))
+                 'A factor: {} and fs: {}'.format(x, fs))
         odf = compute_vol(x)
         return odf.vol_itmix_m3.sum() - odf.oggm.sum()
 
@@ -670,7 +670,7 @@ def calibrate_inversion_from_consensus(gdirs, ignore_missing=True,
         # Ok can't find an A. Log for debug:
         odf1 = compute_vol(a_bounds[0]).sum() * 1e-9
         odf2 = compute_vol(a_bounds[1]).sum() * 1e-9
-        msg = ('calibration fom consensus estimate cannot converge with fs={}.\n'
+        msg = ('calibration fom consensus estimate CANT converge with fs={}.\n'
                'Bound values (km3):\nRef={:.3f} OGGM={:.3f} for A factor {}\n'
                'Ref={:.3f} OGGM={:.3f} for A factor {}'
                ''.format(fs,
@@ -687,9 +687,9 @@ def calibrate_inversion_from_consensus(gdirs, ignore_missing=True,
 
         out_fac = a_bounds[int(abs(odf1.vol_itmix_m3 - odf1.oggm) >
                                abs(odf2.vol_itmix_m3 - odf2.oggm))]
-        log.warning(msg)
-        log.warning('We use A factor = {} and fs = {} and move on.'
-                    ''.format(out_fac, fs))
+        log.workflow(msg)
+        log.workflow('We use A factor = {} and fs = {} and move on.'
+                     ''.format(out_fac, fs))
 
     # Compute the final volume with the correct A
     execute_entity_task(tasks.mass_conservation_inversion,

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -728,7 +728,7 @@ def match_regional_geodetic_mb(gdirs, rgi_reg):
     # Original units: km3 a-1, to change to mm a-1 (units of specific MB)
     rho = cfg.PARAMS['ice_density']
     if 'calving_flux' in dfs:
-        odf['CALVING'] = dfs['calving_flux'] * 1e9 * rho / odf['AREA']
+        odf['CALVING'] = dfs['calving_flux'].fillna(0) * 1e9 * rho / odf['AREA']
     else:
         odf['CALVING'] = 0
 

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -662,7 +662,7 @@ def calibrate_inversion_from_consensus_estimate(gdirs, ignore_missing=True,
         # Ok can't find an A. Log for debug:
         odf1 = compute_vol(a_bounds[0]).sum() * 1e-9
         odf2 = compute_vol(a_bounds[1]).sum() * 1e-9
-        msg = ('calibrate_inversion_from_consensus_estimate cannot converge.\n' 
+        msg = ('calibration fom consensus estimate cannot converge.\n'
                'Bound values (km3):\nRef={:.3f} OGGM={:.3f} for A factor {}\n'
                'Ref={:.3f} OGGM={:.3f} for A factor {}'
                ''.format(odf1.vol_itmix_m3, odf1.oggm, a_bounds[0],

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -590,7 +590,7 @@ def inversion_tasks(gdirs):
         execute_entity_task(tasks.filter_inversion_output, gdirs)
 
 
-def calibrate_inversion_from_consensus_estimate(gdirs, ignore_missing=False):
+def calibrate_inversion_from_consensus_estimate(gdirs, ignore_missing=True):
     """Fit the total volume of the glaciers to the 2019 consensus estimate.
 
     This method finds the "best Glen A" to match all glaciers in gdirs with

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -723,7 +723,10 @@ def match_regional_geodetic_mb(gdirs, rgi_reg):
     # Just take the calving rate and change its units
     # Original units: km3 a-1, to change to mm a-1 (units of specific MB)
     rho = cfg.PARAMS['ice_density']
-    odf['CALVING'] = dfs['calving_flux'] * 1e9 * rho / odf['AREA']
+    if 'calving_flux' in dfs:
+        odf['CALVING'] = dfs['calving_flux'] * 1e9 * rho / odf['AREA']
+    else:
+        odf['CALVING'] = 0
 
     # Total MB OGGM
     out_smb = np.average(odf['SMB'], weights=odf['AREA'])  # for logging

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -676,7 +676,7 @@ def calibrate_inversion_from_consensus(gdirs, ignore_missing=True,
                ''.format(fs,
                          odf1.vol_itmix_m3, odf1.oggm, a_bounds[0],
                          odf2.vol_itmix_m3, odf2.oggm, a_bounds[1]))
-        if apply_fs_on_mismatch and fs == 0:
+        if apply_fs_on_mismatch and fs == 0 and odf2.oggm > odf2.vol_itmix_m3:
             return calibrate_inversion_from_consensus(gdirs,
                                                       ignore_missing=ignore_missing,
                                                       fs=5.7e-20, a_bounds=a_bounds,


### PR DESCRIPTION
I did what we should not do: a monster PR. This has grown a bit out of control, but I'll merge soon and hope for the best.

In order not to let this linger further, I'll try to write a proper documentation in a big documentation push over the holidays.

Here is a summary of the main changes:
- `calibrate_inversion_from_consensus_estimate` is renamed to `calibrate_inversion_from_consensus` and works much better. It also allows to use sliding in case the consensus volumes are way too low for oggm.
- the logging level "WORKFLOW" is now logging at a higher level than errors or warnings, i.e. setting to "WORKFLOW" will hide individual glacier error and avoid cluttering of the run output (but also hiding potential very large numbers of errors). Because many of the tutorials have this logginf level in them I have to add a deprecation warning in code
- the `prepro_levels` CLI has a large number of changes. 
   - We now can select normal flowlines, elevation band flowlines, or a mix of both. It's a long story, but for global runs I'm really leaning towards making elevation band flowlines the default.
   - The default workflow now calibrates A from the consensus at the regional level, 
   - and also calibrates the mass-balance at the regional level using regional MB estimates. This is a very coarse and temporary solution
   - there are now 5 instead of 4 prepro levels. The 5th level contains also the "warm-up" historical runs, i.e. GCM runs can be started from 2019 (depending on historical climate) directly
   - there is a new utility function called `utils.extend_past_climate_run` which extends the past historical runs to account for late RGI date, by assuming a fixed glacier geometry
- there was a bug in `_filter_small_slopes`: in this task I cut the flowline for a min slope, which was set to 0. But in the inversion it is set to 1.5°! So now this is correct, but it actually changes the look of the flowlines in some cases, and the reason why I had to update the graphics test
- `elevation_band_flowline` now can also bin other data as well, e.g. the thicknesses from the consensus
- `invert_with_calving` now has a new parameter, `calving_min_mu_star_frac`, which tells OGGM not to reduce mu* below a certain fraction of the original (without calving) mu*
- the flowline model's `run_until_and_store` now writes all variables (including calving ones) regardless if it is a calving glacier or not. This makes the output larger but more predictable (I think: not tooooo large since we are using compression...)
- we now use `cftime` to read the CMIP file's time out of the netcdf
- I checked for many places where we clip the slope to be sure, but I think this should be checked again.
- new `bedtopo.py` module in the shop to project the consensus topography into a glacier directory.

TODOS:
- [x] deprecation warning in logging level
- [x] in another PR: make the Ice caps flowlines start from highest point instead of highest on outline.