### PR TITLE
Do not error when SLURM_JOB_CPUS_PER_NODE is weird

### DIFF
--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -471,7 +471,7 @@ def initialize_minimal(file=None, logging_level='INFO', params=None,
             mpp = int(os.environ['SLURM_JOB_CPUS_PER_NODE'])
             log.workflow('Multiprocessing: using slurm allocated '
                          'processors (N={})'.format(mpp))
-        except KeyError, ValueError:
+        except (KeyError, ValueError):
             import multiprocessing
             mpp = multiprocessing.cpu_count()
             log.workflow('Multiprocessing: using all available '

--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -471,7 +471,7 @@ def initialize_minimal(file=None, logging_level='INFO', params=None,
             mpp = int(os.environ['SLURM_JOB_CPUS_PER_NODE'])
             log.workflow('Multiprocessing: using slurm allocated '
                          'processors (N={})'.format(mpp))
-        except KeyError:
+        except KeyError, ValueError:
             import multiprocessing
             mpp = multiprocessing.cpu_count()
             log.workflow('Multiprocessing: using all available '


### PR DESCRIPTION
<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->
@TimoRoth , fyi, @drounce is working on a system where `SLURM_JOB_CPUS_PER_NODE` gets the value `24(x2)` 

I wonder if these shenanigans with SLURM_JOB_CPUS_PER_NODE are good or if we should just rely on `multiprocessing.cpu_count()` always?
