### PR TITLE
Funny bug in elevation band type downstream lines

### DIFF
--- a/oggm/core/centerlines.py
+++ b/oggm/core/centerlines.py
@@ -800,7 +800,13 @@ def _line_extend(uline, dline, dx):
 
     # First points is easy
     points = [shpg.Point(c) for c in uline.coords]
-    dpoints = []
+
+    if len(points) == 0:
+        # eb flowline
+        dpoints = [shpg.Point(dline.coords[0])]
+        points = [shpg.Point(dline.coords[0])]
+    else:
+        dpoints = []
 
     # Continue as long as line is not finished
     while True:
@@ -1005,7 +1011,9 @@ def compute_downstream_line(gdir):
         lline, dline = _line_extend(cl.line, line, cl.dx)
         out = dict(full_line=lline, downstream_line=dline)
     else:
-        out = dict(full_line=None, downstream_line=line)
+        # Eb flowlines - we trick
+        _, dline = _line_extend(shpg.LineString(), line, cl.dx)
+        out = dict(full_line=None, downstream_line=dline)
 
     gdir.write_pickle(out, 'downstream_line')
 

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -626,7 +626,7 @@ class TestCenterlines(unittest.TestCase):
         self.assertEqual(
             len(d['full_line'].coords) - len(d['downstream_line'].coords),
             cl.nx)
-        assert d['downstream_line'].length > 11
+        np.testing.assert_allclose(d['downstream_line'].length, 12, atol=0.5)
 
     def test_downstream_bedshape(self):
 
@@ -947,7 +947,7 @@ class TestElevationBandFlowlines(unittest.TestCase):
         centerlines.compute_downstream_line(gdir)
 
         dl = gdir.read_pickle('downstream_line')
-        assert dl['downstream_line'].length > 13
+        np.testing.assert_allclose(dl['downstream_line'].length, 12, atol=0.5)
 
         centerlines.compute_downstream_bedshape(gdir)
         climate.process_custom_climate_data(gdir)


### PR DESCRIPTION
<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->

That's a fun bug that would make the downstream lines of eb flowlines actually twice as long as they should have been. That's mostly an issue for growing glaciers, but it makes that I have to re-run all preprocessing steps...
