### PR TITLE
allow prcp_fac to change in PastMassbalance instance

### DIFF
--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -416,7 +416,7 @@ class PastMassBalance(MassBalanceModel):
         # just to check that no invalid prcp_factors are used
         if new_prcp_fac <= 0:
             raise InvalidParamsError('prcp_fac has to be above zero!')
-        self.prcp = self.prcp * new_prcp_fac / self._prcp_fac
+        self.prcp *= new_prcp_fac / self._prcp_fac
         # update old prcp_fac in order that it can be updated
         # again ...
         self._prcp_fac = new_prcp_fac

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -22,6 +22,7 @@ from oggm.core import climate, inversion, centerlines
 from oggm.shop import gcm_climate
 from oggm.cfg import SEC_IN_YEAR, SEC_IN_MONTH
 from oggm.utils import get_demo_file
+from oggm.exceptions import InvalidParamsError, InvalidWorkflowError
 
 from oggm.tests.funcs import get_test_dir, apply_test_ref_tstars
 from oggm.tests.funcs import (dummy_bumpy_bed, dummy_constant_bed,
@@ -349,6 +350,49 @@ class TestMassBalanceModels:
         s = massbalance.fixed_geometry_mass_balance(gdir,
                                                     years=mbdf.index.values)
         assert_allclose(s, mbdf['MY_MB'])
+
+    def test_prcp_fac_update(self, hef_gdir):
+
+        gdir = hef_gdir
+        init_present_time_glacier(gdir)
+
+        mb_mod = massbalance.PastMassBalance(gdir, bias=0,
+                                             check_calib_params=False)
+        # save old precipitation time series
+        prcp_old = mb_mod.prcp
+        prcp_fac_old = cfg.PARAMS['prcp_scaling_factor']
+        # basic checks
+        assert mb_mod.prcp_fac == prcp_fac_old
+        assert mb_mod._prcp_fac == prcp_fac_old
+
+        # increase prcp by factor of 10
+        factor = 10
+        mb_mod.prcp_fac = factor
+        assert mb_mod.prcp_fac == factor
+        assert mb_mod._prcp_fac == factor
+        prcp_new = mb_mod.prcp
+        assert_allclose(prcp_new, prcp_old * factor / prcp_fac_old)
+
+        # check if it gets back to the old prcp time series
+        mb_mod.prcp_fac = prcp_fac_old
+        assert mb_mod.prcp_fac == prcp_fac_old
+        assert mb_mod._prcp_fac == prcp_fac_old
+        assert_allclose(mb_mod.prcp, prcp_old)
+
+        with pytest.raises(InvalidParamsError):
+            mb_mod.prcp_fac = -100
+
+        # check if an error is raised if check_calib_params
+        # is true
+        mb_mod = massbalance.PastMassBalance(gdir, bias=0,
+                                             check_calib_params=True)
+        with pytest.raises(InvalidWorkflowError):
+            mb_mod.prcp_fac = 10
+
+        # normally this should also be implemented for mu_star ...
+        # with pytest.raises(InvalidWorkflowError):
+        #    mb_mod.mu_star = 100
+
 
     @pytest.mark.parametrize("cl", [massbalance.PastMassBalance,
                                     massbalance.ConstantMassBalance,

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -359,7 +359,7 @@ class TestMassBalanceModels:
         mb_mod = massbalance.PastMassBalance(gdir, bias=0,
                                              check_calib_params=False)
         # save old precipitation time series
-        prcp_old = mb_mod.prcp
+        prcp_old = mb_mod.prcp.copy()
         prcp_fac_old = cfg.PARAMS['prcp_scaling_factor']
         # basic checks
         assert mb_mod.prcp_fac == prcp_fac_old


### PR DESCRIPTION
<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->

This allows to change the precipitation scaling factor after instantiation of the PastMassBalance class
to be faster when optimising this factor. Some tests are added. 

- [x] Tests added/passed
- [ ] Fully documented
- [ ] Entry in `whats-new.rst` 
