### PR TITLE
rename prcp_bias to prcp_fac and allow it to change in tasks

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -10,8 +10,20 @@ v1.4.1 (unreleased)
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
+- Mass-balance models now do their computations with float64 arrays instead
+  of float32 (:pull:`1211`).
+  By `Lilian Schuster <https://github.com/lilianschuster>`_
+- `prcp_bias` renamed to `prcp_fac` in mass-balance models (:pull:`1211`).
+  By `Lilian Schuster <https://github.com/lilianschuster>`_
+
 Enhancements
 ~~~~~~~~~~~~
+
+- Mass-balance models now properly refer to `prcp_fac` (was incorrectly named
+  "bias") (:pull:`1211`).
+  Additionally, the `run_*` tasks in `oggm.core.flowline` can now also adjust
+  the precipitation factor for sensitivity experiments.
+  By `Lilian Schuster <https://github.com/lilianschuster>`_
 
 Bug fixes
 ~~~~~~~~~

--- a/oggm/core/climate.py
+++ b/oggm/core/climate.py
@@ -417,9 +417,9 @@ def historical_climate_qc(gdir):
     with utils.ncDataset(fpath) as nc:
         # time
         # Read timeseries
-        itemp = nc.variables['temp'][:]
+        itemp = nc.variables['temp'][:].astype(np.float64)
         if 'gradient' in nc.variables:
-            igrad = nc.variables['gradient'][:]
+            igrad = nc.variables['gradient'][:].astype(np.float64)
             # Security for stuff that can happen with local gradients
             igrad = np.where(~np.isfinite(igrad), default_grad, igrad)
             igrad = utils.clip_array(igrad, g_minmax[0], g_minmax[1])
@@ -549,10 +549,10 @@ def mb_climate_on_height(gdir, heights, *, time_range=None, year_range=None):
         time = time[p0:p1+1]
 
         # Read timeseries
-        itemp = nc.variables['temp'][p0:p1+1]
-        iprcp = nc.variables['prcp'][p0:p1+1]
+        itemp = nc.variables['temp'][p0:p1+1].astype(np.float64)
+        iprcp = nc.variables['prcp'][p0:p1+1].astype(np.float64)
         if 'gradient' in nc.variables:
-            igrad = nc.variables['gradient'][p0:p1+1]
+            igrad = nc.variables['gradient'][p0:p1+1].astype(np.float64)
             # Security for stuff that can happen with local gradients
             igrad = np.where(~np.isfinite(igrad), default_grad, igrad)
             igrad = utils.clip_array(igrad, g_minmax[0], g_minmax[1])

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -2196,8 +2196,7 @@ def run_random_climate(gdir, nyears=1000, y0=None, halfsize=15,
                        climate_input_filesuffix='',
                        output_filesuffix='', init_model_fls=None,
                        zero_initial_glacier=False,
-                       unique_samples=False, check_calib_params=True,
-                       **kwargs):
+                       unique_samples=False, **kwargs):
     """Runs the random mass-balance model for a given number of years.
 
     This will initialize a
@@ -2250,11 +2249,6 @@ def run_random_climate(gdir, nyears=1000, y0=None, halfsize=15,
         per random climate period-length
         if false, every model year will be chosen from the random climate
         period with the same probability
-    check_calib_params : bool
-        OGGM will try hard not to use wrongly calibrated mu* by checking
-        the parameters used during calibration and the ones you are
-        using at run time. If they don't match, it will raise an error.
-        Set to False to suppress this check.
     kwargs : dict
         kwargs to pass to the FluxBasedModel instance
     """
@@ -2264,8 +2258,7 @@ def run_random_climate(gdir, nyears=1000, y0=None, halfsize=15,
                                      bias=bias, seed=seed,
                                      filename=climate_filename,
                                      input_filesuffix=climate_input_filesuffix,
-                                     unique_samples=unique_samples,
-                                     check_calib_params=check_calib_params)
+                                     unique_samples=unique_samples)
 
     if temperature_bias is not None:
         mb.temp_bias = temperature_bias
@@ -2289,9 +2282,7 @@ def run_constant_climate(gdir, nyears=1000, y0=None, halfsize=15,
                          climate_filename='climate_historical',
                          climate_input_filesuffix='',
                          init_model_fls=None,
-                         zero_initial_glacier=False,
-                         check_calib_params=True,
-                         **kwargs):
+                         zero_initial_glacier=False, **kwargs):
     """Runs the constant mass-balance model for a given number of years.
 
     This will initialize a
@@ -2336,11 +2327,6 @@ def run_constant_climate(gdir, nyears=1000, y0=None, halfsize=15,
     init_model_fls : []
         list of flowlines to use to initialise the model (the default is the
         present_time_glacier file from the glacier directory)
-    check_calib_params : bool
-        OGGM will try hard not to use wrongly calibrated mu* by checking
-        the parameters used during calibration and the ones you are
-        using at run time. If they don't match, it will raise an error.
-        Set to False to suppress this check.
     kwargs : dict
         kwargs to pass to the FluxBasedModel instance
     """
@@ -2348,8 +2334,7 @@ def run_constant_climate(gdir, nyears=1000, y0=None, halfsize=15,
     mb = MultipleFlowlineMassBalance(gdir, mb_model_class=ConstantMassBalance,
                                      y0=y0, halfsize=halfsize,
                                      bias=bias, filename=climate_filename,
-                                     input_filesuffix=climate_input_filesuffix,
-                                     check_calib_params=check_calib_params)
+                                     input_filesuffix=climate_input_filesuffix)
 
     if temperature_bias is not None:
         mb.temp_bias = temperature_bias
@@ -2372,8 +2357,7 @@ def run_from_climate_data(gdir, ys=None, ye=None, min_ys=None, max_ys=None,
                           init_model_filesuffix=None, init_model_yr=None,
                           init_model_fls=None, zero_initial_glacier=False,
                           bias=None, temperature_bias=None,
-                          precipitation_factor=None, check_calib_params=True,
-                          **kwargs):
+                          precipitation_factor=None, **kwargs):
     """ Runs a glacier with climate input from e.g. CRU or a GCM.
 
     This will initialize a
@@ -2428,11 +2412,6 @@ def run_from_climate_data(gdir, ys=None, ye=None, min_ys=None, max_ys=None,
         multiply a factor to the precipitation time series
         default is None and means that the precipitation factor from the
         calibration is applied which is cfg.PARAMS['prcp_scaling_factor']
-    check_calib_params : bool
-        OGGM will try hard not to use wrongly calibrated mu* by checking
-        the parameters used during calibration and the ones you are
-        using at run time. If they don't match, it will raise an error.
-        Set to False to suppress this check.
     kwargs : dict
         kwargs to pass to the FluxBasedModel instance
     """
@@ -2467,8 +2446,7 @@ def run_from_climate_data(gdir, ys=None, ye=None, min_ys=None, max_ys=None,
 
     mb = MultipleFlowlineMassBalance(gdir, mb_model_class=PastMassBalance,
                                      filename=climate_filename, bias=bias,
-                                     input_filesuffix=climate_input_filesuffix,
-                                     check_calib_params=check_calib_params)
+                                     input_filesuffix=climate_input_filesuffix)
 
     if temperature_bias is not None:
         mb.temp_bias = temperature_bias

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -5,6 +5,7 @@ import logging
 import numpy as np
 import pandas as pd
 import netCDF4
+import warnings
 from scipy.interpolate import interp1d
 from scipy import optimize as optimization
 # Locals
@@ -302,9 +303,10 @@ class PastMassBalance(MassBalanceModel):
         ----------
         temp_bias : float, default 0
             Add a temperature bias to the time series
-        prcp_bias : float, default 1
-            Precipitation factor to the time series (called bias for
-            consistency with `temp_bias`)
+        prcp_fac : float, default cfg.PARAMS['prcp_scaling_factor']
+            Precipitation factor to the time series (called factor to make clear
+             that it is a multiplicative factor in contrast to the additive
+             `temp_bias`)
         """
 
         super(PastMassBalance, self).__init__()
@@ -354,15 +356,15 @@ class PastMassBalance(MassBalanceModel):
 
         # Public attrs
         self.hemisphere = gdir.hemisphere
-        self.temp_bias = 0.
-        self.prcp_bias = 1.
         self.repeat = repeat
 
         # Private attrs
         # to allow prcp_fac to be changed after instantiation
         # prescribe the prcp_fac as it is instantiated
         self._prcp_fac = prcp_fac
-        # need to ckeck this when prcp_fac should be updated
+        # same for temp bias:
+        self._temp_bias = 0
+        # need to check this when prcp_fac should be updated
         # normally should also be checked when mu_star is updated?
         self.check_calib_params = check_calib_params
 
@@ -380,8 +382,8 @@ class PastMassBalance(MassBalanceModel):
             self.years = np.repeat(np.arange(time[-1].year-ny+1,
                                              time[-1].year+1), 12)
             self.months = np.tile(np.arange(1, 13), ny)
-            # Read timeseries
-            self.temp = nc.variables['temp'][:]
+            # Read timeseries and correct it:
+            self.temp = nc.variables['temp'][:] + self._temp_bias
             self.prcp = nc.variables['prcp'][:] * self._prcp_fac
             if 'gradient' in nc.variables:
                 grad = nc.variables['gradient'][:]
@@ -421,6 +423,36 @@ class PastMassBalance(MassBalanceModel):
         # again ...
         self._prcp_fac = new_prcp_fac
 
+
+    # give a warning if prcp_bias is used:
+    @property
+    def prcp_bias(self):
+        warnings.warn('prcp_bias has been renamed to prcp_fac as it is'
+                             'a multiplicative factor, please use prcp_fac'
+                             'instead', DeprecationWarning)
+        return self.prcp_fac
+
+    # same for temp_bias:
+    @property
+    def temp_bias(self):
+        return self._temp_bias
+
+    @temp_bias.setter
+    def temp_bias(self, new_temp_bias):
+        # OK, this could get problematic when mass balance is calibrated
+        # to other values
+        # Check the climate related params to the GlacierDir to make sure
+        if self.check_calib_params:
+            msg = ('You want to change the temperature bias'
+                   'which was used for calibration. Set '
+                   '`check_calib_params=False` to ignore this '
+                   'warning.')
+            raise InvalidWorkflowError(msg)
+        self.temp += new_temp_bias - self._temp_bias
+        # update old temp_bias in order that it can be updated
+        # again ...
+        self._temp_bias = new_temp_bias
+
     def get_monthly_climate(self, heights, year=None):
         """Monthly climate information at given heights.
 
@@ -440,9 +472,10 @@ class PastMassBalance(MassBalanceModel):
                              '[{}, {}]'.format(y, self.ys, self.ye))
         pok = np.where((self.years == y) & (self.months == m))[0][0]
 
-        # Read timeseries
-        itemp = self.temp[pok] + self.temp_bias
-        iprcp = self.prcp[pok] * self.prcp_bias
+        # Read already temperature bias and precipitation factor corrected
+        # timeseries
+        itemp = self.temp[pok]
+        iprcp = self.prcp[pok]
         igrad = self.grad[pok]
 
         # For each height pixel:
@@ -471,9 +504,10 @@ class PastMassBalance(MassBalanceModel):
         if len(pok) < 1:
             raise ValueError('Year {} not in record'.format(int(year)))
 
-        # Read timeseries
-        itemp = self.temp[pok] + self.temp_bias
-        iprcp = self.prcp[pok] * self.prcp_bias
+        # Read already temperature bias and precipitation factor corrected
+        # timeseries
+        itemp = self.temp[pok]
+        iprcp = self.prcp[pok]
         igrad = self.grad[pok]
 
         # For each height pixel:
@@ -604,17 +638,25 @@ class ConstantMassBalance(MassBalanceModel):
         self.mbmod.temp_bias = value
 
     @property
-    def prcp_bias(self):
+    def prcp_fac(self):
         """Precipitation factor to apply to the original series."""
-        return self.mbmod.prcp_bias
+        return self.mbmod.prcp_fac
 
-    @prcp_bias.setter
-    def prcp_bias(self, value):
+    @prcp_fac.setter
+    def prcp_fac(self, value):
         """Precipitation factor to apply to the original series."""
         for attr_name in ['_lazy_interp_yr', '_lazy_interp_m']:
             if hasattr(self, attr_name):
                 delattr(self, attr_name)
-        self.mbmod.prcp_bias = value
+        self.mbmod.prcp_fac = value
+
+    # give a warning if prcp_bias is used:
+    @property
+    def prcp_bias(self):
+        warnings.warn('prcp_bias has been renamed to prcp_fac as it is'
+                             'a multiplicative factor, please use prcp_fac'
+                             'instead', DeprecationWarning)
+        return self.prcp_fac
 
     @property
     def bias(self):
@@ -700,7 +742,7 @@ class RandomMassBalance(MassBalanceModel):
     def __init__(self, gdir, mu_star=None, bias=None,
                  y0=None, halfsize=15, seed=None,
                  filename='climate_historical', input_filesuffix='',
-                 all_years=False, unique_samples=False):
+                 all_years=False, unique_samples=False, **kwargs):
         """Initialize.
 
         Parameters
@@ -741,7 +783,8 @@ class RandomMassBalance(MassBalanceModel):
         self.valid_bounds = [-1e4, 2e4]  # in m
         self.mbmod = PastMassBalance(gdir, mu_star=mu_star, bias=bias,
                                      filename=filename,
-                                     input_filesuffix=input_filesuffix)
+                                     input_filesuffix=input_filesuffix,
+                                     **kwargs)
 
         # Climate period
         if all_years:
@@ -778,17 +821,24 @@ class RandomMassBalance(MassBalanceModel):
         self.mbmod.temp_bias = value
 
     @property
-    def prcp_bias(self):
+    def prcp_fac(self):
         """Precipitation factor to apply to the original series."""
-        return self.mbmod.prcp_bias
+        return self.mbmod.prcp_fac
 
-    @prcp_bias.setter
-    def prcp_bias(self, value):
+    @prcp_fac.setter
+    def prcp_fac(self, value):
         """Precipitation factor to apply to the original series."""
         for attr_name in ['_lazy_interp_yr', '_lazy_interp_m']:
             if hasattr(self, attr_name):
                 delattr(self, attr_name)
-        self.mbmod.prcp_bias = value
+        self.mbmod.prcp_fac = value
+
+    @property
+    def prcp_bias(self):
+        warnings.warn('prcp_bias has been renamed to prcp_fac as it is'
+                             'a multiplicative factor, please use prcp_fac'
+                             'instead', DeprecationWarning)
+        return self.prcp_fac
 
     @property
     def bias(self):
@@ -857,14 +907,19 @@ class UncertainMassBalance(MassBalanceModel):
             the standard deviation of the random temperature error
         rdn_prcp_bias_seed : int
             the seed of the random number generator
+            (to be consistent this should be renamed prcp_fac as well)
         rdn_prcp_bias_sigma : float
             the standard deviation of the random precipitation error
+            (to be consistent this should be renamed prcp_fac as well)
         rdn_bias_seed : int
             the seed of the random number generator
         rdn_bias_sigma : float
             the standard deviation of the random MB error
         """
         super(UncertainMassBalance, self).__init__()
+        # the aim here is to change temp_bias and prcp_fac so
+        # check_calib_params has to be set to False
+        basis_model.check_calib_params = False
         self.mbmod = basis_model
         self.hemisphere = basis_model.hemisphere
         self.valid_bounds = self.mbmod.valid_bounds
@@ -877,6 +932,7 @@ class UncertainMassBalance(MassBalanceModel):
         self._state_temp = dict()
         self._state_prcp = dict()
         self._state_bias = dict()
+
 
     @property
     def temp_bias(self):
@@ -892,14 +948,22 @@ class UncertainMassBalance(MassBalanceModel):
         self.mbmod.temp_bias = value
 
     @property
-    def prcp_bias(self):
+    def prcp_fac(self):
         """Precipitation factor to apply to the original series."""
-        return self.mbmod.prcp_bias
+        return self.mbmod.prcp_fac
 
-    @prcp_bias.setter
-    def prcp_bias(self, value):
+    @prcp_fac.setter
+    def prcp_fac(self, value):
         """Precipitation factor to apply to the original series."""
-        self.mbmod.prcp_bias = value
+        self.mbmod.prcp_fac = value
+
+    # give a warning if prcp_bias is used:
+    @property
+    def prcp_bias(self):
+        warnings.warn('prcp_bias has been renamed to prcp_fac as it is'
+                      'a multiplicative factor, please use prcp_fac'
+                      'instead', DeprecationWarning)
+        return self.prcp_fac
 
     def _get_state_temp(self, year):
         year = int(year)
@@ -926,21 +990,21 @@ class UncertainMassBalance(MassBalanceModel):
 
         # Keep the original biases and add a random error
         _t = self.mbmod.temp_bias
-        _p = self.mbmod.prcp_bias
+        _p = self.mbmod.prcp_fac
         _b = self.mbmod.bias
         self.mbmod.temp_bias = self._get_state_temp(year) + _t
-        self.mbmod.prcp_bias = self._get_state_prcp(year) + _p
+        self.mbmod.prcp_fac = self._get_state_prcp(year) + _p
         self.mbmod.bias = self._get_state_bias(year) + _b
         try:
             out = self.mbmod.get_annual_mb(heights, year=year, fl_id=fl_id)
         except BaseException:
             self.mbmod.temp_bias = _t
-            self.mbmod.prcp_bias = _p
+            self.mbmod.prcp_fac = _p
             self.mbmod.bias = _b
             raise
         # Back to normal
         self.mbmod.temp_bias = _t
-        self.mbmod.prcp_bias = _p
+        self.mbmod.prcp_fac = _p
         self.mbmod.bias = _b
         return out
 
@@ -1060,15 +1124,23 @@ class MultipleFlowlineMassBalance(MassBalanceModel):
             mbmod.temp_bias = value
 
     @property
-    def prcp_bias(self):
+    def prcp_fac(self):
         """Precipitation factor to apply to the original series."""
-        return self.flowline_mb_models[0].prcp_bias
+        return self.flowline_mb_models[0].prcp_fac
 
-    @prcp_bias.setter
-    def prcp_bias(self, value):
+    @prcp_fac.setter
+    def prcp_fac(self, value):
         """Precipitation factor to apply to the original series."""
         for mbmod in self.flowline_mb_models:
-            mbmod.prcp_bias = value
+            mbmod.prcp_fac = value
+
+    # give a warning if prcp_bias is used:
+    @property
+    def prcp_bias(self):
+        warnings.warn('prcp_bias has been renamed to prcp_fac as it is'
+                      'a multiplicative factor, please use prcp_fac'
+                             'instead', DeprecationWarning)
+        return self.prcp_fac
 
     @property
     def bias(self):

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -367,10 +367,16 @@ class TestMassBalanceModels:
         assert mb_mod._prcp_fac == prcp_fac_old
         assert mb_mod.temp_bias == temp_bias_old
 
+        # Deprecated attrs
+        with pytest.raises(AttributeError):
+            mb_mod.prcp_bias = 2
+        with pytest.raises(AttributeError):
+            mb_mod.prcp_bias
+
         # increase prcp by factor of 10 and add a temperature bias of 1
         factor = 10
         mb_mod.prcp_fac = factor
-        temp_bias = 0.1
+        temp_bias = 1
         mb_mod.temp_bias = temp_bias
         assert mb_mod.prcp_fac == factor
         assert mb_mod._prcp_fac == factor

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -349,7 +349,7 @@ class TestMassBalanceModels:
 
         s = massbalance.fixed_geometry_mass_balance(gdir,
                                                     years=mbdf.index.values)
-        assert_allclose(s, mbdf['MY_MB'], rtol=1e-6)
+        assert_allclose(s, mbdf['MY_MB'])
 
     def test_prcp_fac_temp_bias_update(self, hef_gdir):
 
@@ -390,10 +390,7 @@ class TestMassBalanceModels:
         mb_mod.temp_bias = temp_bias_old
         assert mb_mod.temp_bias == temp_bias_old
         assert mb_mod._temp_bias == temp_bias_old
-        # not perfectly equal because of some rounding issues when
-        # doing addition, this effect is stronger for -> need to
-        # avoid adding numbers of different magnitudes
-        assert_allclose(mb_mod.temp, temp_old, rtol=1e-6)
+        assert_allclose(mb_mod.temp, temp_old)
 
         # check if error occurs for invalid prcp_fac
         with pytest.raises(InvalidParamsError):
@@ -477,11 +474,8 @@ class TestMassBalanceModels:
             mb_gw = massbalance.UncertainMassBalance(mb_gw, rdn_bias_seed=1,
                                                      rdn_prcp_bias_seed=2,
                                                      rdn_temp_bias_seed=3)
-        # here is a problem with UncertainMassBalance ...
-        # it needs rtol=1e-4 to work now
         assert_allclose(mb.get_specific_mb(h, w, year=yrs[:30]),
-                        mb_gw.get_specific_mb(fls=fls, year=yrs[:30]),
-                        rtol=1e-4)
+                        mb_gw.get_specific_mb(fls=fls, year=yrs[:30]))
 
         # ELA won't pass because of API incompatibility
         # assert_allclose(mb.get_ela(year=yrs[:30]),
@@ -766,20 +760,12 @@ class TestMassBalanceModels:
         check_mb = ref_mod.get_specific_mb(h, w, year=yrs)
         temp_3 = ref_mod.mbmod.temp.copy()
         unc2_mb = mb_mod.get_specific_mb(h, w, year=yrs)
-        # problem: UncertainMassBalance does something to ref_mod,
-        # it slightly changes the precipitation and temperature time series
-        # maybe there is a problem because of rounding issues???
-        # because I always update the time/prcp time series immediately...
-        # this might be the reason that the tests fail, but actually the tests
-        # fail more with larger _sigma, (see below)
-        # so there must be something in ref_mb that changes ref_mod stronger
-        # with a larger _sigma, the temp_bias and prcp_fac stay however the same
-        assert_allclose(temp_1, temp_2, rtol=1e-5)
-        assert_allclose(temp_1, temp_3, rtol=1e-5)
-        assert_allclose(ref_mb, check_mb, rtol=1e-2) # 0.0048
-        assert_allclose(unc_mb, unc2_mb, rtol=1e-3)
-        assert np.std(unc_mb) > 50
 
+        assert_allclose(temp_1, temp_2)
+        assert_allclose(temp_1, temp_3)
+        assert_allclose(ref_mb, check_mb)
+        assert_allclose(unc_mb, unc2_mb)
+        assert np.std(unc_mb) > 50
 
         mb_mod = massbalance.UncertainMassBalance(ref_mod,
                                                   rdn_temp_bias_sigma=0.1,
@@ -788,7 +774,7 @@ class TestMassBalanceModels:
         ref_mb = ref_mod.get_specific_mb(h, w, year=yrs)
         unc_mb = mb_mod.get_specific_mb(h, w, year=yrs)
         check_mb = ref_mod.get_specific_mb(h, w, year=yrs)
-        assert_allclose(ref_mb, check_mb, rtol=1e-3)
+        assert_allclose(ref_mb, check_mb)
         assert np.std(unc_mb) > 50
 
         mb_mod = massbalance.UncertainMassBalance(ref_mod,
@@ -798,9 +784,8 @@ class TestMassBalanceModels:
         ref_mb = ref_mod.get_specific_mb(h, w, year=yrs)
         unc_mb = mb_mod.get_specific_mb(h, w, year=yrs)
         check_mb = ref_mod.get_specific_mb(h, w, year=yrs)
-        assert_allclose(ref_mb, check_mb, rtol=1e-4)
+        assert_allclose(ref_mb, check_mb)
         assert np.std(unc_mb) > 50
-
 
         # Other MBs
         ref_mod = massbalance.PastMassBalance(gdir)
@@ -812,8 +797,8 @@ class TestMassBalanceModels:
         check_mb = ref_mod.get_specific_mb(h, w, year=yrs)
         unc2_mb = mb_mod.get_specific_mb(h, w, year=yrs)
 
-        assert_allclose(ref_mb, check_mb, rtol=1e-4)
-        assert_allclose(unc_mb, unc2_mb, rtol=1e-4)
+        assert_allclose(ref_mb, check_mb)
+        assert_allclose(unc_mb, unc2_mb)
         assert np.std(unc_mb - ref_mb) > 50
         assert np.corrcoef(ref_mb, unc_mb)[0, 1] > 0.5
 
@@ -827,8 +812,8 @@ class TestMassBalanceModels:
         check_mb = ref_mod.get_specific_mb(h, w, year=yrs)
         unc2_mb = mb_mod.get_specific_mb(h, w, year=yrs)
 
-        assert_allclose(ref_mb, check_mb, rtol=1e-4)
-        assert_allclose(unc_mb, unc2_mb, rtol=1e-4)
+        assert_allclose(ref_mb, check_mb)
+        assert_allclose(unc_mb, unc2_mb)
         assert np.std(unc_mb - ref_mb) > 50
         assert np.corrcoef(ref_mb, unc_mb)[0, 1] > 0.5
 
@@ -842,14 +827,11 @@ class TestMassBalanceModels:
         check_mb = ref_mod.get_specific_mb(h, w, year=yrs)
         temp_3 = ref_mod.mbmod.temp.copy()
         unc2_mb = mb_mod.get_specific_mb(h, w, year=yrs)
-        assert_allclose(temp_1, temp_2, rtol=1e-5)
-        assert_allclose(temp_1, temp_3, rtol=1e-5)
-        assert_allclose(ref_mb, check_mb, rtol=0.05) # max rel: 0.015
-        assert_allclose(unc_mb, unc2_mb, rtol=1e-3)
+        assert_allclose(temp_1, temp_2)
+        assert_allclose(temp_1, temp_3)
+        assert_allclose(ref_mb, check_mb)
+        assert_allclose(unc_mb, unc2_mb)
         assert np.std(unc_mb) > 50
-
-        # after that ref_mod is modified that much that the other tests fail
-        # as well
 
     def test_mb_performance(self, hef_gdir):
 


### PR DESCRIPTION
<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->
I have tried to rename everything that is called prcp_bias in OGGM  to prcp_fac as it is a multiplicative factor, not a bias and I added some documentation. 
 In addition:
- when calling `self.temp` in a PastMassbalance instance, the bias corrected temperature time series is shown and not the uncorrected as before
-  the precipitation_factor has been added as a keyword argument for tasks.run_random_climate/run_constant_climate...  
- in order to change precipitation factor or temperature bias one has to set the `check_calib_params` to False, otherwise an error occurs, if this gets finally merged, a change has to be done in the water resources notebook of oggm-edu that I will commit then (but if this does not make sense for the temperature bias I can remove it again)  

The tests were updated. All but one tests pass: there is still an issue in the UncertainMassbalance test, somehow it changes the basis_model but I did not find out how, I first thought these were just rounding errors but they are too large. I just don't understand what is happening there 


- [x] Tests added/passed

