### PR TITLE
hydro year corresponds to calendar year if hydro month=1

### DIFF
--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -2433,10 +2433,11 @@ def run_from_climate_data(gdir, ys=None, ye=None, min_ys=None, max_ys=None,
         except AttributeError:
             ys = gdir.rgi_date
         # The RGI timestamp is in calendar date - we convert to hydro date,
-        # i.e. 2003 becomes 2004 (so that we don't count the MB year 2003
-        # in the simulation)
+        # i.e. 2003 becomes 2004 if hydro_month is not 1 (January)
+        # (so that we don't count the MB year 2003 in the simulation)
         # See also: https://github.com/OGGM/oggm/issues/1020
-        ys += 1
+        if cfg.PARAMS['hydro_month_'+gdir.hemisphere] != 1:
+            ys += 1
 
     # Final crop
     if min_ys is not None:

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -221,6 +221,41 @@ class TestFuncs(unittest.TestCase):
         np.testing.assert_array_equal(y, time.year)
         np.testing.assert_array_equal(m, time.month)
 
+        # January
+        # hydro year/month corresponds to calendar year/month
+        y, m = utils.hydrodate_to_calendardate(1, 1, start_month=1)
+        assert (y, m) == (1, 1)
+        y, m = utils.hydrodate_to_calendardate(1, 4, start_month=1)
+        assert (y, m) == (1, 4)
+        y, m = utils.hydrodate_to_calendardate(1, 12, start_month=1)
+        assert (y, m) == (1, 12)
+
+        y, m = utils.hydrodate_to_calendardate([1, 1, 1], [1, 4, 12],
+                                               start_month=1)
+        np.testing.assert_array_equal(y, [1, 1, 1])
+        np.testing.assert_array_equal(m, [1, 4, 12])
+
+        y, m = utils.calendardate_to_hydrodate(1, 1, start_month=1)
+        assert (y, m) == (1, 1)
+        y, m = utils.calendardate_to_hydrodate(1, 9, start_month=1)
+        assert (y, m) == (1, 9)
+        y, m = utils.calendardate_to_hydrodate(1, 10, start_month=1)
+        assert (y, m) == (1, 10)
+
+        y, m = utils.calendardate_to_hydrodate([1, 1, 1], [1, 9, 10],
+                                               start_month=1)
+        np.testing.assert_array_equal(y, [1, 1, 1])
+        np.testing.assert_array_equal(m, [1, 9, 10])
+
+        # Roundtrip
+        time = pd.period_range('0001-01', '1000-12', freq='M')
+        y, m = utils.calendardate_to_hydrodate(time.year, time.month,
+                                               start_month=1)
+        y, m = utils.hydrodate_to_calendardate(y, m, start_month=1)
+        np.testing.assert_array_equal(y, time.year)
+        np.testing.assert_array_equal(m, time.month)
+
+
     def test_rgi_meta(self):
         cfg.initialize()
         reg_names, subreg_names = utils.parse_rgi_meta(version='6')

--- a/oggm/utils/_funcs.py
+++ b/oggm/utils/_funcs.py
@@ -609,7 +609,10 @@ def hydrodate_to_calendardate(y, m, start_month=None):
     e = 13 - start_month
     try:
         if m <= e:
-            out_y = y - 1
+            if start_month == 1:
+                out_y = y
+            else:
+                out_y = y - 1
             out_m = m + start_month - 1
         else:
             out_y = y
@@ -645,7 +648,10 @@ def calendardate_to_hydrodate(y, m, start_month=None):
 
     try:
         if m >= start_month:
-            out_y = y + 1
+            if start_month == 1:
+                out_y = y
+            else:
+                out_y = y + 1
             out_m = m - start_month + 1
         else:
             out_y = y


### PR DESCRIPTION
<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->

hydrodate_to_calendardate  and calendardate_to_hydrodate are adapted such that hydro_year is equal to calendar_year. In addition, in order that the "time" coordinate is right, I  adapted run_from_climate_data. Tests have passed and I added one for hydromonth = 1. 


Closes https://github.com/OGGM/oggm/issues/1218

- [x] Tests added/passed

