### PR TITLE
Implement monthly time steps in run_with_hydro

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -25,7 +25,7 @@ Enhancements
 ~~~~~~~~~~~~
 
 - Mass-balance models now properly refer to ``prcp_fac`` (was incorrectly named
-  ``prcp+bias``) (:pull:`1211`).
+  ``prcp_bias``) (:pull:`1211`).
   Additionally, the ``run_*`` tasks in ``oggm.core.flowline`` can now also adjust
   the precipitation factor for sensitivity experiments.
   By `Lilian Schuster <https://github.com/lilianschuster>`_
@@ -38,6 +38,9 @@ Enhancements
   diagnostics after a standard dynamical run (:pull:`1224`).
   This is highly experimental, will likely change in the future.
   By `Fabien Maussion <https://github.com/fmaussion>`_
+- Added monthly output to ``run_with_hydro`` (:pull:`1232`).
+  By `Sarah Hanus <https://github.com/sarah-hanus>`_ and
+  `Fabien Maussion <https://github.com/fmaussion>`_
 
 
 Bug fixes

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -2217,8 +2217,9 @@ def flowline_model_run(gdir, output_filesuffix=None, mb_model=None,
                       "is updated yearly. If you want the output to be stored "
                       "monthly and also reflect reflect monthly processes,"
                       "set store_monthly_step=True and "
-                      "mb_elev_feedback='monthly'. This is not necessarily "
-                      "recommended though.")
+                      "mb_elev_feedback='monthly'. This is not recommended "
+                      "though: for monthly MB applications, we recommend to "
+                      "use the `run_with_hydro` task.")
 
     if cfg.PARAMS['use_inversion_params_for_run']:
         diag = gdir.get_diagnostics()
@@ -2583,14 +2584,14 @@ def run_from_climate_data(gdir, ys=None, ye=None, min_ys=None, max_ys=None,
 
 
 @entity_task(log)
-def run_with_hydro(gdir, run_task=None, store_monthly_hydro=None, **kwargs):
+def run_with_hydro(gdir, run_task=None, store_monthly_hydro=False, **kwargs):
     """Run the flowline model and add hydro diagnostics (experimental!).
 
     TODOs:
         - Add the possibility to merge with previous model runs
         - Add the possibility to prescribe glacier area (e.g. with starting area)
-        - Add the possibility to store monthly hydro output
-        - Add the possibility to record during run (requires change in API)
+        - Add the possibility to record MB during run to improve performance
+          (requires change in API)
         - ...
 
     Parameters

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -2215,7 +2215,7 @@ def flowline_model_run(gdir, output_filesuffix=None, mb_model=None,
     if store_monthly_step and (mb_elev_feedback == 'annual'):
         warnings.warn("The mass-balance used to drive the ice dynamics model "
                       "is updated yearly. If you want the output to be stored "
-                      "monthly and also reflect reflect monthly processes," 
+                      "monthly and also reflect reflect monthly processes,"
                       "set store_monthly_step=True and "
                       "mb_elev_feedback='monthly'. This is not necessarily "
                       "recommended though.")
@@ -2615,7 +2615,7 @@ def run_with_hydro(gdir, run_task=None, store_monthly_hydro=None, **kwargs):
     if kwargs.get('mb_elev_feedback', 'annual') != 'annual':
         raise InvalidParamsError('run_with_hydro only compatible with '
                                  "mb_elev_feedback='annual' (yes, even "
-                                 "when asked for monthly hydro output.")
+                                 "when asked for monthly hydro output).")
 
     out = run_task(gdir, **kwargs)
     if out is None:
@@ -2653,10 +2653,8 @@ def run_with_hydro(gdir, run_task=None, store_monthly_hydro=None, **kwargs):
     # Ok now fetch all geometry data in a first loop
     # We do that because we want to get the largest possible area (always)
     # and we want to minimize the number of calls to run_until
-    model_vol = []
     for i, yr in enumerate(years):
         fmod.run_until(yr)
-        model_vol.append(fmod.volume_m3)
 
         for fl_id, (fl, max_area, bin_area_2d, bin_elev_2d) in \
                 enumerate(zip(fmod.fls, max_areas, bin_area_2ds, bin_elev_2ds)):
@@ -2848,10 +2846,12 @@ def run_with_hydro(gdir, run_task=None, store_monthly_hydro=None, **kwargs):
             else:
                 # We simply spread over the months
                 residual_mb /= 12
-                out['melt_on_glacier']['data'][i, :] = out['melt_on_glacier']['data'][i, :] - residual_mb
+                out['melt_on_glacier']['data'][i, :] = (out['melt_on_glacier']['data'][i, :] -
+                                                        residual_mb)
         else:
             # We simply apply the residual - no choice here
-            out['melt_on_glacier']['data'][i, :] = out['melt_on_glacier']['data'][i, :] - residual_mb
+            out['melt_on_glacier']['data'][i, :] = (out['melt_on_glacier']['data'][i, :] -
+                                                    residual_mb)
 
         out['model_mb']['data'][i] = model_mb
         out['residual_mb']['data'][i] = residual_mb

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -2213,8 +2213,12 @@ def flowline_model_run(gdir, output_filesuffix=None, mb_model=None,
      """
     mb_elev_feedback = kwargs.get('mb_elev_feedback', 'annual')
     if store_monthly_step and (mb_elev_feedback == 'annual'):
-        warnings.warn("Mass balance is computed yearly. If you want output to "
-                      "reflect monthly processes set mb_elev_feedback = 'monthly'")
+        warnings.warn("The mass-balance used to drive the ice dynamics model "
+                      "is updated yearly. If you want the output to be stored "
+                      "monthly and also reflect reflect monthly processes," 
+                      "set store_monthly_step=True and "
+                      "mb_elev_feedback='monthly'. This is not necessarily "
+                      "recommended though.")
 
     if cfg.PARAMS['use_inversion_params_for_run']:
         diag = gdir.get_diagnostics()
@@ -2579,7 +2583,7 @@ def run_from_climate_data(gdir, ys=None, ye=None, min_ys=None, max_ys=None,
 
 
 @entity_task(log)
-def run_with_hydro(gdir, run_task=None, store_monthly_hydro = False, **kwargs):
+def run_with_hydro(gdir, run_task=None, store_monthly_hydro=None, **kwargs):
     """Run the flowline model and add hydro diagnostics (experimental!).
 
     TODOs:
@@ -2592,17 +2596,30 @@ def run_with_hydro(gdir, run_task=None, store_monthly_hydro = False, **kwargs):
     Parameters
     ----------
     run_task : func
-        any of the `run_*`` tasks above. The mass-balance model used needs
-        to have the `add_climate` output option available though
+        any of the `run_*`` tasks in the oggm.flowline module.
+        The mass-balance model used needs to have the `add_climate` output
+        kwarg available though.
+    store_monthly_hydro : bool
+        also compute monthly hydrological diagnostics. The monthly ouptputs
+        are stored in 2D fields (years, months)
     **kwargs : all valid kwargs for ``run_task``
     """
 
     # Make sure it'll return something
     kwargs['return_value'] = True
-    out = run_task(gdir, **kwargs)
 
+    # Check that kwargs are compatible
+    if kwargs.get('store_monthly_step', False):
+        raise InvalidParamsError('run_with_hydro only compatible with '
+                                 'store_monthly_step=False.')
+    if kwargs.get('mb_elev_feedback', 'annual') != 'annual':
+        raise InvalidParamsError('run_with_hydro only compatible with '
+                                 "mb_elev_feedback='annual' (yes, even "
+                                 "when asked for monthly hydro output.")
+
+    out = run_task(gdir, **kwargs)
     if out is None:
-        raise InvalidWorkflowError('Previous run task ({}) did not run '
+        raise InvalidWorkflowError('The run task ({}) did not run '
                                    'successfully.'.format(run_task.__name__))
 
     # Mass balance model used during the run
@@ -2612,10 +2629,11 @@ def run_with_hydro(gdir, run_task=None, store_monthly_hydro = False, **kwargs):
     suffix = kwargs.get('output_filesuffix', '')
 
     # We start by fetching mass balance data and geometry for all years
-    # although the netcdf file is in monthly timesteps FileModel only gives yearly timesteps
+    # model_geometry files always retrieve yearly timesteps
     fmod = FileModel(gdir.get_filepath('model_geometry', filesuffix=suffix))
-    years = np.arange(fmod.y0, fmod.last_yr)
-    
+    # The last one is the final state - we can't compute MB for that
+    years = fmod.years[:-1]
+
     # Geometry at t0 to start with + off-glacier snow bucket
     bin_area_2ds = []
     bin_elev_2ds = []
@@ -2635,19 +2653,9 @@ def run_with_hydro(gdir, run_task=None, store_monthly_hydro = False, **kwargs):
     # Ok now fetch all geometry data in a first loop
     # We do that because we want to get the largest possible area (always)
     # and we want to minimize the number of calls to run_until
-    model_area = []
     model_vol = []
-    if kwargs['store_monthly_step']:
-        years = utils.monthly_timeseries(years[0],years[-1]+1)[:-1]
     for i, yr in enumerate(years):
-        if kwargs['store_monthly_step']:
-            y, m = utils.floatyear_to_date(yr)
-            #this does not work though
-            #fmod.months are always 1
-            fmod.run_until(y, m)
-        else:
-            fmod.run_until(yr)
-        model_area.append(fmod.area_m2)
+        fmod.run_until(yr)
         model_vol.append(fmod.volume_m3)
 
         for fl_id, (fl, max_area, bin_area_2d, bin_elev_2d) in \
@@ -2661,186 +2669,224 @@ def run_with_hydro(gdir, run_task=None, store_monthly_hydro = False, **kwargs):
             bin_elev_2d[i, :] = fl.surface_h
 
     # Ok now we have arrays, we can work with that
-    # Second time varying loop for mass-balance
+    # -> second time varying loop is for mass-balance
+    months = [1]
+    seconds = cfg.SEC_IN_YEAR
+    ntime = len(years) + 1
+    oshape = (ntime, 1)
+    if store_monthly_hydro:
+        months = np.arange(1, 13)
+        seconds = cfg.SEC_IN_MONTH
+        oshape = (ntime, 12)
 
-    # Columns that need initial values
-    index = [
-        'off_area',
-        'on_area',
-        'melt_off_glacier',
-        'melt_on_glacier',
-        'liq_prcp_off_glacier',
-        'liq_prcp_on_glacier',
-        'snowfall_off_glacier',
-        'snowfall_on_glacier',
-        'snow_bucket',
-    ]
-
-    odf = []
-    if kwargs['store_monthly_step'] or store_monthly_hydro:
-        years = utils.monthly_timeseries(years[0],years[-1]+1)[:-1]
-    for i, yr in enumerate(years):
-        o = pd.Series(index=index, data=np.zeros(len(index)))
-        o.name = yr
-        for fl_id, (max_area, snow_bucket, bin_area_2d, bin_elev_2d) in \
-                enumerate(zip(max_areas, snow_buckets, bin_area_2ds, bin_elev_2ds)):
-            if kwargs['store_monthly_step'] or store_monthly_hydro:
-                #would not be needed if FileModel works on monthly scale
-                i = int(np.floor(i/12))
-            bin_area = bin_area_2d[i, :]
-            bin_elev = bin_elev_2d[i, :]
-
-            # Make sure we have no negative contribution
-            off_area = utils.clip_min(max_area - bin_area, 0)
-            
-            # Get the mb data
-            try:
-                if kwargs['store_monthly_step'] or store_monthly_hydro:
-                    mb, _, _, prcp, prcpsol = mb_mod.get_monthly_mb(bin_elev,
-                                                               fl_id=fl_id,
-                                                               year=yr,
-                                                               add_climate=True)
-                else:
-                    mb, _, _, prcp, prcpsol = mb_mod.get_annual_mb(bin_elev,
-                                                               fl_id=fl_id,
-                                                               year=yr,
-                                                               add_climate=True)
-            except ValueError as e:
-                if 'too many values to unpack' in str(e):
-                    raise InvalidWorkflowError('Run with hydro needs a MB '
-                                               'model able to add climate '
-                                               'info to `get_annual_mb`.')
-                raise
-
-            # Here we use mass (kg yr-1) not ice volume
-            if kwargs['store_monthly_step'] or store_monthly_hydro:
-                mb *= cfg.SEC_IN_MONTH * cfg.PARAMS['ice_density']
-            else:
-                mb *= cfg.SEC_IN_YEAR * cfg.PARAMS['ice_density']
-
-            liq_prcp_on_g = (prcp - prcpsol) * bin_area
-            liq_prcp_off_g = (prcp - prcpsol) * off_area
-
-            prcpsol_on_g = prcpsol * bin_area
-            prcpsol_off_g = prcpsol * off_area
-
-            # This doesn't check if there is enough to melt yet
-            melt_on_g = (prcpsol - mb) * bin_area
-            melt_off_g = (prcpsol - mb) * off_area
-
-            # Update bucket with accumulation and melt
-            snow_bucket += prcpsol_off_g
-
-            # It can only melt that much
-            melt_off_g = np.where((snow_bucket - melt_off_g) >= 0, melt_off_g, snow_bucket)
-
-            # Update bucket
-            snow_bucket -= melt_off_g
-
-            # out
-            o.loc['off_area'] += np.sum(off_area)
-            o.loc['on_area'] += np.sum(bin_area)
-            o.loc['melt_off_glacier'] += np.sum(melt_off_g)
-            o.loc['melt_on_glacier'] += np.sum(melt_on_g)
-            o.loc['liq_prcp_off_glacier'] += np.sum(liq_prcp_off_g)
-            o.loc['liq_prcp_on_glacier'] += np.sum(liq_prcp_on_g)
-            o.loc['snowfall_off_glacier'] += np.sum(prcpsol_off_g)
-            o.loc['snowfall_on_glacier'] += np.sum(prcpsol_on_g)
-            o.loc['snow_bucket'] += np.sum(snow_bucket)
-
-        # Update the final dataframe
-        odf.append(o)
-
-    # Add an empty one for the last year for compatibility with the diags
-    o = pd.Series(index=index, data=np.zeros(len(index)) * np.NaN)
-    if kwargs['store_monthly_step'] or store_monthly_hydro:
-        yr_add = yr + 1/12
-        yr, m = utils.floatyear_to_date(yr_add)
-    else:
-        yr_add = yr + 1
-    o.name = yr_add
-    odf.append(o)
-    #TO DO run until only runs on yearly time scale, therefore output of model area and model vol is in years
-    if kwargs['store_monthly_step'] or store_monthly_hydro:
-        #this does not give monthly output but monthly output necessary for model_area, model_vol
-        fmod.run_until(yr, m)
-    else:
-        fmod.run_until(yr_add)
-    model_area.append(fmod.area_m2)
-    model_vol.append(fmod.volume_m3)
-
-    # Final output
-    odf = pd.DataFrame(odf)
-    odf.index.name = 'time'
-    #model volume has yearly steps but odf has monthly steps, does not work together
-    odf['model_vol'] = np.array(model_vol) * cfg.PARAMS['ice_density']
-    odf['model_mb'] = odf['model_vol'].iloc[1:].values - odf['model_vol'].iloc[:-1]
-
-    # The snow bucket is actually a state variable - pos end of timestamp
-    odf['snow_bucket'] = np.append(0., odf['snow_bucket'].iloc[:-1])
-
-    # Correct for non available mass
-    reconstructed_mb = odf['snowfall_on_glacier'] - odf['melt_on_glacier']
-    residual_mb = odf['model_mb'] - reconstructed_mb
-    odf['residual_mb'] = residual_mb
-    odf['melt_on_glacier'] = odf['melt_on_glacier'] - residual_mb
-
-    # Append the output to the existing diagnostics and convert to
-    # xarray for compatibility
-    #TO DO: it can not be added to existing file path, because if the run only stores yearly values you cannot change this and store monthly values
-    fpath = gdir.get_filepath('model_diagnostics', filesuffix=suffix)
-
-    sel_vars = {
+    out = {
         'off_area': {
             'description': 'Off-glacier area',
-            'unit': 'm 2'
+            'unit': 'm 2',
+            'data': np.zeros(ntime),
         },
         'on_area': {
             'description': 'On-glacier area',
-            'unit': 'm 2'
+            'unit': 'm 2',
+            'data': np.zeros(ntime),
         },
         'melt_off_glacier': {
             'description': 'Off-glacier melt',
-            'unit': 'kg yr-1'
+            'unit': 'kg yr-1',
+            'data': np.zeros(oshape),
         },
         'melt_on_glacier': {
             'description': 'On-glacier melt',
-            'unit': 'kg yr-1'
+            'unit': 'kg yr-1',
+            'data': np.zeros(oshape),
         },
         'liq_prcp_off_glacier': {
             'description': 'Off-glacier liquid precipitation',
-            'unit': 'kg yr-1'
+            'unit': 'kg yr-1',
+            'data': np.zeros(oshape),
         },
         'liq_prcp_on_glacier': {
             'description': 'On-glacier liquid precipitation',
-            'unit': 'kg yr-1'
+            'unit': 'kg yr-1',
+            'data': np.zeros(oshape),
         },
         'snowfall_off_glacier': {
             'description': 'Off-glacier solid precipitation',
-            'unit': 'kg yr-1'
+            'unit': 'kg yr-1',
+            'data': np.zeros(oshape),
         },
         'snowfall_on_glacier': {
             'description': 'On-glacier solid precipitation',
-            'unit': 'kg yr-1'
+            'unit': 'kg yr-1',
+            'data': np.zeros(oshape),
         },
         'snow_bucket': {
             'description': 'Off-glacier snow reservoir (state variable)',
-            'unit': 'kg'
+            'unit': 'kg',
+            'data': np.zeros(oshape),
         },
         'model_mb': {
             'description': 'Annual mass-balance from dynamical model',
-            'unit': 'kg yr-1'
+            'unit': 'kg yr-1',
+            'data': np.zeros(ntime),
         },
         'residual_mb': {
             'description': 'Difference (before correction) between mb model and dyn model melt',
-            'unit': 'kg yr-1'
+            'unit': 'kg yr-1',
+            'data': np.zeros(oshape),
         },
     }
-    ods = xr.Dataset.from_dataframe(odf[sel_vars.keys()])
-    for k, v in sel_vars.items():
-        ods[k].attrs = v
 
-    # Add attrs
+    # Initialize
+    fmod.run_until(years[0])
+    prev_model_vol = fmod.volume_m3
+
+    for i, yr in enumerate(years):
+
+        # Now the loop over the months
+        for m in months:
+
+            # A bit silly but avoid double counting in monthly ts
+            off_area_out = 0
+            on_area_out = 0
+
+            for fl_id, (max_area, snow_bucket, bin_area_2d, bin_elev_2d) in \
+                    enumerate(zip(max_areas, snow_buckets, bin_area_2ds, bin_elev_2ds)):
+
+                bin_area = bin_area_2d[i, :]
+                bin_elev = bin_elev_2d[i, :]
+
+                # Make sure we have no negative contribution
+                off_area = utils.clip_min(max_area - bin_area, 0)
+
+                try:
+                    if store_monthly_hydro:
+                        flt_yr = utils.date_to_floatyear(int(yr), m)
+                        mb_out = mb_mod.get_monthly_mb(bin_elev, fl_id=fl_id,
+                                                       year=flt_yr,
+                                                       add_climate=True)
+                        mb, _, _, prcp, prcpsol = mb_out
+                    else:
+                        mb_out = mb_mod.get_annual_mb(bin_elev, fl_id=fl_id,
+                                                      year=yr, add_climate=True)
+                        mb, _, _, prcp, prcpsol = mb_out
+                except ValueError as e:
+                    if 'too many values to unpack' in str(e):
+                        raise InvalidWorkflowError('Run with hydro needs a MB '
+                                                   'model able to add climate '
+                                                   'info to `get_annual_mb`.')
+                    raise
+
+                # Here we use mass (kg yr-1) not ice volume
+                mb *= seconds * cfg.PARAMS['ice_density']
+
+                liq_prcp_on_g = (prcp - prcpsol) * bin_area
+                liq_prcp_off_g = (prcp - prcpsol) * off_area
+
+                prcpsol_on_g = prcpsol * bin_area
+                prcpsol_off_g = prcpsol * off_area
+
+                # IMPORTANT: this does not guarantee that melt cannot be negative
+                # the reason is the MB residual (called .bias in the model)
+                # that here can only be understood as a fake melt process.
+                # In particular at the montly scale this can lead to negative
+                # melt id mb_mod.bias is negative
+                melt_on_g = (prcpsol - mb) * bin_area
+                melt_off_g = (prcpsol - mb) * off_area
+
+                # Update bucket with accumulation and melt
+                snow_bucket += prcpsol_off_g
+                # It can only melt that much
+                melt_off_g = np.where((snow_bucket - melt_off_g) >= 0, melt_off_g, snow_bucket)
+                # Update bucket
+                snow_bucket -= melt_off_g
+
+                # This is recomputed each month but well
+                off_area_out += np.sum(off_area)
+                on_area_out += np.sum(bin_area)
+
+                # Monthly out
+                out['melt_off_glacier']['data'][i, m-1] += np.sum(melt_off_g)
+                out['melt_on_glacier']['data'][i, m-1] += np.sum(melt_on_g)
+                out['liq_prcp_off_glacier']['data'][i, m-1] += np.sum(liq_prcp_off_g)
+                out['liq_prcp_on_glacier']['data'][i, m-1] += np.sum(liq_prcp_on_g)
+                out['snowfall_off_glacier']['data'][i, m-1] += np.sum(prcpsol_off_g)
+                out['snowfall_on_glacier']['data'][i, m-1] += np.sum(prcpsol_on_g)
+
+                # Snow bucket is a state variable - stored at end of timestamp
+                if store_monthly_hydro:
+                    if m == 12:
+                        out['snow_bucket']['data'][i+1, 0] += np.sum(snow_bucket)
+                    else:
+                        out['snow_bucket']['data'][i, m] += np.sum(snow_bucket)
+                else:
+                    out['snow_bucket']['data'][i+1, m-1] += np.sum(snow_bucket)
+
+        # Update the annual data
+        out['off_area']['data'][i] = off_area_out
+        out['on_area']['data'][i] = on_area_out
+
+        # Correct for mass-conservation
+        fmod.run_until(yr + 1)
+        model_mb = (fmod.volume_m3 - prev_model_vol) * cfg.PARAMS['ice_density']
+        prev_model_vol = fmod.volume_m3
+
+        reconstructed_mb = (out['snowfall_on_glacier']['data'][i, :].sum() -
+                            out['melt_on_glacier']['data'][i, :].sum())
+        residual_mb = model_mb - reconstructed_mb
+
+        # Now correct
+        if store_monthly_hydro:
+            # We try to correct the melt only where there is some
+            asum = out['melt_on_glacier']['data'][i, :].sum()
+            if asum > 1 and residual_mb > 0:
+                # try to find a fac
+                fac = 1 - residual_mb / asum
+                corr = out['melt_on_glacier']['data'][i, :] * fac
+                residual_mb = out['melt_on_glacier']['data'][i, :] - corr
+                out['melt_on_glacier']['data'][i, :] = corr
+            else:
+                # We simply spread over the months
+                residual_mb /= 12
+                out['melt_on_glacier']['data'][i, :] = out['melt_on_glacier']['data'][i, :] - residual_mb
+        else:
+            # We simply apply the residual - no choice here
+            out['melt_on_glacier']['data'][i, :] = out['melt_on_glacier']['data'][i, :] - residual_mb
+
+        out['model_mb']['data'][i] = model_mb
+        out['residual_mb']['data'][i] = residual_mb
+
+    # Convert to xarray
+    ods = xr.Dataset()
+    ods.coords['time'] = fmod.years
+    if store_monthly_hydro:
+        ods.coords['month_2d'] = ('month_2d', np.arange(1, 13))
+        # For the user later
+        sm = cfg.PARAMS['hydro_month_' + mb_mod.hemisphere]
+        ods.coords['calendar_month_2d'] = ('month_2d', (np.arange(12) + sm - 1) % 12 + 1)
+    for varname, d in out.items():
+        data = d.pop('data')
+        if len(data.shape) == 2:
+            # First the annual agg
+            if varname == 'snow_bucket':
+                # Snowbucket is a state variable
+                ods[varname] = ('time', data[:, 0])
+            else:
+                # Last year is never good
+                data[-1, :] = np.NaN
+                ods[varname] = ('time', np.sum(data, axis=1))
+            # Then the monthly ones
+            if store_monthly_hydro:
+                ods[varname + '_monthly'] = (('time', 'month_2d'), data)
+        else:
+            assert varname != 'snow_bucket'
+            data[-1] = np.NaN
+            ods[varname] = ('time', data)
+        for k, v in d.items():
+            ods[varname].attrs[k] = v
+
+    # Append the output to the existing diagnostics
+    fpath = gdir.get_filepath('model_diagnostics', filesuffix=suffix)
     ods.to_netcdf(fpath, mode='a')
 
     return out

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -1000,7 +1000,7 @@ class FlowlineModel(object):
         if 'length' in ovars:
             diag_ds['length_m'] = ('time', np.zeros(nm) * np.NaN)
             diag_ds['length_m'].attrs['description'] = 'Glacier length'
-            diag_ds['length_m'].attrs['unit'] = 'm 3'
+            diag_ds['length_m'].attrs['unit'] = 'm'
 
         if 'calving' in ovars:
             diag_ds['calving_m3'] = ('time', np.zeros(nm) * np.NaN)

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -865,7 +865,7 @@ class RandomMassBalance(MassBalanceModel):
     def get_monthly_mb(self, heights, year=None, **kwargs):
         ryr, m = floatyear_to_date(year)
         ryr = date_to_floatyear(self.get_state_yr(ryr), m)
-        return self.mbmod.get_monthly_mb(heights, year=ryr)
+        return self.mbmod.get_monthly_mb(heights, year=ryr, **kwargs)
 
     def get_annual_mb(self, heights, year=None, **kwargs):
         ryr = self.get_state_yr(int(year))

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -677,7 +677,38 @@ class ConstantMassBalance(MassBalanceModel):
             interp_m.append(interp1d(self.hbins, mb_on_h / len(self.years)))
         return interp_m
 
-    def get_climate(self, heights, year=None):
+    def get_monthly_climate(self, heights, year=None):
+        """Average climate information at given heights.
+
+        Note that prcp is corrected with the precipitation factor and that
+        all other biases (precipitation, temp) are applied
+
+        Returns
+        -------
+        (temp, tempformelt, prcp, prcpsol)
+        """
+        _, m = floatyear_to_date(year)
+        yrs = [date_to_floatyear(y, m) for y in self.years]
+        heights = np.atleast_1d(heights)
+        nh = len(heights)
+        shape = (len(yrs), nh)
+        temp = np.zeros(shape)
+        tempformelt = np.zeros(shape)
+        prcp = np.zeros(shape)
+        prcpsol = np.zeros(shape)
+        for i, yr in enumerate(yrs):
+            t, tm, p, ps = self.mbmod.get_monthly_climate(heights, year=yr)
+            temp[i, :] = t
+            tempformelt[i, :] = tm
+            prcp[i, :] = p
+            prcpsol[i, :] = ps
+        # Note that we do not weight for number of days per month - bad
+        return (np.mean(temp, axis=0),
+                np.mean(tempformelt, axis=0),
+                np.mean(prcp, axis=0),
+                np.mean(prcpsol, axis=0))
+
+    def get_annual_climate(self, heights, year=None):
         """Average climate information at given heights.
 
         Note that prcp is corrected with the precipitation factor and that
@@ -702,7 +733,8 @@ class ConstantMassBalance(MassBalanceModel):
             tempformelt[i, :] = tm
             prcp[i, :] = p
             prcpsol[i, :] = ps
-        # Note that we do not weight for number of days per month - bad
+        # Note that we do not weight for number of days per month
+        # That's OGGM
         return (np.mean(temp, axis=0),
                 np.mean(tempformelt, axis=0) * 12,
                 np.mean(prcp, axis=0) * 12,
@@ -711,14 +743,14 @@ class ConstantMassBalance(MassBalanceModel):
     def get_monthly_mb(self, heights, year=None, add_climate=False, **kwargs):
         yr, m = floatyear_to_date(year)
         if add_climate:
-            t, tmelt, prcp, prcpsol = self.get_climate(heights)
+            t, tmelt, prcp, prcpsol = self.get_monthly_climate(heights, year=year)
             return self.interp_m[m-1](heights), t, tmelt, prcp, prcpsol
         return self.interp_m[m-1](heights)
 
     def get_annual_mb(self, heights, year=None, add_climate=False, **kwargs):
         mb = self.interp_yr(heights)
         if add_climate:
-            t, tmelt, prcp, prcpsol = self.get_climate(heights)
+            t, tmelt, prcp, prcpsol = self.get_annual_climate(heights)
             return mb, t, tmelt, prcp, prcpsol
         return mb
 

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -712,7 +712,7 @@ class ConstantMassBalance(MassBalanceModel):
         yr, m = floatyear_to_date(year)
         if add_climate:
             t, tmelt, prcp, prcpsol = self.get_climate(heights)
-            return self.interp_m[m-1](heights), t, tmelt, prcp, prcpsol       
+            return self.interp_m[m-1](heights), t, tmelt, prcp, prcpsol
         return self.interp_m[m-1](heights)
 
     def get_annual_mb(self, heights, year=None, add_climate=False, **kwargs):

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -702,7 +702,6 @@ class ConstantMassBalance(MassBalanceModel):
             tempformelt[i, :] = tm
             prcp[i, :] = p
             prcpsol[i, :] = ps
-        # Note that we do not weight for number of days per month - bad
         return (np.mean(temp, axis=0),
                 np.mean(tempformelt, axis=0),
                 np.mean(prcp, axis=0),
@@ -733,8 +732,8 @@ class ConstantMassBalance(MassBalanceModel):
             tempformelt[i, :] = tm
             prcp[i, :] = p
             prcpsol[i, :] = ps
-        # Note that we do not weight for number of days per month
-        # That's OGGM
+        # Note that we do not weight for number of days per month:
+        # this is consistent with OGGM's calendar
         return (np.mean(temp, axis=0),
                 np.mean(tempformelt, axis=0) * 12,
                 np.mean(prcp, axis=0) * 12,

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -532,11 +532,14 @@ class PastMassBalance(MassBalanceModel):
         return (t.mean(axis=1), tmelt.sum(axis=1),
                 prcp.sum(axis=1), prcpsol.sum(axis=1))
 
-    def get_monthly_mb(self, heights, year=None, **kwargs):
+    def get_monthly_mb(self, heights, year=None, add_climate=False, **kwargs):
 
-        _, tmelt, _, prcpsol = self.get_monthly_climate(heights, year=year)
+        t, tmelt, prcp, prcpsol = self.get_monthly_climate(heights, year=year)
         mb_month = prcpsol - self.mu_star * tmelt
         mb_month -= self.bias * SEC_IN_MONTH / SEC_IN_YEAR
+        if add_climate:
+            return (mb_month / SEC_IN_MONTH / self.rho, t, tmelt,
+                    prcp, prcpsol)
         return mb_month / SEC_IN_MONTH / self.rho
 
     def get_annual_mb(self, heights, year=None, add_climate=False, **kwargs):
@@ -705,8 +708,11 @@ class ConstantMassBalance(MassBalanceModel):
                 np.mean(prcp, axis=0) * 12,
                 np.mean(prcpsol, axis=0) * 12)
 
-    def get_monthly_mb(self, heights, year=None, **kwargs):
+    def get_monthly_mb(self, heights, year=None, add_climate=False, **kwargs):
         yr, m = floatyear_to_date(year)
+        if add_climate:
+            t, tmelt, prcp, prcpsol = self.get_climate(heights)
+            return self.interp_m[m-1](heights), t, tmelt, prcp, prcpsol       
         return self.interp_m[m-1](heights)
 
     def get_annual_mb(self, heights, year=None, add_climate=False, **kwargs):

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -3471,7 +3471,7 @@ class TestHydro:
 
         # Residual MB should not be crazy large
         frac = odf_ma['residual_mb'] / odf_ma['melt_on_glacier']
-        assert_allclose(frac, 0, atol=0.01)
+        assert_allclose(frac.loc[~frac.isnull()], 0, atol=0.01)
 
         # Runoff peak should follow a temperature curve
         assert_allclose(odf_ma['runoff'].idxmax(), 11, atol=1.1)

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -3157,307 +3157,307 @@ class TestHEF:
 @pytest.mark.usefixtures('with_class_wd')
 class TestHydro:
 
-        @pytest.mark.slow
-        @pytest.mark.parametrize('store_monthly_hydro', [False], ids=['annual'])
-        # @pytest.mark.parametrize('store_monthly_hydro', [False, True], ids=['annual', 'monthly'])
-        def test_hydro_out_from_no_glacier(self, hef_gdir, inversion_params, store_monthly_hydro):
+    @pytest.mark.slow
+    @pytest.mark.parametrize('store_monthly_hydro', [False], ids=['annual'])
+    # @pytest.mark.parametrize('store_monthly_hydro', [False, True], ids=['annual', 'monthly'])
+    def test_hydro_out_from_no_glacier(self, hef_gdir, inversion_params, store_monthly_hydro):
 
-            gdir = hef_gdir
+        gdir = hef_gdir
 
-            # Try minimal output and see if it works
-            cfg.PARAMS['store_diagnostic_variables'] = ['volume', 'area']
+        # Try minimal output and see if it works
+        cfg.PARAMS['store_diagnostic_variables'] = ['volume', 'area']
 
-            init_present_time_glacier(gdir)
-            tasks.run_with_hydro(gdir, run_task=tasks.run_constant_climate,
-                                 store_monthly_hydro=store_monthly_hydro,
-                                 bias=0, nyears=100, zero_initial_glacier=True,
-                                 output_filesuffix='_const')
+        init_present_time_glacier(gdir)
+        tasks.run_with_hydro(gdir, run_task=tasks.run_constant_climate,
+                             store_monthly_hydro=store_monthly_hydro,
+                             bias=0, nyears=100, zero_initial_glacier=True,
+                             output_filesuffix='_const')
 
-            with xr.open_dataset(gdir.get_filepath('model_diagnostics',
-                                                   filesuffix='_const')) as ds:
-                sel_vars = [v for v in ds.variables if 'month_2d' not in ds[v].dims]
-                odf = ds[sel_vars].to_dataframe().iloc[:-1]
+        with xr.open_dataset(gdir.get_filepath('model_diagnostics',
+                                               filesuffix='_const')) as ds:
+            sel_vars = [v for v in ds.variables if 'month_2d' not in ds[v].dims]
+            odf = ds[sel_vars].to_dataframe().iloc[:-1]
 
-            # Sanity checks
-            # Tot prcp here is constant (constant climate)
-            odf['tot_prcp'] = (odf['liq_prcp_off_glacier'] +
-                               odf['liq_prcp_on_glacier'] +
-                               odf['snowfall_off_glacier'] +
-                               odf['snowfall_on_glacier'])
-            assert_allclose(odf['tot_prcp'], odf['tot_prcp'].iloc[0])
+        # Sanity checks
+        # Tot prcp here is constant (constant climate)
+        odf['tot_prcp'] = (odf['liq_prcp_off_glacier'] +
+                           odf['liq_prcp_on_glacier'] +
+                           odf['snowfall_off_glacier'] +
+                           odf['snowfall_on_glacier'])
+        assert_allclose(odf['tot_prcp'], odf['tot_prcp'].iloc[0])
 
-            # Glacier area is the same (remove on_area?)
-            assert_allclose(odf['on_area'], odf['area_m2'])
+        # Glacier area is the same (remove on_area?)
+        assert_allclose(odf['on_area'], odf['area_m2'])
 
-            # Our MB is the same as the glacier dyn one
-            odf['reconstructed_vol'] = odf['model_mb'].cumsum() / cfg.PARAMS['ice_density']
-            assert_allclose(odf['volume_m3'].iloc[1:], odf['reconstructed_vol'].iloc[:-1])
+        # Our MB is the same as the glacier dyn one
+        odf['reconstructed_vol'] = odf['model_mb'].cumsum() / cfg.PARAMS['ice_density']
+        assert_allclose(odf['volume_m3'].iloc[1:], odf['reconstructed_vol'].iloc[:-1])
 
-            # Mass-conservation
-            odf['runoff'] = (odf['melt_on_glacier'] +
-                             odf['melt_off_glacier'] +
-                             odf['liq_prcp_on_glacier'] +
-                             odf['liq_prcp_off_glacier'])
+        # Mass-conservation
+        odf['runoff'] = (odf['melt_on_glacier'] +
+                         odf['melt_off_glacier'] +
+                         odf['liq_prcp_on_glacier'] +
+                         odf['liq_prcp_off_glacier'])
 
-            mass_in_glacier = odf['volume_m3'].iloc[-1] * cfg.PARAMS['ice_density']
-            mass_in_snow = odf['snow_bucket'].iloc[-1]
-            mass_in = odf['tot_prcp'].iloc[:-1].sum()
-            mass_out = odf['runoff'].iloc[:-1].sum()
-            assert_allclose(mass_in - mass_out - mass_in_snow - mass_in_glacier,
-                            0, atol=1e-2)  # 0.01 kg is OK as numerical error
+        mass_in_glacier = odf['volume_m3'].iloc[-1] * cfg.PARAMS['ice_density']
+        mass_in_snow = odf['snow_bucket'].iloc[-1]
+        mass_in = odf['tot_prcp'].iloc[:-1].sum()
+        mass_out = odf['runoff'].iloc[:-1].sum()
+        assert_allclose(mass_in - mass_out - mass_in_snow - mass_in_glacier,
+                        0, atol=1e-2)  # 0.01 kg is OK as numerical error
 
-            # At the very first timesep there is no glacier so the
-            # melt_on_glacier var is negative - this is a numerical artifact
-            # from the residual
-            assert_allclose(odf['melt_on_glacier'].iloc[0],
-                            - odf['residual_mb'].iloc[0])
+        # At the very first timesep there is no glacier so the
+        # melt_on_glacier var is negative - this is a numerical artifact
+        # from the residual
+        assert_allclose(odf['melt_on_glacier'].iloc[0],
+                        - odf['residual_mb'].iloc[0])
 
-        @pytest.mark.slow
-        @pytest.mark.parametrize('store_monthly_hydro', [False], ids=['annual'])
-        # @pytest.mark.parametrize('store_monthly_hydro', [False, True], ids=['annual', 'monthly'])
-        def test_hydro_out_commitment(self, hef_gdir, inversion_params, store_monthly_hydro):
+    @pytest.mark.slow
+    @pytest.mark.parametrize('store_monthly_hydro', [False], ids=['annual'])
+    # @pytest.mark.parametrize('store_monthly_hydro', [False, True], ids=['annual', 'monthly'])
+    def test_hydro_out_commitment(self, hef_gdir, inversion_params, store_monthly_hydro):
 
-            gdir = hef_gdir
+        gdir = hef_gdir
 
-            # Try minimal output and see if it works
-            cfg.PARAMS['store_diagnostic_variables'] = ['volume', 'area']
+        # Try minimal output and see if it works
+        cfg.PARAMS['store_diagnostic_variables'] = ['volume', 'area']
 
-            init_present_time_glacier(gdir)
-            tasks.run_with_hydro(gdir, run_task=tasks.run_constant_climate,
-                                 store_monthly_hydro=store_monthly_hydro,
-                                 nyears=100, y0=2003-5, halfsize=5,
-                                 output_filesuffix='_const')
+        init_present_time_glacier(gdir)
+        tasks.run_with_hydro(gdir, run_task=tasks.run_constant_climate,
+                             store_monthly_hydro=store_monthly_hydro,
+                             nyears=100, y0=2003-5, halfsize=5,
+                             output_filesuffix='_const')
 
-            with xr.open_dataset(gdir.get_filepath('model_diagnostics',
-                                                   filesuffix='_const')) as ds:
-                sel_vars = [v for v in ds.variables if 'month_2d' not in ds[v].dims]
-                odf = ds[sel_vars].to_dataframe().iloc[:-1]
+        with xr.open_dataset(gdir.get_filepath('model_diagnostics',
+                                               filesuffix='_const')) as ds:
+            sel_vars = [v for v in ds.variables if 'month_2d' not in ds[v].dims]
+            odf = ds[sel_vars].to_dataframe().iloc[:-1]
 
-            # Sanity checks
-            # Tot prcp here is constant (constant climate)
-            odf['tot_prcp'] = (odf['liq_prcp_off_glacier'] +
-                               odf['liq_prcp_on_glacier'] +
-                               odf['snowfall_off_glacier'] +
-                               odf['snowfall_on_glacier'])
-            assert_allclose(odf['tot_prcp'], odf['tot_prcp'].iloc[0])
+        # Sanity checks
+        # Tot prcp here is constant (constant climate)
+        odf['tot_prcp'] = (odf['liq_prcp_off_glacier'] +
+                           odf['liq_prcp_on_glacier'] +
+                           odf['snowfall_off_glacier'] +
+                           odf['snowfall_on_glacier'])
+        assert_allclose(odf['tot_prcp'], odf['tot_prcp'].iloc[0])
 
-            # Glacier area is the same (remove on_area?)
-            assert_allclose(odf['on_area'], odf['area_m2'])
+        # Glacier area is the same (remove on_area?)
+        assert_allclose(odf['on_area'], odf['area_m2'])
 
-            # Our MB is the same as the glacier dyn one
-            reconstructed_vol = (odf['model_mb'].cumsum() / cfg.PARAMS['ice_density'] +
-                                 odf['volume_m3'].iloc[0])
-            assert_allclose(odf['volume_m3'].iloc[1:], reconstructed_vol.iloc[:-1])
+        # Our MB is the same as the glacier dyn one
+        reconstructed_vol = (odf['model_mb'].cumsum() / cfg.PARAMS['ice_density'] +
+                             odf['volume_m3'].iloc[0])
+        assert_allclose(odf['volume_m3'].iloc[1:], reconstructed_vol.iloc[:-1])
 
-            # Mass-conservation
-            odf['runoff'] = (odf['melt_on_glacier'] +
-                             odf['melt_off_glacier'] +
-                             odf['liq_prcp_on_glacier'] +
-                             odf['liq_prcp_off_glacier'])
+        # Mass-conservation
+        odf['runoff'] = (odf['melt_on_glacier'] +
+                         odf['melt_off_glacier'] +
+                         odf['liq_prcp_on_glacier'] +
+                         odf['liq_prcp_off_glacier'])
 
-            mass_in_glacier_end = odf['volume_m3'].iloc[-1] * cfg.PARAMS['ice_density']
-            mass_in_glacier_start = odf['volume_m3'].iloc[0] * cfg.PARAMS['ice_density']
+        mass_in_glacier_end = odf['volume_m3'].iloc[-1] * cfg.PARAMS['ice_density']
+        mass_in_glacier_start = odf['volume_m3'].iloc[0] * cfg.PARAMS['ice_density']
 
-            mass_in_snow = odf['snow_bucket'].iloc[-1]
-            mass_in = odf['tot_prcp'].iloc[:-1].sum()
-            mass_out = odf['runoff'].iloc[:-1].sum()
-            assert_allclose(mass_in_glacier_end,
-                            mass_in_glacier_start + mass_in - mass_out - mass_in_snow,
-                            atol=1e-2)  # 0.01 kg is OK as numerical error
+        mass_in_snow = odf['snow_bucket'].iloc[-1]
+        mass_in = odf['tot_prcp'].iloc[:-1].sum()
+        mass_out = odf['runoff'].iloc[:-1].sum()
+        assert_allclose(mass_in_glacier_end,
+                        mass_in_glacier_start + mass_in - mass_out - mass_in_snow,
+                        atol=1e-2)  # 0.01 kg is OK as numerical error
 
-            # Qualitative assessments
-            assert odf['melt_on_glacier'].iloc[-1] < odf['melt_on_glacier'].iloc[0] * 0.7
-            assert odf['liq_prcp_off_glacier'].iloc[-1] > odf['liq_prcp_on_glacier'].iloc[-1]
-            assert odf['liq_prcp_off_glacier'].iloc[0] < odf['liq_prcp_on_glacier'].iloc[0]
+        # Qualitative assessments
+        assert odf['melt_on_glacier'].iloc[-1] < odf['melt_on_glacier'].iloc[0] * 0.7
+        assert odf['liq_prcp_off_glacier'].iloc[-1] > odf['liq_prcp_on_glacier'].iloc[-1]
+        assert odf['liq_prcp_off_glacier'].iloc[0] < odf['liq_prcp_on_glacier'].iloc[0]
 
-            # Residual MB should not be crazy large
-            frac = odf['residual_mb'] / odf['melt_on_glacier']
-            assert_allclose(frac, 0, atol=0.02)
+        # Residual MB should not be crazy large
+        frac = odf['residual_mb'] / odf['melt_on_glacier']
+        assert_allclose(frac, 0, atol=0.02)
 
-        @pytest.mark.slow
-        @pytest.mark.parametrize('store_monthly_hydro', [True, False], ids=['monthly', 'annual'])
-        def test_hydro_out_past_climate(self, hef_gdir, inversion_params, store_monthly_hydro):
+    @pytest.mark.slow
+    @pytest.mark.parametrize('store_monthly_hydro', [True, False], ids=['monthly', 'annual'])
+    def test_hydro_out_past_climate(self, hef_gdir, inversion_params, store_monthly_hydro):
 
-            gdir = hef_gdir
-            gdir.rgi_date = 1990
+        gdir = hef_gdir
+        gdir.rgi_date = 1990
 
-            # Try minimal output and see if it works
-            cfg.PARAMS['store_diagnostic_variables'] = ['volume', 'area']
+        # Try minimal output and see if it works
+        cfg.PARAMS['store_diagnostic_variables'] = ['volume', 'area']
 
-            init_present_time_glacier(gdir)
-            tasks.run_with_hydro(gdir, run_task=tasks.run_from_climate_data,
-                                 store_monthly_hydro=store_monthly_hydro,
-                                 min_ys=1980, output_filesuffix='_hist')
+        init_present_time_glacier(gdir)
+        tasks.run_with_hydro(gdir, run_task=tasks.run_from_climate_data,
+                             store_monthly_hydro=store_monthly_hydro,
+                             min_ys=1980, output_filesuffix='_hist')
 
-            with xr.open_dataset(gdir.get_filepath('model_diagnostics',
-                                                   filesuffix='_hist')) as ds:
-                sel_vars = [v for v in ds.variables if 'month_2d' not in ds[v].dims]
-                odf = ds[sel_vars].to_dataframe().iloc[:-1]
+        with xr.open_dataset(gdir.get_filepath('model_diagnostics',
+                                               filesuffix='_hist')) as ds:
+            sel_vars = [v for v in ds.variables if 'month_2d' not in ds[v].dims]
+            odf = ds[sel_vars].to_dataframe().iloc[:-1]
 
-            # Sanity checks
-            odf['tot_prcp'] = (odf['liq_prcp_off_glacier'] +
-                               odf['liq_prcp_on_glacier'] +
-                               odf['snowfall_off_glacier'] +
-                               odf['snowfall_on_glacier'])
+        # Sanity checks
+        odf['tot_prcp'] = (odf['liq_prcp_off_glacier'] +
+                           odf['liq_prcp_on_glacier'] +
+                           odf['snowfall_off_glacier'] +
+                           odf['snowfall_on_glacier'])
 
-            # Glacier area is the same (remove on_area?)
-            assert_allclose(odf['on_area'], odf['area_m2'])
+        # Glacier area is the same (remove on_area?)
+        assert_allclose(odf['on_area'], odf['area_m2'])
 
-            # Our MB is the same as the glacier dyn one
-            reconstructed_vol = (odf['model_mb'].cumsum() / cfg.PARAMS['ice_density'] +
-                                 odf['volume_m3'].iloc[0])
-            assert_allclose(odf['volume_m3'].iloc[1:], reconstructed_vol.iloc[:-1])
+        # Our MB is the same as the glacier dyn one
+        reconstructed_vol = (odf['model_mb'].cumsum() / cfg.PARAMS['ice_density'] +
+                             odf['volume_m3'].iloc[0])
+        assert_allclose(odf['volume_m3'].iloc[1:], reconstructed_vol.iloc[:-1])
 
-            # Mass-conservation
-            odf['runoff'] = (odf['melt_on_glacier'] +
-                             odf['melt_off_glacier'] +
-                             odf['liq_prcp_on_glacier'] +
-                             odf['liq_prcp_off_glacier'])
+        # Mass-conservation
+        odf['runoff'] = (odf['melt_on_glacier'] +
+                         odf['melt_off_glacier'] +
+                         odf['liq_prcp_on_glacier'] +
+                         odf['liq_prcp_off_glacier'])
 
-            mass_in_glacier_end = odf['volume_m3'].iloc[-1] * cfg.PARAMS['ice_density']
-            mass_in_glacier_start = odf['volume_m3'].iloc[0] * cfg.PARAMS['ice_density']
+        mass_in_glacier_end = odf['volume_m3'].iloc[-1] * cfg.PARAMS['ice_density']
+        mass_in_glacier_start = odf['volume_m3'].iloc[0] * cfg.PARAMS['ice_density']
 
-            mass_in_snow = odf['snow_bucket'].iloc[-1]
-            mass_in = odf['tot_prcp'].iloc[:-1].sum()
-            mass_out = odf['runoff'].iloc[:-1].sum()
-            assert_allclose(mass_in_glacier_end,
-                            mass_in_glacier_start + mass_in - mass_out - mass_in_snow,
-                            atol=1e-2)  # 0.01 kg is OK as numerical error
+        mass_in_snow = odf['snow_bucket'].iloc[-1]
+        mass_in = odf['tot_prcp'].iloc[:-1].sum()
+        mass_out = odf['runoff'].iloc[:-1].sum()
+        assert_allclose(mass_in_glacier_end,
+                        mass_in_glacier_start + mass_in - mass_out - mass_in_snow,
+                        atol=1e-2)  # 0.01 kg is OK as numerical error
 
-            # Residual MB should not be crazy large
-            frac = odf['residual_mb'] / odf['melt_on_glacier']
-            assert_allclose(frac, 0, atol=0.05)
+        # Residual MB should not be crazy large
+        frac = odf['residual_mb'] / odf['melt_on_glacier']
+        assert_allclose(frac, 0, atol=0.05)
 
-            # Also check output stuff
-            nds = utils.compile_run_output([gdir], input_filesuffix='_hist')
-            assert nds.residual_mb.attrs['unit'] == 'kg yr-1'
-            assert_allclose(nds['snowfall_on_glacier'].squeeze()[:-1],
-                            odf['snowfall_on_glacier'])
-            if 'month_2d' in nds:
-                # 3d vars
-                sel_vars = [v for v in nds.variables if 'month_2d' in nds[v].dims]
-                odf_ma = nds[sel_vars].mean(dim=('time', 'rgi_id')).to_dataframe()
-                odf_ma.columns = [c.replace('_monthly', '') for c in odf_ma.columns]
-                # Runoff peak should follow a temperature curve
-                assert_allclose(odf_ma['melt_on_glacier'].idxmax(), 11, atol=1.1)
-
-        @pytest.mark.slow
-        def test_hydro_monhly_vs_annual(self, hef_gdir, inversion_params):
-
-            gdir = hef_gdir
-            gdir.rgi_date = 1990
-
-            cfg.PARAMS['store_diagnostic_variables'] = ['volume', 'area']
-
-            init_present_time_glacier(gdir)
-            tasks.run_with_hydro(gdir, run_task=tasks.run_from_climate_data,
-                                 store_monthly_hydro=False,
-                                 min_ys=1980, output_filesuffix='_annual')
-
-            with xr.open_dataset(gdir.get_filepath('model_diagnostics',
-                                                   filesuffix='_annual')) as ds:
-                odf_a = ds.to_dataframe()
-
-            tasks.run_with_hydro(gdir, run_task=tasks.run_from_climate_data,
-                                 store_monthly_hydro=True,
-                                 min_ys=1980, output_filesuffix='_monthly')
-
-            with xr.open_dataset(gdir.get_filepath('model_diagnostics',
-                                                   filesuffix='_monthly')) as ds:
-                sel_vars = [v for v in ds.variables if 'month_2d' not in ds[v].dims]
-                odf_m = ds[sel_vars].to_dataframe()
-                sel_vars = [v for v in ds.variables if 'month_2d' in ds[v].dims]
-                odf_ma = ds[sel_vars].mean(dim='time').to_dataframe()
-                odf_ma.columns = [c.replace('_monthly', '') for c in odf_ma.columns]
-
-            # Check that yearly equals monthly
-            np.testing.assert_array_equal(odf_a.columns, odf_m.columns)
-            for c in odf_a.columns:
-                rtol = 1e-5
-                if c == 'melt_off_glacier':
-                    rtol = 0.1
-                if c in ['snow_bucket']:
-                    continue
-                assert_allclose(odf_a[c], odf_m[c], rtol=rtol)
-
-            # Check monthly stuff
-            odf_ma['tot_prcp'] = (odf_ma['liq_prcp_off_glacier'] +
-                                  odf_ma['liq_prcp_on_glacier'] +
-                                  odf_ma['snowfall_off_glacier'] +
-                                  odf_ma['snowfall_on_glacier'])
-
-            odf_ma['runoff'] = (odf_ma['melt_on_glacier'] +
-                                odf_ma['melt_off_glacier'] +
-                                odf_ma['liq_prcp_on_glacier'] +
-                                odf_ma['liq_prcp_off_glacier'])
-
-            # Residual MB should not be crazy large
-            frac = odf_ma['residual_mb'] / odf_ma['melt_on_glacier']
-            assert_allclose(frac, 0, atol=0.01)
-
+        # Also check output stuff
+        nds = utils.compile_run_output([gdir], input_filesuffix='_hist')
+        assert nds.residual_mb.attrs['unit'] == 'kg yr-1'
+        assert_allclose(nds['snowfall_on_glacier'].squeeze()[:-1],
+                        odf['snowfall_on_glacier'])
+        if 'month_2d' in nds:
+            # 3d vars
+            sel_vars = [v for v in nds.variables if 'month_2d' in nds[v].dims]
+            odf_ma = nds[sel_vars].mean(dim=('time', 'rgi_id')).to_dataframe()
+            odf_ma.columns = [c.replace('_monthly', '') for c in odf_ma.columns]
             # Runoff peak should follow a temperature curve
-            assert_allclose(odf_ma['runoff'].idxmax(), 11, atol=1.1)
+            assert_allclose(odf_ma['melt_on_glacier'].idxmax(), 11, atol=1.1)
 
-        @pytest.mark.slow
-        @pytest.mark.parametrize('store_monthly_hydro', [False], ids=['annual'])
-        # @pytest.mark.parametrize('store_monthly_hydro', [False, True], ids=['annual', 'monthly'])
-        def test_hydro_out_random(self, hef_gdir, inversion_params, store_monthly_hydro):
+    @pytest.mark.slow
+    def test_hydro_monhly_vs_annual(self, hef_gdir, inversion_params):
 
-            gdir = hef_gdir
+        gdir = hef_gdir
+        gdir.rgi_date = 1990
 
-            # Try minimal output and see if it works
-            cfg.PARAMS['store_diagnostic_variables'] = ['volume', 'area']
+        cfg.PARAMS['store_diagnostic_variables'] = ['volume', 'area']
 
-            init_present_time_glacier(gdir)
-            tasks.run_with_hydro(gdir, run_task=tasks.run_random_climate,
-                                 store_monthly_hydro=store_monthly_hydro,
-                                 seed=0, nyears=100, y0=2003-5, halfsize=5,
-                                 output_filesuffix='_rand')
+        init_present_time_glacier(gdir)
+        tasks.run_with_hydro(gdir, run_task=tasks.run_from_climate_data,
+                             store_monthly_hydro=False,
+                             min_ys=1980, output_filesuffix='_annual')
 
-            with xr.open_dataset(gdir.get_filepath('model_diagnostics',
-                                                   filesuffix='_rand')) as ds:
-                sel_vars = [v for v in ds.variables if 'month_2d' not in ds[v].dims]
-                odf = ds[sel_vars].to_dataframe().iloc[:-1]
+        with xr.open_dataset(gdir.get_filepath('model_diagnostics',
+                                               filesuffix='_annual')) as ds:
+            odf_a = ds.to_dataframe()
 
-            # Sanity checks
-            # Tot prcp here is constant (constant climate)
-            odf['tot_prcp'] = (odf['liq_prcp_off_glacier'] +
-                               odf['liq_prcp_on_glacier'] +
-                               odf['snowfall_off_glacier'] +
-                               odf['snowfall_on_glacier'])
+        tasks.run_with_hydro(gdir, run_task=tasks.run_from_climate_data,
+                             store_monthly_hydro=True,
+                             min_ys=1980, output_filesuffix='_monthly')
 
-            # Glacier area is the same (remove on_area?)
-            assert_allclose(odf['on_area'], odf['area_m2'])
+        with xr.open_dataset(gdir.get_filepath('model_diagnostics',
+                                               filesuffix='_monthly')) as ds:
+            sel_vars = [v for v in ds.variables if 'month_2d' not in ds[v].dims]
+            odf_m = ds[sel_vars].to_dataframe()
+            sel_vars = [v for v in ds.variables if 'month_2d' in ds[v].dims]
+            odf_ma = ds[sel_vars].mean(dim='time').to_dataframe()
+            odf_ma.columns = [c.replace('_monthly', '') for c in odf_ma.columns]
 
-            # Our MB is the same as the glacier dyn one
-            reconstructed_vol = (odf['model_mb'].cumsum() / cfg.PARAMS['ice_density'] +
-                                 odf['volume_m3'].iloc[0])
-            assert_allclose(odf['volume_m3'].iloc[1:], reconstructed_vol.iloc[:-1])
+        # Check that yearly equals monthly
+        np.testing.assert_array_equal(odf_a.columns, odf_m.columns)
+        for c in odf_a.columns:
+            rtol = 1e-5
+            if c == 'melt_off_glacier':
+                rtol = 0.1
+            if c in ['snow_bucket']:
+                continue
+            assert_allclose(odf_a[c], odf_m[c], rtol=rtol)
 
-            # Mass-conservation
-            odf['runoff'] = (odf['melt_on_glacier'] +
-                             odf['melt_off_glacier'] +
-                             odf['liq_prcp_on_glacier'] +
-                             odf['liq_prcp_off_glacier'])
+        # Check monthly stuff
+        odf_ma['tot_prcp'] = (odf_ma['liq_prcp_off_glacier'] +
+                              odf_ma['liq_prcp_on_glacier'] +
+                              odf_ma['snowfall_off_glacier'] +
+                              odf_ma['snowfall_on_glacier'])
 
-            mass_in_glacier_end = odf['volume_m3'].iloc[-1] * cfg.PARAMS['ice_density']
-            mass_in_glacier_start = odf['volume_m3'].iloc[0] * cfg.PARAMS['ice_density']
+        odf_ma['runoff'] = (odf_ma['melt_on_glacier'] +
+                            odf_ma['melt_off_glacier'] +
+                            odf_ma['liq_prcp_on_glacier'] +
+                            odf_ma['liq_prcp_off_glacier'])
 
-            mass_in_snow = odf['snow_bucket'].iloc[-1]
-            mass_in = odf['tot_prcp'].iloc[:-1].sum()
-            mass_out = odf['runoff'].iloc[:-1].sum()
-            assert_allclose(mass_in_glacier_end,
-                            mass_in_glacier_start + mass_in - mass_out - mass_in_snow,
-                            atol=1e-2)  # 0.01 kg is OK as numerical error
+        # Residual MB should not be crazy large
+        frac = odf_ma['residual_mb'] / odf_ma['melt_on_glacier']
+        assert_allclose(frac, 0, atol=0.01)
 
-            # Qualitative assessments
-            assert odf['melt_on_glacier'].iloc[-1] < odf['melt_on_glacier'].iloc[0] * 0.7
-            assert odf['liq_prcp_off_glacier'].iloc[-1] > odf['liq_prcp_on_glacier'].iloc[-1]
-            assert odf['liq_prcp_off_glacier'].iloc[0] < odf['liq_prcp_on_glacier'].iloc[0]
+        # Runoff peak should follow a temperature curve
+        assert_allclose(odf_ma['runoff'].idxmax(), 11, atol=1.1)
 
-            # Residual MB should not be crazy large
-            frac = odf['residual_mb'] / odf['melt_on_glacier']
-            assert_allclose(frac, 0, atol=0.04)  # annual can be large (prob)
+    @pytest.mark.slow
+    @pytest.mark.parametrize('store_monthly_hydro', [False], ids=['annual'])
+    # @pytest.mark.parametrize('store_monthly_hydro', [False, True], ids=['annual', 'monthly'])
+    def test_hydro_out_random(self, hef_gdir, inversion_params, store_monthly_hydro):
+
+        gdir = hef_gdir
+
+        # Try minimal output and see if it works
+        cfg.PARAMS['store_diagnostic_variables'] = ['volume', 'area']
+
+        init_present_time_glacier(gdir)
+        tasks.run_with_hydro(gdir, run_task=tasks.run_random_climate,
+                             store_monthly_hydro=store_monthly_hydro,
+                             seed=0, nyears=100, y0=2003-5, halfsize=5,
+                             output_filesuffix='_rand')
+
+        with xr.open_dataset(gdir.get_filepath('model_diagnostics',
+                                               filesuffix='_rand')) as ds:
+            sel_vars = [v for v in ds.variables if 'month_2d' not in ds[v].dims]
+            odf = ds[sel_vars].to_dataframe().iloc[:-1]
+
+        # Sanity checks
+        # Tot prcp here is constant (constant climate)
+        odf['tot_prcp'] = (odf['liq_prcp_off_glacier'] +
+                           odf['liq_prcp_on_glacier'] +
+                           odf['snowfall_off_glacier'] +
+                           odf['snowfall_on_glacier'])
+
+        # Glacier area is the same (remove on_area?)
+        assert_allclose(odf['on_area'], odf['area_m2'])
+
+        # Our MB is the same as the glacier dyn one
+        reconstructed_vol = (odf['model_mb'].cumsum() / cfg.PARAMS['ice_density'] +
+                             odf['volume_m3'].iloc[0])
+        assert_allclose(odf['volume_m3'].iloc[1:], reconstructed_vol.iloc[:-1])
+
+        # Mass-conservation
+        odf['runoff'] = (odf['melt_on_glacier'] +
+                         odf['melt_off_glacier'] +
+                         odf['liq_prcp_on_glacier'] +
+                         odf['liq_prcp_off_glacier'])
+
+        mass_in_glacier_end = odf['volume_m3'].iloc[-1] * cfg.PARAMS['ice_density']
+        mass_in_glacier_start = odf['volume_m3'].iloc[0] * cfg.PARAMS['ice_density']
+
+        mass_in_snow = odf['snow_bucket'].iloc[-1]
+        mass_in = odf['tot_prcp'].iloc[:-1].sum()
+        mass_out = odf['runoff'].iloc[:-1].sum()
+        assert_allclose(mass_in_glacier_end,
+                        mass_in_glacier_start + mass_in - mass_out - mass_in_snow,
+                        atol=1e-2)  # 0.01 kg is OK as numerical error
+
+        # Qualitative assessments
+        assert odf['melt_on_glacier'].iloc[-1] < odf['melt_on_glacier'].iloc[0] * 0.7
+        assert odf['liq_prcp_off_glacier'].iloc[-1] > odf['liq_prcp_on_glacier'].iloc[-1]
+        assert odf['liq_prcp_off_glacier'].iloc[0] < odf['liq_prcp_on_glacier'].iloc[0]
+
+        # Residual MB should not be crazy large
+        frac = odf['residual_mb'] / odf['melt_on_glacier']
+        assert_allclose(frac, 0, atol=0.04)  # annual can be large (prob)
 
 
 @pytest.fixture(scope='class')

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -3157,231 +3157,307 @@ class TestHEF:
 @pytest.mark.usefixtures('with_class_wd')
 class TestHydro:
 
-    @pytest.mark.slow
-    def test_hydro_out_from_no_glacier(self, hef_gdir, inversion_params):
+        @pytest.mark.slow
+        @pytest.mark.parametrize('store_monthly_hydro', [False], ids=['annual'])
+        # @pytest.mark.parametrize('store_monthly_hydro', [False, True], ids=['annual', 'monthly'])
+        def test_hydro_out_from_no_glacier(self, hef_gdir, inversion_params, store_monthly_hydro):
 
-        gdir = hef_gdir
+            gdir = hef_gdir
 
-        # Try minimal output and see if it works
-        cfg.PARAMS['store_diagnostic_variables'] = ['volume', 'area']
+            # Try minimal output and see if it works
+            cfg.PARAMS['store_diagnostic_variables'] = ['volume', 'area']
 
-        init_present_time_glacier(gdir)
-        tasks.run_with_hydro(gdir, run_task=tasks.run_constant_climate,
-                             bias=0, nyears=100, zero_initial_glacier=True,
-                             output_filesuffix='_const')
+            init_present_time_glacier(gdir)
+            tasks.run_with_hydro(gdir, run_task=tasks.run_constant_climate,
+                                 store_monthly_hydro=store_monthly_hydro,
+                                 bias=0, nyears=100, zero_initial_glacier=True,
+                                 output_filesuffix='_const')
 
-        with xr.open_dataset(gdir.get_filepath('model_diagnostics',
-                                               filesuffix='_const')) as ds:
-            odf = ds.to_dataframe().iloc[:-1]
+            with xr.open_dataset(gdir.get_filepath('model_diagnostics',
+                                                   filesuffix='_const')) as ds:
+                sel_vars = [v for v in ds.variables if 'month_2d' not in ds[v].dims]
+                odf = ds[sel_vars].to_dataframe().iloc[:-1]
 
-        # Sanity checks
-        # Tot prcp here is constant (constant climate)
-        odf['tot_prcp'] = (odf['liq_prcp_off_glacier'] +
-                           odf['liq_prcp_on_glacier'] +
-                           odf['snowfall_off_glacier'] +
-                           odf['snowfall_on_glacier'])
-        assert_allclose(odf['tot_prcp'], odf['tot_prcp'].iloc[0])
+            # Sanity checks
+            # Tot prcp here is constant (constant climate)
+            odf['tot_prcp'] = (odf['liq_prcp_off_glacier'] +
+                               odf['liq_prcp_on_glacier'] +
+                               odf['snowfall_off_glacier'] +
+                               odf['snowfall_on_glacier'])
+            assert_allclose(odf['tot_prcp'], odf['tot_prcp'].iloc[0])
 
-        # Glacier area is the same (remove on_area?)
-        assert_allclose(odf['on_area'], odf['area_m2'])
+            # Glacier area is the same (remove on_area?)
+            assert_allclose(odf['on_area'], odf['area_m2'])
 
-        # Our MB is the same as the glacier dyn one
-        odf['reconstructed_vol'] = odf['model_mb'].cumsum() / cfg.PARAMS['ice_density']
-        assert_allclose(odf['volume_m3'].iloc[1:], odf['reconstructed_vol'].iloc[:-1])
+            # Our MB is the same as the glacier dyn one
+            odf['reconstructed_vol'] = odf['model_mb'].cumsum() / cfg.PARAMS['ice_density']
+            assert_allclose(odf['volume_m3'].iloc[1:], odf['reconstructed_vol'].iloc[:-1])
 
-        # Mass-conservation
-        odf['runoff'] = (odf['melt_on_glacier'] +
-                         odf['melt_off_glacier'] +
-                         odf['liq_prcp_on_glacier'] +
-                         odf['liq_prcp_off_glacier'])
+            # Mass-conservation
+            odf['runoff'] = (odf['melt_on_glacier'] +
+                             odf['melt_off_glacier'] +
+                             odf['liq_prcp_on_glacier'] +
+                             odf['liq_prcp_off_glacier'])
 
-        mass_in_glacier = odf['volume_m3'].iloc[-1] * cfg.PARAMS['ice_density']
-        mass_in_snow = odf['snow_bucket'].iloc[-1]
-        mass_in = odf['tot_prcp'].iloc[:-1].sum()
-        mass_out = odf['runoff'].iloc[:-1].sum()
-        assert_allclose(mass_in - mass_out - mass_in_snow - mass_in_glacier,
-                        0, atol=1e-2)  # 0.01 kg is OK as numerical error
+            mass_in_glacier = odf['volume_m3'].iloc[-1] * cfg.PARAMS['ice_density']
+            mass_in_snow = odf['snow_bucket'].iloc[-1]
+            mass_in = odf['tot_prcp'].iloc[:-1].sum()
+            mass_out = odf['runoff'].iloc[:-1].sum()
+            assert_allclose(mass_in - mass_out - mass_in_snow - mass_in_glacier,
+                            0, atol=1e-2)  # 0.01 kg is OK as numerical error
 
-        # At the very first timesep there is no glacier so the
-        # melt_on_glacier var is negative - this is a numerical artifact
-        # from the residual
-        assert_allclose(odf['melt_on_glacier'].iloc[0],
-                        - odf['residual_mb'].iloc[0])
+            # At the very first timesep there is no glacier so the
+            # melt_on_glacier var is negative - this is a numerical artifact
+            # from the residual
+            assert_allclose(odf['melt_on_glacier'].iloc[0],
+                            - odf['residual_mb'].iloc[0])
 
-    @pytest.mark.slow
-    def test_hydro_out_commitment(self, hef_gdir, inversion_params):
+        @pytest.mark.slow
+        @pytest.mark.parametrize('store_monthly_hydro', [False], ids=['annual'])
+        # @pytest.mark.parametrize('store_monthly_hydro', [False, True], ids=['annual', 'monthly'])
+        def test_hydro_out_commitment(self, hef_gdir, inversion_params, store_monthly_hydro):
 
-        gdir = hef_gdir
+            gdir = hef_gdir
 
-        # Try minimal output and see if it works
-        cfg.PARAMS['store_diagnostic_variables'] = ['volume', 'area']
+            # Try minimal output and see if it works
+            cfg.PARAMS['store_diagnostic_variables'] = ['volume', 'area']
 
-        init_present_time_glacier(gdir)
-        tasks.run_with_hydro(gdir, run_task=tasks.run_constant_climate,
-                             nyears=100, y0=2003-5, halfsize=5,
-                             output_filesuffix='_const')
+            init_present_time_glacier(gdir)
+            tasks.run_with_hydro(gdir, run_task=tasks.run_constant_climate,
+                                 store_monthly_hydro=store_monthly_hydro,
+                                 nyears=100, y0=2003-5, halfsize=5,
+                                 output_filesuffix='_const')
 
-        with xr.open_dataset(gdir.get_filepath('model_diagnostics',
-                                               filesuffix='_const')) as ds:
-            odf = ds.to_dataframe().iloc[:-1]
+            with xr.open_dataset(gdir.get_filepath('model_diagnostics',
+                                                   filesuffix='_const')) as ds:
+                sel_vars = [v for v in ds.variables if 'month_2d' not in ds[v].dims]
+                odf = ds[sel_vars].to_dataframe().iloc[:-1]
 
-        # Sanity checks
-        # Tot prcp here is constant (constant climate)
-        odf['tot_prcp'] = (odf['liq_prcp_off_glacier'] +
-                           odf['liq_prcp_on_glacier'] +
-                           odf['snowfall_off_glacier'] +
-                           odf['snowfall_on_glacier'])
-        assert_allclose(odf['tot_prcp'], odf['tot_prcp'].iloc[0])
+            # Sanity checks
+            # Tot prcp here is constant (constant climate)
+            odf['tot_prcp'] = (odf['liq_prcp_off_glacier'] +
+                               odf['liq_prcp_on_glacier'] +
+                               odf['snowfall_off_glacier'] +
+                               odf['snowfall_on_glacier'])
+            assert_allclose(odf['tot_prcp'], odf['tot_prcp'].iloc[0])
 
-        # Glacier area is the same (remove on_area?)
-        assert_allclose(odf['on_area'], odf['area_m2'])
+            # Glacier area is the same (remove on_area?)
+            assert_allclose(odf['on_area'], odf['area_m2'])
 
-        # Our MB is the same as the glacier dyn one
-        reconstructed_vol = (odf['model_mb'].cumsum() / cfg.PARAMS['ice_density'] +
-                             odf['volume_m3'].iloc[0])
-        assert_allclose(odf['volume_m3'].iloc[1:], reconstructed_vol.iloc[:-1])
+            # Our MB is the same as the glacier dyn one
+            reconstructed_vol = (odf['model_mb'].cumsum() / cfg.PARAMS['ice_density'] +
+                                 odf['volume_m3'].iloc[0])
+            assert_allclose(odf['volume_m3'].iloc[1:], reconstructed_vol.iloc[:-1])
 
-        # Mass-conservation
-        odf['runoff'] = (odf['melt_on_glacier'] +
-                         odf['melt_off_glacier'] +
-                         odf['liq_prcp_on_glacier'] +
-                         odf['liq_prcp_off_glacier'])
+            # Mass-conservation
+            odf['runoff'] = (odf['melt_on_glacier'] +
+                             odf['melt_off_glacier'] +
+                             odf['liq_prcp_on_glacier'] +
+                             odf['liq_prcp_off_glacier'])
 
-        mass_in_glacier_end = odf['volume_m3'].iloc[-1] * cfg.PARAMS['ice_density']
-        mass_in_glacier_start = odf['volume_m3'].iloc[0] * cfg.PARAMS['ice_density']
+            mass_in_glacier_end = odf['volume_m3'].iloc[-1] * cfg.PARAMS['ice_density']
+            mass_in_glacier_start = odf['volume_m3'].iloc[0] * cfg.PARAMS['ice_density']
 
-        mass_in_snow = odf['snow_bucket'].iloc[-1]
-        mass_in = odf['tot_prcp'].iloc[:-1].sum()
-        mass_out = odf['runoff'].iloc[:-1].sum()
-        assert_allclose(mass_in_glacier_end,
-                        mass_in_glacier_start + mass_in - mass_out - mass_in_snow,
-                        atol=1e-2)  # 0.01 kg is OK as numerical error
+            mass_in_snow = odf['snow_bucket'].iloc[-1]
+            mass_in = odf['tot_prcp'].iloc[:-1].sum()
+            mass_out = odf['runoff'].iloc[:-1].sum()
+            assert_allclose(mass_in_glacier_end,
+                            mass_in_glacier_start + mass_in - mass_out - mass_in_snow,
+                            atol=1e-2)  # 0.01 kg is OK as numerical error
 
-        # Qualitative assessments
-        assert odf['melt_on_glacier'].iloc[-1] < odf['melt_on_glacier'].iloc[0] * 0.7
-        assert odf['liq_prcp_off_glacier'].iloc[-1] > odf['liq_prcp_on_glacier'].iloc[-1]
-        assert odf['liq_prcp_off_glacier'].iloc[0] < odf['liq_prcp_on_glacier'].iloc[0]
+            # Qualitative assessments
+            assert odf['melt_on_glacier'].iloc[-1] < odf['melt_on_glacier'].iloc[0] * 0.7
+            assert odf['liq_prcp_off_glacier'].iloc[-1] > odf['liq_prcp_on_glacier'].iloc[-1]
+            assert odf['liq_prcp_off_glacier'].iloc[0] < odf['liq_prcp_on_glacier'].iloc[0]
 
-        # Residual MB should not be crazy large
-        frac = odf['residual_mb'] / odf['melt_on_glacier']
-        assert_allclose(frac, 0, atol=0.02)
+            # Residual MB should not be crazy large
+            frac = odf['residual_mb'] / odf['melt_on_glacier']
+            assert_allclose(frac, 0, atol=0.02)
 
-    @pytest.mark.slow
-    def test_hydro_out_past_climate(self, hef_gdir, inversion_params):
+        @pytest.mark.slow
+        @pytest.mark.parametrize('store_monthly_hydro', [True, False], ids=['monthly', 'annual'])
+        def test_hydro_out_past_climate(self, hef_gdir, inversion_params, store_monthly_hydro):
 
-        gdir = hef_gdir
-        gdir.rgi_date = 1990
+            gdir = hef_gdir
+            gdir.rgi_date = 1990
 
-        # Try minimal output and see if it works
-        cfg.PARAMS['store_diagnostic_variables'] = ['volume', 'area']
+            # Try minimal output and see if it works
+            cfg.PARAMS['store_diagnostic_variables'] = ['volume', 'area']
 
-        # Try minimal output and see if it works
-        cfg.PARAMS['store_diagnostic_variables'] = ['volume', 'area']
+            init_present_time_glacier(gdir)
+            tasks.run_with_hydro(gdir, run_task=tasks.run_from_climate_data,
+                                 store_monthly_hydro=store_monthly_hydro,
+                                 min_ys=1980, output_filesuffix='_hist')
 
-        init_present_time_glacier(gdir)
-        tasks.run_with_hydro(gdir, run_task=tasks.run_from_climate_data,
-                             min_ys=1980, output_filesuffix='_hist')
+            with xr.open_dataset(gdir.get_filepath('model_diagnostics',
+                                                   filesuffix='_hist')) as ds:
+                sel_vars = [v for v in ds.variables if 'month_2d' not in ds[v].dims]
+                odf = ds[sel_vars].to_dataframe().iloc[:-1]
 
-        with xr.open_dataset(gdir.get_filepath('model_diagnostics',
-                                               filesuffix='_hist')) as ds:
-            odf = ds.to_dataframe().iloc[:-1]
+            # Sanity checks
+            odf['tot_prcp'] = (odf['liq_prcp_off_glacier'] +
+                               odf['liq_prcp_on_glacier'] +
+                               odf['snowfall_off_glacier'] +
+                               odf['snowfall_on_glacier'])
 
-        # Sanity checks
-        odf['tot_prcp'] = (odf['liq_prcp_off_glacier'] +
-                           odf['liq_prcp_on_glacier'] +
-                           odf['snowfall_off_glacier'] +
-                           odf['snowfall_on_glacier'])
+            # Glacier area is the same (remove on_area?)
+            assert_allclose(odf['on_area'], odf['area_m2'])
 
-        # Glacier area is the same (remove on_area?)
-        assert_allclose(odf['on_area'], odf['area_m2'])
+            # Our MB is the same as the glacier dyn one
+            reconstructed_vol = (odf['model_mb'].cumsum() / cfg.PARAMS['ice_density'] +
+                                 odf['volume_m3'].iloc[0])
+            assert_allclose(odf['volume_m3'].iloc[1:], reconstructed_vol.iloc[:-1])
 
-        # Our MB is the same as the glacier dyn one
-        reconstructed_vol = (odf['model_mb'].cumsum() / cfg.PARAMS['ice_density'] +
-                             odf['volume_m3'].iloc[0])
-        assert_allclose(odf['volume_m3'].iloc[1:], reconstructed_vol.iloc[:-1])
+            # Mass-conservation
+            odf['runoff'] = (odf['melt_on_glacier'] +
+                             odf['melt_off_glacier'] +
+                             odf['liq_prcp_on_glacier'] +
+                             odf['liq_prcp_off_glacier'])
 
-        # Mass-conservation
-        odf['runoff'] = (odf['melt_on_glacier'] +
-                         odf['melt_off_glacier'] +
-                         odf['liq_prcp_on_glacier'] +
-                         odf['liq_prcp_off_glacier'])
+            mass_in_glacier_end = odf['volume_m3'].iloc[-1] * cfg.PARAMS['ice_density']
+            mass_in_glacier_start = odf['volume_m3'].iloc[0] * cfg.PARAMS['ice_density']
 
-        mass_in_glacier_end = odf['volume_m3'].iloc[-1] * cfg.PARAMS['ice_density']
-        mass_in_glacier_start = odf['volume_m3'].iloc[0] * cfg.PARAMS['ice_density']
+            mass_in_snow = odf['snow_bucket'].iloc[-1]
+            mass_in = odf['tot_prcp'].iloc[:-1].sum()
+            mass_out = odf['runoff'].iloc[:-1].sum()
+            assert_allclose(mass_in_glacier_end,
+                            mass_in_glacier_start + mass_in - mass_out - mass_in_snow,
+                            atol=1e-2)  # 0.01 kg is OK as numerical error
 
-        mass_in_snow = odf['snow_bucket'].iloc[-1]
-        mass_in = odf['tot_prcp'].iloc[:-1].sum()
-        mass_out = odf['runoff'].iloc[:-1].sum()
-        assert_allclose(mass_in_glacier_end,
-                        mass_in_glacier_start + mass_in - mass_out - mass_in_snow,
-                        atol=1e-2)  # 0.01 kg is OK as numerical error
+            # Residual MB should not be crazy large
+            frac = odf['residual_mb'] / odf['melt_on_glacier']
+            assert_allclose(frac, 0, atol=0.05)
 
-        # Residual MB should not be crazy large
-        frac = odf['residual_mb'] / odf['melt_on_glacier']
-        assert_allclose(frac, 0, atol=0.01)
+            # Also check output stuff
+            nds = utils.compile_run_output([gdir], input_filesuffix='_hist')
+            assert nds.residual_mb.attrs['unit'] == 'kg yr-1'
+            assert_allclose(nds['snowfall_on_glacier'].squeeze()[:-1],
+                            odf['snowfall_on_glacier'])
+            if 'month_2d' in nds:
+                # 3d vars
+                sel_vars = [v for v in nds.variables if 'month_2d' in nds[v].dims]
+                odf_ma = nds[sel_vars].mean(dim=('time', 'rgi_id')).to_dataframe()
+                odf_ma.columns = [c.replace('_monthly', '') for c in odf_ma.columns]
+                # Runoff peak should follow a temperature curve
+                assert_allclose(odf_ma['melt_on_glacier'].idxmax(), 11, atol=1.1)
 
-        # Also check output stuff
-        nds = utils.compile_run_output([gdir], filesuffix='_hist')
-        assert nds.residual_mb.attrs['unit'] == 'kg yr-1'
-        assert_allclose(nds['snowfall_on_glacier'].squeeze()[:-1],
-                        odf['snowfall_on_glacier'])
+        @pytest.mark.slow
+        def test_hydro_monhly_vs_annual(self, hef_gdir, inversion_params):
 
-    @pytest.mark.slow
-    def test_hydro_out_random(self, hef_gdir, inversion_params):
+            gdir = hef_gdir
+            gdir.rgi_date = 1990
 
-        gdir = hef_gdir
+            cfg.PARAMS['store_diagnostic_variables'] = ['volume', 'area']
 
-        # Try minimal output and see if it works
-        cfg.PARAMS['store_diagnostic_variables'] = ['volume', 'area']
+            init_present_time_glacier(gdir)
+            tasks.run_with_hydro(gdir, run_task=tasks.run_from_climate_data,
+                                 store_monthly_hydro=False,
+                                 min_ys=1980, output_filesuffix='_annual')
 
-        init_present_time_glacier(gdir)
-        tasks.run_with_hydro(gdir, run_task=tasks.run_random_climate,
-                             seed=0, nyears=100, y0=2003-5, halfsize=5,
-                             output_filesuffix='_rand')
+            with xr.open_dataset(gdir.get_filepath('model_diagnostics',
+                                                   filesuffix='_annual')) as ds:
+                odf_a = ds.to_dataframe()
 
-        with xr.open_dataset(gdir.get_filepath('model_diagnostics',
-                                               filesuffix='_rand')) as ds:
-            odf = ds.to_dataframe().iloc[:-1]
+            tasks.run_with_hydro(gdir, run_task=tasks.run_from_climate_data,
+                                 store_monthly_hydro=True,
+                                 min_ys=1980, output_filesuffix='_monthly')
 
-        # Sanity checks
-        # Tot prcp here is constant (constant climate)
-        odf['tot_prcp'] = (odf['liq_prcp_off_glacier'] +
-                           odf['liq_prcp_on_glacier'] +
-                           odf['snowfall_off_glacier'] +
-                           odf['snowfall_on_glacier'])
+            with xr.open_dataset(gdir.get_filepath('model_diagnostics',
+                                                   filesuffix='_monthly')) as ds:
+                sel_vars = [v for v in ds.variables if 'month_2d' not in ds[v].dims]
+                odf_m = ds[sel_vars].to_dataframe()
+                sel_vars = [v for v in ds.variables if 'month_2d' in ds[v].dims]
+                odf_ma = ds[sel_vars].mean(dim='time').to_dataframe()
+                odf_ma.columns = [c.replace('_monthly', '') for c in odf_ma.columns]
 
-        # Glacier area is the same (remove on_area?)
-        assert_allclose(odf['on_area'], odf['area_m2'])
+            # Check that yearly equals monthly
+            np.testing.assert_array_equal(odf_a.columns, odf_m.columns)
+            for c in odf_a.columns:
+                rtol = 1e-5
+                if c == 'melt_off_glacier':
+                    rtol = 0.1
+                if c in ['snow_bucket']:
+                    continue
+                assert_allclose(odf_a[c], odf_m[c], rtol=rtol)
 
-        # Our MB is the same as the glacier dyn one
-        reconstructed_vol = (odf['model_mb'].cumsum() / cfg.PARAMS['ice_density'] +
-                             odf['volume_m3'].iloc[0])
-        assert_allclose(odf['volume_m3'].iloc[1:], reconstructed_vol.iloc[:-1])
+            # Check monthly stuff
+            odf_ma['tot_prcp'] = (odf_ma['liq_prcp_off_glacier'] +
+                                  odf_ma['liq_prcp_on_glacier'] +
+                                  odf_ma['snowfall_off_glacier'] +
+                                  odf_ma['snowfall_on_glacier'])
 
-        # Mass-conservation
-        odf['runoff'] = (odf['melt_on_glacier'] +
-                         odf['melt_off_glacier'] +
-                         odf['liq_prcp_on_glacier'] +
-                         odf['liq_prcp_off_glacier'])
+            odf_ma['runoff'] = (odf_ma['melt_on_glacier'] +
+                                odf_ma['melt_off_glacier'] +
+                                odf_ma['liq_prcp_on_glacier'] +
+                                odf_ma['liq_prcp_off_glacier'])
 
-        mass_in_glacier_end = odf['volume_m3'].iloc[-1] * cfg.PARAMS['ice_density']
-        mass_in_glacier_start = odf['volume_m3'].iloc[0] * cfg.PARAMS['ice_density']
+            # Residual MB should not be crazy large
+            frac = odf_ma['residual_mb'] / odf_ma['melt_on_glacier']
+            assert_allclose(frac, 0, atol=0.01)
 
-        mass_in_snow = odf['snow_bucket'].iloc[-1]
-        mass_in = odf['tot_prcp'].iloc[:-1].sum()
-        mass_out = odf['runoff'].iloc[:-1].sum()
-        assert_allclose(mass_in_glacier_end,
-                        mass_in_glacier_start + mass_in - mass_out - mass_in_snow,
-                        atol=1e-2)  # 0.01 kg is OK as numerical error
+            # Runoff peak should follow a temperature curve
+            assert_allclose(odf_ma['runoff'].idxmax(), 11, atol=1.1)
 
-        # Qualitative assessments
-        assert odf['melt_on_glacier'].iloc[-1] < odf['melt_on_glacier'].iloc[0] * 0.7
-        assert odf['liq_prcp_off_glacier'].iloc[-1] > odf['liq_prcp_on_glacier'].iloc[-1]
-        assert odf['liq_prcp_off_glacier'].iloc[0] < odf['liq_prcp_on_glacier'].iloc[0]
+        @pytest.mark.slow
+        @pytest.mark.parametrize('store_monthly_hydro', [False], ids=['annual'])
+        # @pytest.mark.parametrize('store_monthly_hydro', [False, True], ids=['annual', 'monthly'])
+        def test_hydro_out_random(self, hef_gdir, inversion_params, store_monthly_hydro):
 
-        # Residual MB should not be crazy large
-        frac = odf['residual_mb'] / odf['melt_on_glacier']
-        assert_allclose(frac, 0, atol=0.04)  # annual can be large (prob)
+            gdir = hef_gdir
+
+            # Try minimal output and see if it works
+            cfg.PARAMS['store_diagnostic_variables'] = ['volume', 'area']
+
+            init_present_time_glacier(gdir)
+            tasks.run_with_hydro(gdir, run_task=tasks.run_random_climate,
+                                 store_monthly_hydro=store_monthly_hydro,
+                                 seed=0, nyears=100, y0=2003-5, halfsize=5,
+                                 output_filesuffix='_rand')
+
+            with xr.open_dataset(gdir.get_filepath('model_diagnostics',
+                                                   filesuffix='_rand')) as ds:
+                sel_vars = [v for v in ds.variables if 'month_2d' not in ds[v].dims]
+                odf = ds[sel_vars].to_dataframe().iloc[:-1]
+
+            # Sanity checks
+            # Tot prcp here is constant (constant climate)
+            odf['tot_prcp'] = (odf['liq_prcp_off_glacier'] +
+                               odf['liq_prcp_on_glacier'] +
+                               odf['snowfall_off_glacier'] +
+                               odf['snowfall_on_glacier'])
+
+            # Glacier area is the same (remove on_area?)
+            assert_allclose(odf['on_area'], odf['area_m2'])
+
+            # Our MB is the same as the glacier dyn one
+            reconstructed_vol = (odf['model_mb'].cumsum() / cfg.PARAMS['ice_density'] +
+                                 odf['volume_m3'].iloc[0])
+            assert_allclose(odf['volume_m3'].iloc[1:], reconstructed_vol.iloc[:-1])
+
+            # Mass-conservation
+            odf['runoff'] = (odf['melt_on_glacier'] +
+                             odf['melt_off_glacier'] +
+                             odf['liq_prcp_on_glacier'] +
+                             odf['liq_prcp_off_glacier'])
+
+            mass_in_glacier_end = odf['volume_m3'].iloc[-1] * cfg.PARAMS['ice_density']
+            mass_in_glacier_start = odf['volume_m3'].iloc[0] * cfg.PARAMS['ice_density']
+
+            mass_in_snow = odf['snow_bucket'].iloc[-1]
+            mass_in = odf['tot_prcp'].iloc[:-1].sum()
+            mass_out = odf['runoff'].iloc[:-1].sum()
+            assert_allclose(mass_in_glacier_end,
+                            mass_in_glacier_start + mass_in - mass_out - mass_in_snow,
+                            atol=1e-2)  # 0.01 kg is OK as numerical error
+
+            # Qualitative assessments
+            assert odf['melt_on_glacier'].iloc[-1] < odf['melt_on_glacier'].iloc[0] * 0.7
+            assert odf['liq_prcp_off_glacier'].iloc[-1] > odf['liq_prcp_on_glacier'].iloc[-1]
+            assert odf['liq_prcp_off_glacier'].iloc[0] < odf['liq_prcp_on_glacier'].iloc[0]
+
+            # Residual MB should not be crazy large
+            frac = odf['residual_mb'] / odf['melt_on_glacier']
+            assert_allclose(frac, 0, atol=0.04)  # annual can be large (prob)
 
 
 @pytest.fixture(scope='class')

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -2911,7 +2911,7 @@ class TestColumbiaCalving(unittest.TestCase):
         # We use a simple MB model
         mbmod = massbalance.ConstantMassBalance(gdir)
         heights, widths = gdir.get_inversion_flowline_hw()  # width is in m
-        temp, tempformelt, prcp, prcpsol = mbmod.get_climate(heights)
+        temp, tempformelt, prcp, prcpsol = mbmod.get_annual_climate(heights)
         # prcpsol is in units mm w.e per year - let's convert
         # compute the area of each section
         fls = gdir.read_pickle('inversion_flowlines')

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -1008,7 +1008,7 @@ def compile_run_output(gdirs, path=True, input_filesuffix='',
         if 'month_2d' in ds_diag.dims:
             # We have some 3d vars
             month_2d = ds_diag['month_2d']
-            ds.coords['month_2d'] = ('month_2d', month_2d)
+            ds.coords['month_2d'] = ('month_2d', month_2d.data)
             cn = 'calendar_month_2d'
             ds.coords[cn] = ('month_2d', ds_diag[cn].values)
 

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -1626,7 +1626,7 @@ def climate_statistics(gdir, add_climate_period=1995):
                 d['tstar_mb_grad'] = np.NaN
             d['tstar_ela_h'] = mbmod.get_ela()
             # Climate
-            t, tm, p, ps = mbmod.flowline_mb_models[0].get_climate(
+            t, tm, p, ps = mbmod.flowline_mb_models[0].get_annual_climate(
                 [d['tstar_ela_h'],
                  d['flowline_mean_elev'],
                  d['flowline_max_elev'],
@@ -1664,7 +1664,7 @@ def climate_statistics(gdir, add_climate_period=1995):
                     d[fs + '_mb_grad'] = np.NaN
                 d[fs + '_ela_h'] = mbmod.get_ela()
                 # Climate
-                t, tm, p, ps = mbmod.flowline_mb_models[0].get_climate(
+                t, tm, p, ps = mbmod.flowline_mb_models[0].get_annual_climate(
                     [d[fs + '_ela_h'],
                      d['flowline_mean_elev'],
                      d['flowline_max_elev'],

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -32,7 +32,6 @@ import numpy as np
 from scipy import stats
 import xarray as xr
 import shapely.geometry as shpg
-from scipy.sparse import diags
 from shapely.ops import transform as shp_trafo
 import netCDF4
 


### PR DESCRIPTION
This is a attempt to improve #1224 by making it possible to store hydrological output monthly. 
This is a bit more tricky than expected.

It does not work yet because it has some issues:
1)updating existing model dianostics in line 2791 does not work if model is only run at yearly timesteps: so `store_monthly_step= True` should be used when monthly hydro output is wanted

2) FileModel does not work correctly if `store_monthly_step= True` (line 2616), it still gives only monthly output, so `fmod.months` is always 1, therefore also `fmod.run_until` does not work on monthly timescales. This is however necessary to compute `model_area` and `model_area` at monthly timescales to correct melt on glacier with residual mass balance.

I think it makes sense to be ale to use `run_with_hydro` also with `'store_monthly_step= True`  and `mb_elev_feedback='monthly'`. I am not sure why FileModel does not output monthly timesteps, although the netcdf file that is used as input in FileModel is in monthly timesteps.

Any suggestions are welcome


