### PR TITLE
new `workflow.match_geodetic_mb_for_selection` function to match the MB bias for any selection of glaciers

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -18,9 +18,13 @@ Enhancements
   By `Li Fei <https://github.com/Keeptg>`_
 - Added support for last millenium reanalysis data to the shop (:pull:`1257`).
   By `Fabien Maussion <https://github.com/fmaussion>`_
-- Added an argument ``apply_func`` in ``utils.compile_glacier_statistics``
-  to allow users statistics any information by define a custom function (:pull:`1259`)
+- Added a new ``apply_func``  argument in ``utils.compile_glacier_statistics``
+  that allows user to compute any new statistics from a gdir themselves (:pull:`1259`)
   By `Li Fei <https://github.com/Keeptg>`_
+- Added a new ``workflow.match_geodetic_mb_for_selection`` function to match
+  the MB bias for any selection of glaciers (:pull:`1248`)
+  By `Patrick Schmitt <https://github.com/pat-schmitt>`_
+
 
 Bug fixes
 ~~~~~~~~~

--- a/oggm/tests/conftest.py
+++ b/oggm/tests/conftest.py
@@ -145,7 +145,8 @@ def secure_url_retrieve(url, *args, **kwargs):
             'cluster.klima.uni-bremen.de/~oggm/test_gdirs/' in url or
             'cluster.klima.uni-bremen.de/~oggm/demo_gdirs/' in url or
             'cluster.klima.uni-bremen.de/~oggm/test_climate/' in url or
-            'klima.uni-bremen.de/~oggm/climate/cru/cru_cl2.nc.zip' in url
+            'klima.uni-bremen.de/~oggm/climate/cru/cru_cl2.nc.zip' in url or
+            'klima.uni-bremen.de/~oggm/geodetic_ref_mb' in url
             )
     return oggm_urlretrieve(url, *args, **kwargs)
 


### PR DESCRIPTION
adapted function match_regional_geodatic_mb, things to discusse:
- should hydro month be set to 1 for OGGM SMB, because the data starts in January
- should only the geodetic data be used where also a OGGM SMB is available (I think so, but I added a comment which can be deleted afterwards)
- what is the right way (loggging and/or error) if no geodetic data is available for the current glacier selections
- until now the current options are still available, but I think with the new file (with decade 1 and 2 and 20 years) this could also be deleted (maybe only the current 'hugonnet' option and keep the 'zemp' option)

- [x] Tests added/passed
- [x] Fully documented
- [x] Entry in `whats-new.rst` 
