### PR TITLE
Remove dependency to colorspace package

### DIFF
--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -14,8 +14,8 @@ if [[ $OGGM_TEST_ENV == *-* ]]; then
 fi
 
 [[ $OGGM_TEST_MODE == single ]] && export OGGM_TEST_MULTIPROC=False
-[[ $OGGM_TEST_MODE == multi ]]  && export OGGM_TEST_MULTIPROC=True
-[[ $OGGM_TEST_MODE == mpl ]]  && export OGGM_MPL=--mpl
+[[ $OGGM_TEST_MODE == multi ]]  && export OGGM_TEST_MULTIPROC=True && export OGGM_MPL=--mpl
+[[ $OGGM_TEST_MODE == mpl ]] && export OGGM_MPL=--mpl
 
 if [[ $OGGM_TEST_ENV == minimal ]]; then
     # Special Mode for minimal tests on minimal Python-Image

--- a/docs/installing-oggm.rst
+++ b/docs/installing-oggm.rst
@@ -77,8 +77,6 @@ Other libraries:
 Optional:
     - progressbar2 (displays the download progress)
     - bottleneck (might speed up some xarray operations)
-    - `python-colorspace <https://github.com/retostauffer/python-colorspace>`_
-      (applies HCL-based color palettes to some graphics)
 
 .. _conda-install:
 
@@ -335,7 +333,6 @@ environment from the following ``environment.yml`` file used to work::
         - progressbar2
         - motionless
         - git+https://github.com/fmaussion/salem.git
-        - git+https://github.com/retostauffer/python-colorspace
         - git+https://github.com/OGGM/pytest-mpl
         - git+https://github.com/OGGM/oggm
 
@@ -405,11 +402,10 @@ Install some packages one by one::
 A pinning of the NetCDF4 package to 1.3.1 might be necessary on some systems
 (`related issue <https://github.com/Unidata/netcdf4-python/issues/962>`_).
 
-Finally, install the pytest-mpl OGGM fork, salem and python-colorspace libraries::
+Finally, install the pytest-mpl OGGM fork and salem libraries::
 
     $ pip install git+https://github.com/OGGM/pytest-mpl.git
     $ pip install git+https://github.com/fmaussion/salem.git
-    $ pip install git+https://github.com/retostauffer/python-colorspace.git
 
 Install OGGM and run the tests
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -10,11 +10,11 @@ v1.5.X (unreleased)
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
-Enhancements
-~~~~~~~~~~~~
-
-Bug fixes
-~~~~~~~~~
+- Removed use and dependency on the `python-colorspace` package. Although
+  not very dramatic, this change might change the way your plots look like
+  (:pull:`1284`). Users can specify their own colormaps anyways to get back to
+  the old plots.
+  By `Fabien Maussion <https://github.com/fmaussion>`_
 
 v1.5.1 (28.08.2021)
 -------------------

--- a/oggm/graphics.py
+++ b/oggm/graphics.py
@@ -19,13 +19,6 @@ except ImportError:
 
 OGGM_CMAPS = dict()
 
-try:
-    # optional python-colorspace dependency for better (HCL-based) colormaps
-    from colorspace import sequential_hcl
-    HAS_HCL_CMAP = True
-except ImportError:
-    HAS_HCL_CMAP = False
-
 from oggm.core.flowline import FileModel
 from oggm import cfg, utils
 from oggm.core import gis
@@ -34,22 +27,12 @@ from oggm.core import gis
 log = logging.getLogger(__name__)
 
 
-def set_oggm_cmaps(use_hcl=None):
+def set_oggm_cmaps():
     # Set global colormaps
     global OGGM_CMAPS
-
-    if use_hcl is None:
-        use_hcl = HAS_HCL_CMAP
-
     OGGM_CMAPS['terrain'] = colormap.terrain
-    if HAS_HCL_CMAP and use_hcl:
-        cm_divs = 100  # number of discrete colours from continuous colormaps
-        tcmap = sequential_hcl("Blue-Yellow", rev=True).cmap(cm_divs)
-        OGGM_CMAPS['section_thickness'] = tcmap
-        OGGM_CMAPS['glacier_thickness'] = tcmap
-    else:
-        OGGM_CMAPS['section_thickness'] = plt.cm.get_cmap('YlOrRd')
-        OGGM_CMAPS['glacier_thickness'] = plt.get_cmap('viridis')
+    OGGM_CMAPS['section_thickness'] = plt.cm.get_cmap('YlGnBu')
+    OGGM_CMAPS['glacier_thickness'] = plt.get_cmap('YlGnBu')
 
 
 set_oggm_cmaps()

--- a/oggm/graphics.py
+++ b/oggm/graphics.py
@@ -32,7 +32,7 @@ def set_oggm_cmaps():
     global OGGM_CMAPS
     OGGM_CMAPS['terrain'] = colormap.terrain
     OGGM_CMAPS['section_thickness'] = plt.cm.get_cmap('YlGnBu')
-    OGGM_CMAPS['glacier_thickness'] = plt.get_cmap('YlGnBu')
+    OGGM_CMAPS['glacier_thickness'] = plt.get_cmap('viridis')
 
 
 set_oggm_cmaps()

--- a/oggm/tests/test_graphics.py
+++ b/oggm/tests/test_graphics.py
@@ -31,7 +31,7 @@ pytestmark = pytest.mark.test_env("graphics")
 
 
 def setup_module():
-    graphics.set_oggm_cmaps(use_hcl=False)
+    graphics.set_oggm_cmaps()
 
 
 def teardown_module():

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -69,7 +69,7 @@ logger = logging.getLogger('.'.join(__name__.split('.')[:-1]))
 # The given commit will be downloaded from github and used as source for
 # all sample data
 SAMPLE_DATA_GH_REPO = 'OGGM/oggm-sample-data'
-SAMPLE_DATA_COMMIT = '213f539b27ae633b3862c2bc4a0f61ef2caa3157'
+SAMPLE_DATA_COMMIT = '98f6e299ab60b04cba9eb3be382231e19baf8c9e'
 
 GDIR_L1L2_URL = ('https://cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.4/'
                  'L1-L2_files/centerlines/')

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -69,7 +69,7 @@ logger = logging.getLogger('.'.join(__name__.split('.')[:-1]))
 # The given commit will be downloaded from github and used as source for
 # all sample data
 SAMPLE_DATA_GH_REPO = 'OGGM/oggm-sample-data'
-SAMPLE_DATA_COMMIT = '7c4d9ddb9cd855646f63d66d39324865acbbba0b'
+SAMPLE_DATA_COMMIT = '213f539b27ae633b3862c2bc4a0f61ef2caa3157'
 
 GDIR_L1L2_URL = ('https://cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.4/'
                  'L1-L2_files/centerlines/')


### PR DESCRIPTION
<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->

optional dependencies are not good in general. Colormaps should be a user choice anyways.

Closes https://github.com/OGGM/oggm/issues/1261