### PR TITLE
Fix various doc and source comment typos

### DIFF
--- a/HOWTO_RELEASE
+++ b/HOWTO_RELEASE
@@ -13,7 +13,7 @@ How to issue an OGGM release.
  5. Tag the release:
       git tag -a v1.X.Y -m 'v1.X.Y'
  6. Build source and binary wheels for pypi:
-      git clean -xdf  # this deletes all uncommited changes!
+      git clean -xdf  # this deletes all uncommitted changes!
       python setup.py bdist_wheel sdist
  7. Use twine to register and upload the release on pypi. Be careful, you can't
     take this back!

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -417,7 +417,7 @@ model flowlines
    :py:func:`init_present_time_glacier`, which combines information from
    several preprocessing steps, the downstream line and the bed inversion.
    From a user perspective, especially if preprocessed directories are used,
-   these model flowlines are the most important ones and further informations
+   these model flowlines are the most important ones and further information
    on the class interface and attributes are given below.
 
 .. _Kienholz et al., (2014): http://www.the-cryosphere.net/8/503/2014/

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -60,7 +60,7 @@ Can I use OGGM to simulate long-term glacier evolution?
 -------------------------------------------------------
 
 It depends what you mean by "long-term": at centennial time scales, probably,
-yes. At millenial time scales, maybe. At glacial time scales, probably not.
+yes. At millennial time scales, maybe. At glacial time scales, probably not.
 The major issue we have to face with OGGM is that it uses a "glacier-centric"
 approach: it can simulate the mountain glaciers and ice-caps we know from
 contemporary inventories, but it cannot simulate glaciers which existed before

--- a/docs/flowlines.rst
+++ b/docs/flowlines.rst
@@ -56,7 +56,7 @@ Centerline determination
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 Our algorithm is an implementation of the procedure described by
-`Kienholz et al., (2014)`_. Appart from some minor changes (mostly the choice
+`Kienholz et al., (2014)`_. Apart from some minor changes (mostly the choice
 of some parameters), we stay close to the original algorithm.
 
 .. _Kienholz et al., (2014): http://www.the-cryosphere.net/8/503/2014/
@@ -75,7 +75,7 @@ elevation gain and (ii) the distance to the glacier terminus:
 The glacier has a major centerline (the longest one), and
 tributary branches (in this case: two). The Hintereisferner glacier is a
 good example of a wrongly outlined glacier: the two northern glacier sub-catchments
-should have been classified as independant entities since they do not flow
+should have been classified as independent entities since they do not flow
 to the main flowline (more on this below).
 
 At this stage, the centerlines are still not fully suitable
@@ -182,7 +182,7 @@ quantile range (see [Werder_et_al_2019]_ for details), chosen to remove
 outliers and to return a slope angle that is both representative of the
 main trunk of the glacier and somewhat consistent with its real length.
 
-The flowlines obtained this way have an irregular spacing, dependant on the
+The flowlines obtained this way have an irregular spacing, dependent on the
 bin size and slope. For OGGM, we then convert this first flowline to a regularly
 space one by interpolating to the target resolution, which is the same
 as the geometrical centerlines (default: 2 dx of the underlying map).
@@ -245,8 +245,8 @@ Geometrical centerlines
   - Closer to the "true" length of the glacier.
   - Grid points along the centerlines preserve their geometrical information,
     i.e. one can compute the exact location of ice thickness change.
-  - It is possibile to have different model parameters for each flowline (e.g.
-    different mass-balance models), although this is comming with its own
+  - It is possible to have different model parameters for each flowline (e.g.
+    different mass-balance models), although this is coming with its own
     challenges.
   - Arguably: better suitability for mass-balance parameterizations taking
     glacier geometry and exposition into account.

--- a/docs/ice-dynamics.rst
+++ b/docs/ice-dynamics.rst
@@ -43,7 +43,7 @@ basal shear stress :math:`\tau`:
 
     u = u_d + u_s = f_d h \tau^n + f_s \frac{\tau^n}{h}
 
-wehere u_d and u_s are respectively the speed of ice coming from its deformation and sliding
+where u_d and u_s are respectively the speed of ice coming from its deformation and sliding
 (`n` is equal to 3). Thus, the first term is for ice deformation and the second term 
 is to account for basal sliding, see e.g. [Oerlemans_1997]_ or
 [Golledge_Levy_2011]_. It introduces an additional free parameter :math:`f_s`

--- a/docs/input-data.rst
+++ b/docs/input-data.rst
@@ -190,7 +190,7 @@ directories from the default urls. Here is a summary of the default configuratio
   against geodetic MB (see options below for regional calibration)
 - ice volume inversion calibrated to match the ice volume from [Farinotti_etal_2019]_
   **at the RGI region level**, i.e. glacier estimates might differ. If not specified otherwise,
-  it's also the precalibrated paramaters that will be used for the dynamical run.
+  it's also the precalibrated parameters that will be used for the dynamical run.
 - frontal ablation by calving (at inversion and for the dynamical runs) is switched off
 
 To see the code that generated these directories (for example if you want to
@@ -439,7 +439,7 @@ for three reference periods (2000-2010, 2010-2020, 2000-2020):
     @savefig plot_hugonnet_mbdata.png width=100%
     plt.xlabel(''); plt.xlim(-3, 3); plt.legend();
 
-Just for fun, here is a comparaison of both products at Hintereisferner:
+Just for fun, here is a comparison of both products at Hintereisferner:
 
 .. ipython:: python
 
@@ -515,7 +515,7 @@ and type:
 
 The RGI folders should now contain the glacier outlines in the
 `shapefile format <https://en.wikipedia.org/wiki/Shapefile>`_, a format widely
-used in GIS applications. These files can be read by several softwares
+used in GIS applications. These files can be read by several software
 (e.g. `qgis <https://www.qgis.org/en/site/>`_), and OGGM can read them too.
 
 The "RGI Intersects" shapefiles contain the locations of the ice divides
@@ -736,6 +736,6 @@ period. This method is sometimes called the
 `delta method <http://www.ciesin.org/documents/Downscaling_CLEARED_000.pdf>`_.
 
 Currently we can process data from the
-`CESM Last Millenium Ensemble <http://www.cesm.ucar.edu/projects/community-projects/LME/>`_
+`CESM Last Millennium Ensemble <http://www.cesm.ucar.edu/projects/community-projects/LME/>`_
 project (see :py:func:`tasks.process_cesm_data`), and CMIP5/CMIP6
 (:py:func:`tasks.process_cmip_data`).

--- a/docs/installing-oggm.rst
+++ b/docs/installing-oggm.rst
@@ -21,7 +21,7 @@ Mac OSX, but it should probably run fine there as well.
 
     OGGM does not work on Windows. If you are using Windows 10,
     we recommend to install the free
-    `Windows subsytem for Linux <https://docs.microsoft.com/en-us/windows/wsl/install-win10>`_
+    `Windows subsystem for Linux <https://docs.microsoft.com/en-us/windows/wsl/install-win10>`_
     and install and run OGGM from there.
 
 For most users we recommend to

--- a/docs/mass-balance-2012-pergla.rst
+++ b/docs/mass-balance-2012-pergla.rst
@@ -29,7 +29,7 @@ solid precipitation is based on the monthly mean temperature: all solid below
 (default: 2°C), linear change in between.
 
 The difference with the previous model is that :math:`\epsilon` isn't needed
-anymore, now that we can calibrate on each glacier individualy.
+anymore, now that we can calibrate on each glacier individually.
 
 Calibration
 -----------

--- a/docs/oeps/oep--0001-dependencies.rst
+++ b/docs/oeps/oep--0001-dependencies.rst
@@ -133,14 +133,14 @@ will take place on this repository or the main OGGM repository.
 Docker and Singularity containers (goal 4)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The easiest way to guarantee consistency accross platforms and over longer
+The easiest way to guarantee consistency across platforms and over longer
 periods of time are `containers <https://www.docker.com/resources/what-container>`_.
 A container image is a lightweight, standalone, executable package of software 
 that includes everything needed to run an application: code, runtime, system 
 tools, system libraries and settings.
 
 The most widely used container platform is `Docker <https://www.docker.com>`_.
-For security and preformance reasons, HPC centers prefer to use 
+For security and performance reasons, HPC centers prefer to use 
 `Singularity <https://www.sylabs.io>`_. Fortunately, Singularity containers
 can be built from Docker images.
 

--- a/docs/oeps/oep--0002-cloud.rst
+++ b/docs/oeps/oep--0002-cloud.rst
@@ -39,7 +39,7 @@ list the most important ones:
 - `JupyterLab`_ is the web development environment where the notebooks can be
   run and edited.
 - `JupyterHub`_ is the server which spawns JupyterLab in the containerized
-  environment. It also handles user authentification and many other things.
+  environment. It also handles user authentication and many other things.
 - `MyBinder`_ is a versatile server which automatises the process of
   providing *any kind of environment* in a JupyterHub. MyBinder is a free to
   use deployment of the open-source Binder tool - but anyone can deploy a
@@ -188,7 +188,7 @@ on the cloud idea a little more.
 Detailed roadmap
 ----------------
 
-**Scaling**. This is relatively independant of cloud or HPC and should be done
+**Scaling**. This is relatively independent of cloud or HPC and should be done
 anyway.
 
 - **refactor the multiprocessing workflow of OGGM to use dask**. Once OGGM can

--- a/docs/practicalities.rst
+++ b/docs/practicalities.rst
@@ -384,7 +384,7 @@ developers.
 Dependence on hardware and input data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The OGGM model will always be dependant on the input data (topography, climate,
+The OGGM model will always be dependent on the input data (topography, climate,
 outlines...). Be aware that while certain results are robust (like interannual
 variability of surface mass-balance), other results are highly sensitive
 to small changes in the boundary conditions. Some examples include:

--- a/docs/structure.rst
+++ b/docs/structure.rst
@@ -43,7 +43,7 @@ complexes as if they were single glacier entities.**
     presence of glacier complexes and ice divides (this problem can be mitigated by
     defining glacier complexes as one single entity, requiring other strategies than
     currently standard in OGGM). A larger issue of glacier centric models is that
-    they are focussed on simulating glaciers that have been inventoried, i.e. they cannot
+    they are focused on simulating glaciers that have been inventoried, i.e. they cannot
     retrieve past (or present) uncharted glaciers. For these reasons, they are not well adapted for
     studying glacier evolution in climates when glaciers were widely
     different from today (e.g. the Last Glacial Maximum).

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -55,7 +55,7 @@ Breaking changes
 v1.5.1 (28.08.2021)
 -------------------
 
-This is a minor relase of OGGM, containing mostly bugfixes and a few new
+This is a minor release of OGGM, containing mostly bugfixes and a few new
 features.
 
 Breaking changes
@@ -69,7 +69,7 @@ Enhancements
 - Added ``cook_rgidf()`` function in ``oggm.utils`` to simplify the use
   of a non-RGI glacier inventory in OGGM (:pull:`1251`).
   By `Li Fei <https://github.com/Keeptg>`_
-- Added support for last millenium reanalysis data to the shop (:pull:`1257`).
+- Added support for last millennium reanalysis data to the shop (:pull:`1257`).
   By `Fabien Maussion <https://github.com/fmaussion>`_
 - Added a new ``apply_func``  argument in ``utils.compile_glacier_statistics``
   that allows user to compute any new statistics from a gdir themselves (:pull:`1259`)
@@ -273,7 +273,7 @@ Enhancements
 Bug fixes
 ~~~~~~~~~
 
-- Maintainance updates for upstream libraries and various small bug fixes
+- Maintenance updates for upstream libraries and various small bug fixes
   (:pull:`957`, :pull:`967`, :pull:`968`, :pull:`958`, :pull:`974`, :pull:`977`,
   :pull:`976`, :pull:`1124`).
   By `Fabien Maussion <https://github.com/fmaussion>`_,
@@ -318,7 +318,7 @@ Breaking changes
 ~~~~~~~~~~~~~~~~
 
 - The adaptive time stepping scheme of OGGM has been fixed for several flaws
-  which lead to instable results in certain conditions.
+  which lead to unstable results in certain conditions.
   See `the blog post <https://oggm.org/2020/01/18/stability-analysis/>`_
   for a full description. The API didn't change in the process, but the
   OGGM results are likely to change slightly in some conditions.
@@ -559,7 +559,7 @@ Breaking changes
   anybody was using them (:pull:`465`).
   By `Fabien Maussion <https://github.com/fmaussion>`_.
 - Diagnostic variables (length, area, volume, ELA) are now stored at annual
-  steps instead of montly steps (:pull:`488`). The old behavior can still be
+  steps instead of monthly steps (:pull:`488`). The old behavior can still be
   used with the ``store_monthly_step`` kwarg. Most users should not notice
   this change because the regionally compiled files were stored at yearly
   steps anyways.
@@ -649,7 +649,7 @@ Enhancements
   available. You can get the profiles with ``gdir.get_ref_mb_profile()``
   (:pull:`493`).
   By `Fabien Maussion <https://github.com/fmaussion>`_.
-- New ``process_histalp_data`` taks to run OGGM with HISTALP data
+- New ``process_histalp_data`` task to run OGGM with HISTALP data
   automatically. The task comes with a list of predefined t* like CRU and
   with different default parameters
   (see `blog <https://oggm.org/2018/08/10/histalp-parameters/>`_). The PR

--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -43,7 +43,7 @@ CONFIG_FILE = os.path.join(os.path.expanduser('~'), '.oggm_config')
 # config was changed, indicates that multiprocessing needs a reset
 CONFIG_MODIFIED = False
 
-# Share state accross processes
+# Share state across processes
 DL_VERIFIED = dict()
 DEM_SOURCE_TABLE = dict()
 DATA = dict()

--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -505,7 +505,7 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
     if border >= 20:
         workflow.execute_entity_task(tasks.init_present_time_glacier, gdirs)
     else:
-        log.workflow('L3: for map border values < 20, wont initalize glaciers '
+        log.workflow('L3: for map border values < 20, wont initialize glaciers '
                      'for the run.')
     # Glacier stats
     opath = os.path.join(sum_dir, 'glacier_statistics_{}.csv'.format(rgi_reg))

--- a/oggm/core/centerlines.py
+++ b/oggm/core/centerlines.py
@@ -128,7 +128,7 @@ class Centerline(object, metaclass=SuperclassMeta):
         self.mu_star_is_valid = False  # if mu* leeds to good flux, keep it
         self.flux = None  # Flux (kg m-2)
         self.flux_needs_correction = False  # whether this branch was baaad
-        self.rgi_id = rgi_id  # Usefull if line is used with another glacier
+        self.rgi_id = rgi_id  # Useful if line is used with another glacier
 
     def set_flows_to(self, other, check_tail=True, to_head=False):
         """Find the closest point in "other" and sets all the corresponding
@@ -449,7 +449,7 @@ def _filter_lines(lines, heads, k, r):
 
         ilines.remove(ll)
         if len(olines) > 0:
-            # the cutted line's last point is not guaranteed
+            # the cut line's last point is not guaranteed
             # to on straight coordinates. Remove it
             olines.append(shpg.LineString(np.asarray(ll.xy)[:, 0:-1].T))
         else:
@@ -499,7 +499,7 @@ def _filter_lines_slope(lines, heads, topo, gdir, min_slope):
     oheads = [heads[0]]
     for line, head in zip(lines[1:], heads[1:]):
 
-        # The code below mimicks what initialize_flowlines will do
+        # The code below mimics what initialize_flowlines will do
         # this is a bit smelly but necessary
         points = line_interpol(line, dx_cls)
 
@@ -913,7 +913,7 @@ def compute_centerlines(gdir, heads=None):
         log.debug('(%s) number of heads after slope filter: %d',
                   gdir.rgi_id, len(olines))
 
-    # And rejoin the cutted tails
+    # And rejoin the cut tails
     olines = _join_lines(olines, oheads)
 
     # Adds the line level
@@ -1028,7 +1028,7 @@ def _approx_parabola(x, y, y0=0):
     x : array
        the x axis variabls
     y : array
-       the dependant variable
+       the dependent variable
     y0 : float, optional
        the intercept
 
@@ -2109,7 +2109,7 @@ def elevation_band_flowline(gdir, bin_variables=None, preserve_totals=True):
     bin_variables : str or list of str
         variables to add to the binned flowline
     preserve_totals : bool or list of bool
-        wether or not to preserve the variables totals (e.g. volume)
+        whether or not to preserve the variables totals (e.g. volume)
     """
 
     # Variables
@@ -2259,7 +2259,7 @@ def fixed_dx_elevation_band_flowline(gdir, bin_variables=None,
         csv file: gdir.get_filepath('elevation_band_flowline',
         filesuffix='_fixed_dx').
     preserve_totals : bool or list of bool
-        wether or not to preserve the variables totals (e.g. volume)
+        whether or not to preserve the variables totals (e.g. volume)
     """
 
     df = pd.read_csv(gdir.get_filepath('elevation_band_flowline'), index_col=0)

--- a/oggm/core/climate.py
+++ b/oggm/core/climate.py
@@ -913,7 +913,7 @@ def local_t_star(gdir, *, ref_df=None, tstar=None, bias=None,
     If none of these are provided (the default), this list be obtained from
     the current working directory (``ref_tstars.csv`` and associated params
     ``ref_tstars_params.json``). These files can either be generated with a
-    call to ``compute_ref_t_stars`` if you know what you are doing, ot you
+    call to ``compute_ref_t_stars`` if you know what you are doing, or you
     can obtain pre-preprocessed lists from our servers:
     https://cluster.klima.uni-bremen.de/~oggm/ref_mb_params/
 

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -237,7 +237,7 @@ class ParabolicBedFlowline(Flowline):
     def __init__(self, line=None, dx=None, map_dx=None,
                  surface_h=None, bed_h=None, bed_shape=None, rgi_id=None,
                  water_level=None):
-        """ Instanciate.
+        """ Instantiate.
 
         Parameters
         ----------
@@ -283,7 +283,7 @@ class RectangularBedFlowline(Flowline):
     def __init__(self, line=None, dx=None, map_dx=None,
                  surface_h=None, bed_h=None, widths=None, rgi_id=None,
                  water_level=None):
-        """ Instanciate.
+        """ Instantiate.
 
         Parameters
         ----------
@@ -328,7 +328,7 @@ class TrapezoidalBedFlowline(Flowline):
     def __init__(self, line=None, dx=None, map_dx=None, surface_h=None,
                  bed_h=None, widths=None, lambdas=None, rgi_id=None,
                  water_level=None):
-        """ Instanciate.
+        """ Instantiate.
 
         Parameters
         ----------
@@ -389,7 +389,7 @@ class MixedBedFlowline(Flowline):
                  bed_h=None, section=None, bed_shape=None,
                  is_trapezoid=None, lambdas=None, widths_m=None, rgi_id=None,
                  water_level=None):
-        """ Instanciate.
+        """ Instantiate.
 
         Parameters
         ----------
@@ -544,7 +544,7 @@ class FlowlineModel(object):
             some Flowline models have an adaptive time stepping scheme, which
             is randomly taking steps towards the goal of a "run_until". The
             default ('monthly') makes sure that the model results are
-            consistent wether the users want data at monthly or annual
+            consistent whether the users want data at monthly or annual
             timesteps by forcing the model to land on monthly steps even if
             only annual updates are required. You may want to change this
             for optimisation reasons for models that don't require adaptive
@@ -1201,7 +1201,7 @@ class FluxBasedModel(FlowlineModel):
                  do_kcalving=None, calving_k=None, calving_use_limiter=None,
                  calving_limiter_frac=None, water_level=None,
                  **kwargs):
-        """Instanciate the model.
+        """Instantiate the model.
 
         Parameters
         ----------
@@ -1256,7 +1256,7 @@ class FluxBasedModel(FlowlineModel):
             changing the flux_gate_buildup time. You can also provide
             a function (or an array of functions) returning the flux
             (unit: m3 of ice per second) as a function of time.
-            This is overriden by `flux_gate_thickness` if provided.
+            This is overridden by `flux_gate_thickness` if provided.
         flux_gate_buildup : int
             number of years used to build up the flux gate to full value
         do_kcalving : bool
@@ -1661,7 +1661,7 @@ class MassConservationChecker(FluxBasedModel):
     """This checks if the FluxBasedModel is conserving mass."""
 
     def __init__(self, flowlines, **kwargs):
-        """ Instanciate.
+        """ Instantiate.
 
         Parameters
         ----------
@@ -1699,7 +1699,7 @@ class KarthausModel(FlowlineModel):
     def __init__(self, flowlines, mb_model=None, y0=0., glen_a=None, fs=0.,
                  fixed_dt=None, min_dt=SEC_IN_DAY, max_dt=31*SEC_IN_DAY,
                  inplace=False, **kwargs):
-        """ Instanciate.
+        """ Instantiate.
 
         Parameters
         ----------
@@ -1782,7 +1782,7 @@ class FileModel(object):
     """Duck FlowlineModel which actually reads data out of a nc file."""
 
     def __init__(self, path):
-        """ Instanciate.
+        """ Instantiate.
 
         Parameters
         ----------
@@ -1946,7 +1946,7 @@ class MassRedistributionCurveModel(FlowlineModel):
                  do_kcalving=None, calving_k=None,
                  advance_method=1,
                  **kwargs):
-        """ Instanciate the model.
+        """ Instantiate the model.
 
         Parameters
         ----------
@@ -2008,7 +2008,7 @@ class MassRedistributionCurveModel(FlowlineModel):
         elif dt < cfg.SEC_IN_YEAR:
             # Here however we complain - we really want one year exactly
             raise InvalidWorkflowError('I was asked to run for less than one '
-                                       'year. Delta-H models cant do that.')
+                                       'year. Delta-H models can\'t do that.')
 
         # Flowline state
         fl = self.fls[0]
@@ -2221,7 +2221,7 @@ def mass_redistribution_curve_huss(height, bin_area, mb, glac_idx, glacier_delta
         # No need for a curve when glacier is so small
         return mb * bin_area
 
-    # Select the paramaters based on glacier area
+    # Select the parameters based on glacier area
     if bin_area.sum() * 1e-6 > 20:
         gamma, a, b, c = (6, -0.02, 0.12, 0)
     elif bin_area.sum() * 1e-6 > 5:
@@ -2257,7 +2257,7 @@ def mass_redistribution_curve_huss(height, bin_area, mb, glac_idx, glacier_delta
 
 
 def flowline_from_dataset(ds):
-    """Instanciates a flowline from an xarray Dataset."""
+    """Instantiates a flowline from an xarray Dataset."""
 
     cl = globals()[ds.attrs['class']]
     line = shpg.LineString(ds['linecoords'].values)
@@ -2278,7 +2278,7 @@ def flowline_from_dataset(ds):
 
 
 def glacier_from_netcdf(path):
-    """Instanciates a list of flowlines from an xarray Dataset."""
+    """Instantiates a list of flowlines from an xarray Dataset."""
 
     with xr.open_dataset(path) as ds:
         fls = []
@@ -3490,7 +3490,7 @@ def merge_to_one_glacier(main, tribs, filename='climate_historical',
 
     # read flowlines of the Main glacier
     fls = main.read_pickle('model_flowlines')
-    mfl = fls.pop(-1)  # remove main line from list and treat seperately
+    mfl = fls.pop(-1)  # remove main line from list and treat separately
 
     for trib in tribs:
 
@@ -3590,7 +3590,7 @@ def clean_merged_flowlines(gdir, buffer=None):
 
     fls = gdir.read_pickle('model_flowlines')
 
-    # seperate the main main flowline
+    # separate the main main flowline
     mainfl = fls.pop(-1)
 
     # split fls in main and tribs
@@ -3687,7 +3687,7 @@ def clean_merged_flowlines(gdir, buffer=None):
         # 3. set flow to attributes. This also adds inflow values to other
         fl1.set_flows_to(_olline)
 
-        # change the array size of tributary flowline attributs
+        # change the array size of tributary flowline attributes
         for atr, value in fl1.__dict__.items():
             if atr in ['_ptrap', '_prec']:
                 # those are indices, remove those above nx

--- a/oggm/core/sia2d.py
+++ b/oggm/core/sia2d.py
@@ -314,7 +314,7 @@ class Upstream2D(Model2D):
         self._ixkmlp = ix_(self.km, self.lp)
 
     def diffusion_upstream_2d(self):
-        # Builded upon the Eq. (62) with the term in y in the diffusivity.
+        # Built upon the Eq. (62) with the term in y in the diffusivity.
         # It differs from diffusion_Upstream_2D_V1 only for the definition of
         # "s_grad", l282-283 & l305-306 in V1 and l355-356 & l379-380 in V2)
 

--- a/oggm/graphics.py
+++ b/oggm/graphics.py
@@ -162,7 +162,7 @@ def _plot_map(plotfunc):
 
         if title is None:
             if 'title' not in out:
-                # Make a defaut one
+                # Make a default one
                 title = ''
                 if len(gdirs) == 1:
                     gdir = gdirs[0]
@@ -361,7 +361,7 @@ def plot_centerlines(gdirs, ax=None, smap=None, use_flowlines=False,
         # plot Centerlines
         cls = gdir.read_pickle(filename)
 
-        # Go in reverse order for red always being the longuest
+        # Go in reverse order for red always being the longest
         cls = cls[::-1]
         nl = len(cls)
         color = gencolor(len(cls) + 1, cmap=lines_cmap)

--- a/oggm/sandbox/pygem_compat.py
+++ b/oggm/sandbox/pygem_compat.py
@@ -105,7 +105,7 @@ def present_time_glacier_from_bins(gdir, data=None,
         bed_shape = 4 * thick / width ** 2
 
     # TODO: this is a very dirty fix -> we should rather interpolate,
-    # AND we should be really carefull about flat bed shapes
+    # AND we should be really careful about flat bed shapes
     bed_shape = np.where(np.isfinite(bed_shape), bed_shape,
                          np.nanmean(bed_shape))
 

--- a/oggm/tests/ext/sia_fluxlim.py
+++ b/oggm/tests/ext/sia_fluxlim.py
@@ -24,7 +24,7 @@ class MUSCLSuperBeeModel(FlowlineModel):
     def __init__(self, flowlines, mb_model=None, y0=0., glen_a=None, fs=None,
                  fixed_dt=None, min_dt=SEC_IN_DAY, max_dt=31*SEC_IN_DAY,
                  inplace=False, **kwargs):
-        """ Instanciate.
+        """ Instantiate.
 
         Parameters
         ----------

--- a/oggm/tests/funcs.py
+++ b/oggm/tests/funcs.py
@@ -227,7 +227,7 @@ def dummy_width_bed_tributary(map_dx=100., n_trib=1):
 
 def dummy_bed_tributary_tail_to_head(map_dx=100., n_trib=1, small_cliff=False):
     # bed with tributary glacier(s) flowing directly into their top
-    # (for splitted flowline experiments)
+    # (for split flowline experiments)
     dx = 1.
     nx = 200
 

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -673,7 +673,7 @@ class TestMassBalanceModels:
 
         ref_mbh = ref_mod.get_annual_mb(h, None) * SEC_IN_YEAR
 
-        # two years shoudn't be equal
+        # two years shouldn't be equal
         r_mbh1 = mb_mod.get_annual_mb(h, 1) * SEC_IN_YEAR
         r_mbh2 = mb_mod.get_annual_mb(h, 2) * SEC_IN_YEAR
         assert not np.all(np.allclose(r_mbh1, r_mbh2))
@@ -3117,7 +3117,7 @@ class TestHEF:
             np.testing.assert_allclose(shist.prcp.mean(),
                                        scesm.prcp.mean(),
                                        rtol=1e-3)
-            # And also the anual cycle
+            # And also the annual cycle
             scru = shist.groupby('time.month').mean(dim='time')
             scesm = scesm.groupby('time.month').mean(dim='time')
             np.testing.assert_allclose(scru.temp, scesm.temp, rtol=5e-3)

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -420,7 +420,7 @@ class TestGIS(unittest.TestCase):
         self.assertEqual(ds.height, gdir.grid.ny)
         self.assertEqual(ds.transform[0], gdir.grid.dx)
         self.assertEqual(ds.transform[4], gdir.grid.dy)
-        # orgin is center for gdir grid but corner for dem_mask, so shift
+        # origin is center for gdir grid but corner for dem_mask, so shift
         self.assertAlmostEqual(ds.transform[2], gdir.grid.x0 - gdir.grid.dx/2)
         self.assertAlmostEqual(ds.transform[5], gdir.grid.y0 - gdir.grid.dy/2)
 
@@ -660,7 +660,7 @@ class TestCenterlines(unittest.TestCase):
         c = gdir.read_pickle('downstream_line')['downstream_line']
         c = centerlines.Centerline(c, dx=tpl.dx)
 
-        # Independant reproduction for a few points
+        # Independent reproduction for a few points
         o = out['bedshapes']
         i0s = [0, 5, 10, 15, 20]
         for i0 in i0s:
@@ -2179,7 +2179,7 @@ class TestClimate(unittest.TestCase):
         np.testing.assert_allclose(mb, wgms['ANNUAL_BALANCE'].mean(), atol=30)
 
         # Check error management
-        # We trick with a glaciers whith no valid data
+        # We trick with a glaciers with no valid data
         rdf['is_cor'] = True
         fpath = os.path.join(self.testdir, 'test_hugo.hdf')
         rdf.to_hdf(fpath, key='df')
@@ -2189,7 +2189,7 @@ class TestClimate(unittest.TestCase):
             workflow.match_geodetic_mb_for_selection([gdir], file_path=fpath,
                                                      period='2000-01-01_2010-01-01')
 
-        # This doesnt
+        # This doesn't
         workflow.match_geodetic_mb_for_selection([gdir], file_path=fpath,
                                                  fail_safe=True,
                                                  period='2000-01-01_2010-01-01')
@@ -2884,7 +2884,7 @@ class TestInversion(unittest.TestCase):
             if _max > maxs:
                 maxs = _max
 
-        # check that its not tooo sensitive to the dx
+        # check that its not too sensitive to the dx
         cfg.PARAMS['flowline_dx'] = 1.
         cfg.PARAMS['filter_for_neg_flux'] = False
         centerlines.initialize_flowlines(gdir)
@@ -3113,7 +3113,7 @@ class TestColumbiaCalving(unittest.TestCase):
         prcpsol = np.sum(prcpsol * area_sec)
         # Convert to ice and km3
         accu_ice = prcpsol * 1e-9 / rho
-        # Finally, chech that this is equal to our calving flux
+        # Finally, check that this is equal to our calving flux
         # units: mk3 ice yr-1
         np.testing.assert_allclose(accu_ice, df['calving_flux'],
                                    atol=0.001)

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -1400,7 +1400,7 @@ def _tandem_path(lon_tile, lat_tile):
     level_1 = 'W' if lon_tile < 0 else 'E'
     level_1 += '{:03d}'.format(divmod(abs(lon_tile), 10)[0] * 10)
 
-    # Level 2 is formating, but depends on lat
+    # Level 2 is formatting, but depends on lat
     level_2 = 'W' if lon_tile < 0 else 'E'
     if abs(lat_tile) <= 60:
         level_2 += '{:03d}'.format(abs(lon_tile))

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -256,7 +256,7 @@ class LRUFileCache():
     """
 
     def __init__(self, l0=None, maxsize=None):
-        """Instanciate.
+        """Instantiate.
 
         Parameters
         ----------
@@ -438,7 +438,7 @@ class entity_task(object):
 
         cnt = ['    Notes']
         cnt += ['    -----']
-        cnt += ['    Files writen to the glacier directory:']
+        cnt += ['    Files written to the glacier directory:']
 
         for k in sorted(writes):
             cnt += [cfg.BASENAMES.doc_str(k)]
@@ -1890,7 +1890,7 @@ def extend_past_climate_run(past_run_file=None,
 
             if 'calving_rate' in ods.data_vars:
                 orig_calv_rate_ts = ods.calving_rate_ext.data[:, i]
-                # +1 because calving rate at year 0 is unkown from the dyns model
+                # +1 because calving rate at year 0 is unknown from the dyns model
                 orig_calv_rate_ts[:fid+1] = calv_rate
                 ods.calving_rate_ext.data[:, i] = orig_calv_rate_ts
 
@@ -3260,7 +3260,7 @@ def initialize_merged_gdir(main, tribs=[], glcdf=None,
                            filename='climate_historical',
                            input_filesuffix='',
                            dem_source=None):
-    """Creats a new GlacierDirectory if tributaries are merged to a glacier
+    """Creates a new GlacierDirectory if tributaries are merged to a glacier
 
     This function should be called after centerlines.intersect_downstream_lines
     and before flowline.merge_tributary_flowlines.

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -755,7 +755,7 @@ def calibrate_inversion_from_consensus(gdirs, ignore_missing=True,
         # Ok can't find an A. Log for debug:
         odf1 = compute_vol(a_bounds[0]).sum() * 1e-9
         odf2 = compute_vol(a_bounds[1]).sum() * 1e-9
-        msg = ('calibration fom consensus estimate CANT converge with fs={}.\n'
+        msg = ('calibration from consensus estimate CAN\'T converge with fs={}.\n'
                'Bound values (km3):\nRef={:.3f} OGGM={:.3f} for A factor {}\n'
                'Ref={:.3f} OGGM={:.3f} for A factor {}'
                ''.format(fs,
@@ -903,7 +903,7 @@ def match_geodetic_mb_for_selection(gdirs, period='2000-01-01_2020-01-01',
        local file path to tabular file containing geodetic measurements, file must
        contain the columns:
            - 'rgiid': is the RGIId as in the RGI 6.0
-           - 'period': time intervall of the measurements in the format shown
+           - 'period': time interval of the measurements in the format shown
              above
            - 'dmdtda': the specific-mass change rate in meters water-equivalent
              per year,
@@ -1011,7 +1011,7 @@ def merge_glacier_tasks(gdirs, main_rgi_id=None, return_all=False, buffer=None,
         all glaciers, main and tributary. Preprocessed and initialised
     main_rgi_id: str
         RGI ID of the main glacier of interest. If None is provided merging
-        will start based uppon the largest glacier
+        will start based upon the largest glacier
     return_all : bool
         if main_rgi_id is given and return_all = False: only the main glacier
         is returned
@@ -1099,7 +1099,7 @@ def _recursive_merging(gdirs, gdir_main, glcdf=None, dem_source=None,
         # if no tributaries: nothing to do
         return gdir_main, gdirs
 
-    # seperate those glaciers which are not already found to be a tributary
+    # separate those glaciers which are not already found to be a tributary
     gdirs = [gd for gd in gdirs if gd not in tributaries]
 
     gdirs_to_merge = []


### PR DESCRIPTION
Found via `codespell -q 3 -L asign,hist,nd`