### PR TITLE
Add mechanism to read reference area from a previous run

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -62,7 +62,12 @@ Enhancements
   ignoring glacier area change in this period. Therefore, it is only valid for
   short periods of times (years, not decades).
   By `Fabien Maussion <https://github.com/fmaussion>`_
-
+- Added new keyword arguments to ``run_with_hydro`` which allow to
+  select which glacier area should be used as reference for the hydro
+  computations (:pull:`1331`). Furthermore, it also allows to use a previous
+  geometry file for the computations, i.e. allowing for continuous
+  historical to projections outputs (if needed).
+  By `Fabien Maussion <https://github.com/fmaussion>`_
 
 Bug fixes
 ~~~~~~~~~

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -3698,6 +3698,7 @@ class TestHydro:
         tasks.run_with_hydro(gdir, run_task=tasks.run_from_climate_data,
                              store_monthly_hydro=False,
                              fixed_geometry_spinup_yr=1980,
+                             ref_area_from_y0=True,
                              ye=1999,
                              output_filesuffix='_hist')
         tasks.run_with_hydro(gdir, run_task=tasks.run_from_climate_data,


### PR DESCRIPTION
<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->

@sarah-hanus this is what's needed to keep the same reference area over a spinup (or historical) + projection run.

- [x] Tests added/passed
- [x] Fully documented
- [x] Entry in `whats-new.rst` 
