### PR TITLE
Switch Docker-Image to ghcr.io

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -12,30 +12,47 @@ jobs:
     runs-on: ubuntu-latest
     name: Build Docker Image
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Install buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Login to Docker
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+    - name: Set Names
+      id: names
+      run: |
+        echo "::set-output name=name::ghcr.io/oggm/oggm"
+        echo "::set-output name=date::$(date +%Y%m%d)"
+        echo "::set-output name=sha::$GITHUB_SHA"
+    - name: Stop Commands
+      run: T="$(echo -n ${{ github.token }} | sha256sum | head -c 64)" && echo -e "::add-mask::${T}\n::stop-commands::${T}"
     - name: Build image
-      id: build-image
-      uses: OGGM/docker-build-and-push-action@v1
+      uses: docker/build-push-action@v2
       with:
-        path: ./deployment/docker
-        build_args: GITHUB_SHA,GITHUB_REPOSITORY
-        name: oggm/oggm
-        force_pull: true
-        no_push: true
-        tmp_tag: oggm:test
+        context: deployment/docker
+        pull: true
+        load: true
+        build-args: |
+          GITHUB_SHA=${{ github.sha }}
+          GITHUB_REPOSITORY=${{ github.repository }}
+        tags: |
+          ${{ steps.names.outputs.name }}:test
     - name: Test image
-      id: test-image
-      run: docker run --rm oggm:test /root/test.sh
+      run: docker run --rm ${{ steps.names.outputs.name }}:test /root/test.sh
     - name: Push image
-      id: push-image
-      uses: OGGM/docker-build-and-push-action@v1
+      uses: docker/build-push-action@v2
+      if: ${{ github.repository_owner == 'OGGM' }}
       with:
-        only_on_repo: OGGM/oggm
-        user: ${{ secrets.DockerhubUser }}
-        pass: ${{ secrets.DockerhubPass }}
-        path: ./deployment/docker
-        build_args: GITHUB_SHA,GITHUB_REPOSITORY
-        name: oggm/oggm
-        no_cache: false
-        date_tag: true
-        commit_tag: true
+        context: deployment/docker
+        push: true
+        build-args: |
+          GITHUB_SHA=${{ github.sha }}
+          GITHUB_REPOSITORY=${{ github.repository }}
+        tags: |
+          ${{ steps.names.outputs.name }}:latest
+          ${{ steps.names.outputs.name }}:${{ steps.names.outputs.date }}
+          ${{ steps.names.outputs.name }}:${{ steps.names.outputs.sha }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,11 +24,11 @@ jobs:
           - workflow-multi
           - graphics-mpl
         container:
-          - oggm/untested_base:20210808
-          - oggm/untested_base:py37
-          - oggm/untested_base:py39
+          - ghcr.io/oggm/untested_base:20211114
+          - ghcr.io/oggm/untested_base:py3.7
+          - ghcr.io/oggm/untested_base:py3.9
         include:
-          - container: python:3.8-slim
+          - container: python:3.9-slim
             test-env: minimal
     runs-on: ubuntu-latest
     container: ${{ matrix.container }}
@@ -45,7 +45,7 @@ jobs:
         if: ${{ !contains(matrix.container, 'py3') }}
         continue-on-error: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           COVERALLS_SERVICE_NAME: github
           COVERALLS_PARALLEL: true
         run: coveralls
@@ -53,12 +53,12 @@ jobs:
     name: Coveralls Finished
     needs: test
     runs-on: ubuntu-latest
-    container: python:3-slim
+    container: python:3.9-slim
     continue-on-error: true
     steps:
     - name: Coveralls Finished
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ github.token }}
         COVERALLS_SERVICE_NAME: github
       run: |
         pip3 install --upgrade coveralls &&

--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -1,10 +1,9 @@
 ###################################################
-# Dockerfile to build a Python 3.6 environment
-# with OGGM installed, based on Ubuntu 18.04.
+# Dockerfile to build a Python environment
+# with OGGM installed, based on latest Ubuntu.
 ###################################################
 
-FROM oggm/base:latest
-MAINTAINER Timo Rothenpieler
+FROM ghcr.io/oggm/base:latest
 
 ARG GITHUB_SHA=master
 ARG GITHUB_REPOSITORY=OGGM/oggm

--- a/docs/practicalities.rst
+++ b/docs/practicalities.rst
@@ -139,20 +139,20 @@ you. They are highly configurable, and come in many flavors.
 
 The OGGM team (mostly `Timo <https://github.com/TimoRoth>`_) provides,
 maintains and updates a `Docker <https://www.docker.com/>`_ container.
-You can see all OGGM containers `here <https://hub.docker.com/u/oggm>`_.
+You can see all OGGM containers `here <https://github.com/orgs/OGGM/packages>`_.
 Our most important repositories are:
 
-- `untested_base <https://hub.docker.com/r/oggm/untested_base>`_ is a
-  container based on Ubuntu 18.04 and shipping with all OGGM dependencies
+- `untested_base <https://github.com/OGGM/OGGM-Docker/pkgs/container/untested_base>`_ is a
+  container based on Ubuntu and shipping with all OGGM dependencies
   installed on it. **OGGM is not guaranteed to run on these**, but we
   use them for our tests on
   `GitHub Actions <https://github.com/OGGM/oggm/actions/workflows/run-tests.yml>`_.
-- `base <https://hub.docker.com/r/oggm/base>`_ is built upon ``untested_base``,
+- `base <https://github.com/OGGM/OGGM-Docker/pkgs/container/base>`_ is built upon ``untested_base``,
   but is **pushed online only after the OGGM tests have run successfully
   on it**. Therefore, is provides a more secure base for the model, although
   we cannot guarantee that past or future version of the model will always
   work on it.
-- `oggm <https://hub.docker.com/r/oggm/oggm>`_ is built upon ``base`` each
+- `oggm <https://github.com/OGGM/oggm/pkgs/container/oggm>`_ is built upon ``base`` each
   time that a new change is made to the OGGM codebase. They have OGGM
   installed, and **are guaranteed to run the OGGM version they ship with**.
   We cannot guarantee that past or future version of the model will always
@@ -165,10 +165,10 @@ if you want to install your own OGGM version (don't forget to test it
 afterwards!), and use ``oggm`` if you know which OGGM version you want.
 
 As an example, here is how we run a given fixed version of OGGM on our 
-own cluster. First we pull the image we want to run from docker hub somewhere
+own cluster. First we pull the image we want to run from GitHub somewhere
 on your system::
 
-    $ singularity pull docker://oggm/oggm:20191122
+    $ singularity pull docker://ghcr.io/oggm/oggm:20211115
 
 This will store the image in your current directory and needs to be done only once per image.
 
@@ -181,7 +181,7 @@ This will store the image in your current directory and needs to be done only on
 Then, in your script, so something similar to::
 
     # All commands in the EOF block run inside of the container
-    singularity exec /path/to/oggm/image/oggm_20191122.sif bash -s <<EOF
+    singularity exec /path/to/oggm/image/oggm_20211115.sif bash -s <<EOF
       set -e
       # Setup a fake home dir inside of our workdir, so we don't clutter the
       # actual shared homedir with potentially incompatible stuff
@@ -214,7 +214,7 @@ Some explanations:
   use and run singularity with `srun -n 1 -c X singularity exec ...`:
   this might vary on your cluster.
 - we fix the container version we want to use to a certain
-  `tag <https://hub.docker.com/r/oggm/oggm/tags>`_. With this, we are
+  `tag <https://github.com/OGGM/oggm/pkgs/container/oggm/versions>`_. With this, we are
   guaranteed to always use the same software versions across runs.
 - it follows a number of commands to make sure we don't mess around with
   the system settings. Here we use an `$OGGM_WORKDIR` variable which is 


### PR DESCRIPTION
Since Docker Hub is putting more and more limits on their free tier, moving to somewhere else has become almost inevitable.
All new base Images will be on GitHubs registry, starting today.

This PR switches over the main OGGM image, as well as the tests to the new Pyston-Based main image, all also on GitHubs registry.

Also refactored and modernized the CI Workflow a bit while at it.