### PR TITLE
added dynamic_spinup function

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -73,6 +73,7 @@ Enhancements
   historical to projections outputs (if needed).
   By `Fabien Maussion <https://github.com/fmaussion>`_
 - The package "descartes" is no longer a required dependency for oggm.
+- Added a new entity task ``run_dynamic_spinup``. This task dynamically spinup the glacier to match the area or volume at the RGI date. To do so the glacier is simulated from the recent past (default 1980) to the RGI date. The unknown glacier geometry at the start of the simulation is iteratively changed with a short constant climate run with a varying temperature bias (:pull:`1342`). By `Patrick Schmitt <https://github.com/pat-schmitt/>`_
 
 Bug fixes
 ~~~~~~~~~

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -3910,6 +3910,10 @@ def run_dynamic_spinup(gdir, init_model_filesuffix=None,
         t_bias_guess = [first_guess_t_bias]
         mismatch = [fct_to_minimise(t_bias_guess[0])]
 
+        if mismatch[-1] == 'no ice after spinup!':
+            raise ValueError('During dynamic spinup the glacier disappeared using the first '
+                             'guess temperautre bias! Try again with new (colder) first guess!')
+
         if abs(mismatch[-1]) < precision_percent:
             return t_bias_guess, mismatch
 

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -3952,7 +3952,10 @@ def run_dynamic_spinup(gdir, init_model_filesuffix=None,
     # here do the actual minimisation
     c_fun, model_dynamic_spinup_end = init_cost_fct()
     t_bias_guess, mismatch = minimise_with_polynomial_fit(c_fun)
-    # TODO: save somewhere t_bias and mismatch
+
+    # save the final values
+    gdir.add_to_diagnostics('temp_bias_dynamic_spinup', t_bias_guess[-1])
+    gdir.add_to_diagnostics(f'{minimise_for}_mismatch_dynamic_spinup', mismatch[-1])
 
     # store the outcome
     if store_model_geometry:

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -3749,8 +3749,8 @@ def run_dynamic_spinup(gdir, init_model_filesuffix=None,
                        first_guess_t_bias=-2, maxiter=10,
                        output_filesuffix='_dynamic_spinup',
                        store_model_geometry=True, store_fl_diagnostics=False):
-    """Dynamically spinup glacier to match area or volume at rgi_date. Caution volume should already by calibrated to
-    consensus before using this function!
+    """Dynamically spinup glacier to match area or volume at rgi_date. Caution volume should
+    already by calibrated to consensus before using this function!
 
     Parameters
     ----------
@@ -3768,17 +3768,19 @@ def run_dynamic_spinup(gdir, init_model_filesuffix=None,
     evolution_model : :class:oggm.core.FlowlineModel
         which evolution model to use. Default: FluxBasedModel
     yr_spinup : int
-        The year where the spinup ends and the actual historical model run starts. Must be smaller than yr_rgi_date.
-        The default is 1980
+        The year where the spinup ends and the actual historical model run starts. Must be smaller
+        than yr_rgi_date. The default is 1980
     yr_rgi_date : int
         The rgi date, where we want to match area or volume. If None the gdir.rgi_date + 1 is used.
     minimise_for : str
-        The variable we want to match at yr_rgi_date. Default is 'area'. Options are 'area' or 'volume'.
+        The variable we want to match at yr_rgi_date. Default is 'area'. Options are 'area' or
+        'volume'.
     precision_percent : float
-        Gives the precision we want to match in percent. Default is 1, meaning the difference must be within 1% of the
-        given value (area or volume).
+        Gives the precision we want to match in percent. Default is 1, meaning the difference must
+        be within 1% of the given value (area or volume).
     first_guess_t_bias : float
-        The initial guess for the temperature bias for the spinup MassBalanceModel in °C. Default is -2.
+        The initial guess for the temperature bias for the spinup MassBalanceModel in °C. Default
+        is -2.
     maxiter : int
         Maximum number of minimisation iterations. If reached error is raised. Default is 10.
     output_filesuffix : str
@@ -3809,13 +3811,14 @@ def run_dynamic_spinup(gdir, init_model_filesuffix=None,
     else:
         fls_spinup = copy.deepcopy(init_model_fls)
 
-    # here we define the flowline we want to match, it is assumed that during the inversion the volume was calibrated
-    # towards the consensus estimate (as it is by default), but this means the volume is matched on a regional scale,
-    # maybe we could use here the individual glacier volume
+    # here we define the flowline we want to match, it is assumed that during the inversion the
+    # volume was calibrated towards the consensus estimate (as it is by default), but this means
+    # the volume is matched on a regional scale, maybe we could use here the individual glacier
+    # volume
     fls_ref = copy.deepcopy(fls_spinup)
 
     # define spinup MassBalance
-    # spinup is running for 'yr_rgi_date - yr_spinup' years, using a ConstantMassBalance of this period
+    # spinup is running for 'yr_rgi_date - yr_spinup' years, using a ConstantMassBalance
     y0_spinup = int((yr_spinup + yr_rgi_date) / 2)
     halfsize_spinup = yr_rgi_date - y0_spinup
     mb_spinup = MultipleFlowlineMassBalance(gdir,
@@ -3906,7 +3909,8 @@ def run_dynamic_spinup(gdir, init_model_filesuffix=None,
         t_bias_guess.append(t_bias_guess[0] - step)
         mismatch.append(fct_to_minimise(t_bias_guess[-1]))
 
-        # check if the step was to large and no glacier is left after spinup, otherwise try with smaller step
+        # check if the step was to large and no glacier is left after spinup,
+        # otherwise try with smaller step
         partial_step = 0.9
         while mismatch[-1] == 'no ice after spinup!':
             t_bias_guess[-1] = t_bias_guess[0] - step * partial_step
@@ -3918,10 +3922,11 @@ def run_dynamic_spinup(gdir, init_model_filesuffix=None,
 
         # Now start with polynomial fit for guessing
         while len(t_bias_guess) < maxiter:
-            # get next guess from polyfit (fit function to previously calculated (mismatch, t_bias) pairs and get
-            # t_bias value where mismatch=0 from this fitted curve;
-            # the degree of the fitted curve is the number of value pairs - 1)
-            t_bias_guess.append(np.polyval(np.polyfit(mismatch, t_bias_guess, len(mismatch) - 1), 0))
+            # get next guess from polyfit (fit function to previously calculated
+            # (mismatch, t_bias) pairs and get t_bias value where mismatch=0 from this fitted
+            # curve; the degree of the fitted curve is the number of value pairs - 1)
+            t_bias_guess.append(np.polyval(np.polyfit(mismatch, t_bias_guess, len(mismatch) - 1),
+                                           0))
             mismatch.append(fct_to_minimise(t_bias_guess[-1]))
 
             if mismatch[-1] == 'no ice after spinup!':
@@ -3931,11 +3936,13 @@ def run_dynamic_spinup(gdir, init_model_filesuffix=None,
                 return t_bias_guess, mismatch
 
         raise ValueError('Dynamic spinup could not find satisfying match after ' + str(maxiter) +
-                         ' iterations! Could try again with more iterations or a larger precision.')
+                         ' iterations! Could try again with more iterations or a larger precision.'
+                         )
 
     # here do the actual minimisation
     c_fun, model_dynamic_spinup_end = init_cost_fct()
-    t_bias_guess, mismatch = minimise_with_polynomial_fit(c_fun)  # TODO: save somewhere t_bias and mismatch
+    t_bias_guess, mismatch = minimise_with_polynomial_fit(c_fun)
+    # TODO: save somewhere t_bias and mismatch
 
     # store the outcome
     if store_model_geometry:

--- a/oggm/tasks.py
+++ b/oggm/tasks.py
@@ -56,5 +56,6 @@ from oggm.core.flowline import run_random_climate
 from oggm.core.flowline import run_from_climate_data
 from oggm.core.flowline import run_constant_climate
 from oggm.core.flowline import run_with_hydro
+from oggm.core.flowline import run_dynamic_spinup
 from oggm.utils import copy_to_basedir
 from oggm.utils import gdir_to_tar

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -3217,6 +3217,13 @@ class TestHEF:
         assert not np.allclose(model_dynamic_spinup.fls[1].surface_h, fls[1].surface_h)
         assert not np.allclose(model_dynamic_spinup.fls[2].surface_h, fls[2].surface_h)
 
+        # check if temp_bias and mismatch is saved in model diagnostics
+        gdir_diagnostics = hef_gdir.get_diagnostics()
+        assert 'temp_bias_dynamic_spinup' in gdir_diagnostics.keys()
+        mismatch_key = f'{minimise_for}_mismatch_dynamic_spinup'
+        assert mismatch_key in gdir_diagnostics.keys()
+        assert gdir_diagnostics[mismatch_key] < precision_percent
+
         # check if model geometry is correctly saved in gdir
         fp = hef_gdir.get_filepath('model_geometry',
                                    filesuffix='_dynamic_spinup')

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -3193,12 +3193,12 @@ class TestHEF:
         precision_percent = 1
         assert hef_gdir.rgi_date == 2003
         # is needed because the test climate dataset has ye = 2003 (in hydro years would be 2004)
-        yr_rgi_date = 2003
+        yr_rgi = 2003
         model_dynamic_spinup = run_dynamic_spinup(hef_gdir, init_model_filesuffix=None,
                                                   init_model_fls=None,
                                                   climate_input_filesuffix='',
                                                   evolution_model=FluxBasedModel,
-                                                  yr_spinup=1980, yr_rgi_date=yr_rgi_date,
+                                                  yr_spinup=1980, yr_rgi=yr_rgi,
                                                   minimise_for=minimise_for,
                                                   precision_percent=precision_percent,
                                                   first_guess_t_bias=-2, maxiter=10,
@@ -3209,7 +3209,7 @@ class TestHEF:
         # check if resulting model match wanted value with prescribed precision
         assert np.isclose(getattr(model_dynamic_spinup, var_name), ref_value,
                           rtol=precision_percent/100, atol=0)
-        assert model_dynamic_spinup.yr == yr_rgi_date
+        assert model_dynamic_spinup.yr == yr_rgi
         assert len(model_dynamic_spinup.fls) == len(fls)
         # but surface_h should not be the same
         # (also checks all individual flowlines has same number of grid points)
@@ -3222,7 +3222,7 @@ class TestHEF:
                                    filesuffix='_dynamic_spinup')
         fmod = FileModel(fp)
         assert np.isclose(getattr(model_dynamic_spinup, var_name), getattr(fmod, var_name))
-        assert fmod.last_yr == yr_rgi_date
+        assert fmod.last_yr == yr_rgi
         assert len(model_dynamic_spinup.fls) == len(fmod.fls)
 
     @pytest.mark.slow

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -3192,22 +3192,27 @@ class TestHEF:
 
         precision_percent = 1
         assert hef_gdir.rgi_date == 2003
-        yr_rgi_date = 2003  # is needed because the test climate dataset has ye = 2003 (in hydro years would be 2004)
+        # is needed because the test climate dataset has ye = 2003 (in hydro years would be 2004)
+        yr_rgi_date = 2003
         model_dynamic_spinup = run_dynamic_spinup(hef_gdir, init_model_filesuffix=None,
                                                   init_model_fls=None,
                                                   climate_input_filesuffix='',
                                                   evolution_model=FluxBasedModel,
                                                   yr_spinup=1980, yr_rgi_date=yr_rgi_date,
-                                                  minimise_for=minimise_for, precision_percent=precision_percent,
+                                                  minimise_for=minimise_for,
+                                                  precision_percent=precision_percent,
                                                   first_guess_t_bias=-2, maxiter=10,
                                                   output_filesuffix='_dynamic_spinup',
-                                                  store_model_geometry=True, store_fl_diagnostics=False)
+                                                  store_model_geometry=True,
+                                                  store_fl_diagnostics=False)
 
         # check if resulting model match wanted value with prescribed precision
-        assert np.isclose(getattr(model_dynamic_spinup, var_name), ref_value, rtol=precision_percent/100, atol=0)
+        assert np.isclose(getattr(model_dynamic_spinup, var_name), ref_value,
+                          rtol=precision_percent/100, atol=0)
         assert model_dynamic_spinup.yr == yr_rgi_date
         assert len(model_dynamic_spinup.fls) == len(fls)
-        # but surface_h should not be the same (also checks all individual flowlines has same number of grid points)
+        # but surface_h should not be the same
+        # (also checks all individual flowlines has same number of grid points)
         assert not np.allclose(model_dynamic_spinup.fls[0].surface_h, fls[0].surface_h)
         assert not np.allclose(model_dynamic_spinup.fls[1].surface_h, fls[1].surface_h)
         assert not np.allclose(model_dynamic_spinup.fls[2].surface_h, fls[2].surface_h)


### PR DESCRIPTION
- [x] Tests added/passed
- [ ] Fully documented
- [x] Entry in `whats-new.rst` 

General idea: 
- conduct a spinup from 1980 to the RGI date and match area OR volume at RGI date (e.g. 2003)
- Timeline of spinup: START from 'RGI date' `flowlines` -> run model with `ConstantMassBalance` (defined between 1980 and 2003) with a temperature bias `t_bias` for 23 years (2003 - 1980) -> resulting `flowlines` are defined as glacier state in year 1980 -> run model with `PastMassBalance` until 2003 -> compare resulting area OR volume with RGI date area OR volume -> change `t_bias` and start with next iteration at START
- all model settings are the default ones of prepro level 4

Things to discuss:
- general idea
- Spinup tries to match area OR volume at RGI date. For volume: the function is intended to be used after the volumes of the glaciers are calibrated to the consensus estimate on a regional scale (e.g. starting from glaciers at prepro level 4). Maybe the difference between the resulting spinuped glaciers and the consensus estimate should be checked again after the spinup on a regional scale.
- should the resulting temperature bias and mismatch be stored somewhere (maybe in `model_diagnostics`)
- are the included tests sufficient