### PR TITLE
corrected mb_climate_on_height for hydro month = 1 and qc as diagnostics

### DIFF
--- a/oggm/core/climate.py
+++ b/oggm/core/climate.py
@@ -409,6 +409,8 @@ def historical_climate_qc(gdir):
     default_grad = cfg.PARAMS['temp_default_gradient']
     g_minmax = cfg.PARAMS['temp_local_gradient_bounds']
     qc_months = cfg.PARAMS['climate_qc_months']
+    # add that historical climate qc was done and add amount of climate_qc_months
+    gdir.add_to_diagnostics('climate_qc_months', qc_months)
     if qc_months == 0:
         return
 
@@ -512,7 +514,11 @@ def mb_climate_on_height(gdir, heights, *, time_range=None, year_range=None):
     if year_range is not None:
         sm = cfg.PARAMS['hydro_month_' + gdir.hemisphere]
         em = sm - 1 if (sm > 1) else 12
-        t0 = datetime.datetime(year_range[0]-1, sm, 1)
+        if sm != 1:
+            t0 = datetime.datetime(year_range[0] - 1, sm, 1)
+        else:
+            # hydrological year is the calendar year!!!
+            t0 = datetime.datetime(year_range[0], sm, 1)
         t1 = datetime.datetime(year_range[1], em, 1)
         return mb_climate_on_height(gdir, heights, time_range=[t0, t1])
 

--- a/oggm/shop/cru.py
+++ b/oggm/shop/cru.py
@@ -94,7 +94,7 @@ def process_cru_data(gdir, tmp_file=None, pre_file=None, y0=None, y1=None,
         the entire time period available in the file, but with this kwarg
         you can shorten it (to save space or to crop bad data)
     y1 : int
-        the starting year of the timeseries to write. The default is to take
+        the end year of the timeseries to write. The default is to take
         the entire time period available in the file, but with this kwarg
         you can shorten it (to save space or to crop bad data)
     output_filesuffix : str

--- a/oggm/tests/conftest.py
+++ b/oggm/tests/conftest.py
@@ -146,8 +146,11 @@ def secure_url_retrieve(url, *args, **kwargs):
             'cluster.klima.uni-bremen.de/~oggm/demo_gdirs/' in url or
             'cluster.klima.uni-bremen.de/~oggm/test_climate/' in url or
             'klima.uni-bremen.de/~oggm/climate/cru/cru_cl2.nc.zip' in url or
-            'klima.uni-bremen.de/~oggm/geodetic_ref_mb' in url
+            'klima.uni-bremen.de/~oggm/geodetic_ref_mb' in url or
+            'https://cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.4/'
+            'L1-L2_files/elev_bands' in url
             )
+    # elev_bands url added in order that test_models/test_hef_mu_star_calibration_from_geodetic_mb works!!!
     return oggm_urlretrieve(url, *args, **kwargs)
 
 

--- a/oggm/tests/conftest.py
+++ b/oggm/tests/conftest.py
@@ -146,11 +146,8 @@ def secure_url_retrieve(url, *args, **kwargs):
             'cluster.klima.uni-bremen.de/~oggm/demo_gdirs/' in url or
             'cluster.klima.uni-bremen.de/~oggm/test_climate/' in url or
             'klima.uni-bremen.de/~oggm/climate/cru/cru_cl2.nc.zip' in url or
-            'klima.uni-bremen.de/~oggm/geodetic_ref_mb' in url or
-            'https://cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.4/'
-            'L1-L2_files/elev_bands' in url
+            'klima.uni-bremen.de/~oggm/geodetic_ref_mb' in url
             )
-    # elev_bands url added in order that test_models/test_hef_mu_star_calibration_from_geodetic_mb works!!!
     return oggm_urlretrieve(url, *args, **kwargs)
 
 

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -971,16 +971,18 @@ class TestMassBalanceModels:
 
         pd_geodetic = utils.get_geodetic_mb_dataframe()[
             utils.get_geodetic_mb_dataframe().period == '2000-01-01_2020-01-01']
-        gdir = hef_gdir  # hef_gdir is of RGI50, but geodetic of RGI60, it won't matter here for the test
+        # hef_gdir is of RGI50, geodetic of RGI60, it won't matter here for the test
+        gdir = hef_gdir
         df = ['RGI60-11.00897']
         cfg.PARAMS['use_multiprocessing'] = False
         cfg.PARAMS['hydro_month_nh'] = 1
         cfg.PARAMS['hydro_month_sh'] = 1
         ref_mb_geodetic = pd_geodetic.loc[df[0]].dmdtda * 1000
         cfg.PARAMS['baseline_climate'] = 'CRU'
-        # the test CRU climate goes only until end of 2014, but we can create instead a fake climate for 2000-2019
+        # the test CRU climate goes only until end of 2014, but we can create
+        # instead a fake climate for 2000-2019
         tasks.process_dummy_cru_file(gdir, y0=2000, y1=2019)
-        #tasks.process_cru_data(gdir)  # , y0=2000, y1=2019)
+        # tasks.process_cru_data(gdir)  # , y0=2000, y1=2019)
         cfg.PARAMS['max_mu_star'] = 600
         climate.mu_star_calibration_from_geodetic_mb(gdir, ref_mb=ref_mb_geodetic,
                                                      ref_period='2000-01-01_2020-01-01',

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -967,6 +967,53 @@ class TestMassBalanceModels:
             # no big deal
             pytest.skip('Allowed failure')
 
+    def test_hef_mu_star_calibration_from_geodetic_mb(self, hef_gdir):
+
+        pd_geodetic = utils.get_geodetic_mb_dataframe()[
+            utils.get_geodetic_mb_dataframe().period == '2000-01-01_2020-01-01']
+        reinit = True
+        if reinit:
+            # need to reinitiate, because we need to use the climate till end of 2019!!!
+            cfg.initialize()
+            cfg.PARAMS['use_multiprocessing'] = False
+            cfg.PARAMS['hydro_month_nh'] = 1
+            cfg.PARAMS['hydro_month_sh'] = 1
+            cfg.PATHS['working_dir'] = utils.gettempdir(dirname='test', reset=True)
+
+            base_url = ('https://cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.4/'
+                        'L1-L2_files/elev_bands')
+
+            df = ['RGI60-11.00897']
+            gdirs = workflow.init_glacier_directories(df, from_prepro_level=2,
+                                                      prepro_border=10,
+                                                      prepro_base_url=base_url,
+                                                      prepro_rgi_version='62')
+            gdir = gdirs[0]
+
+        else:
+            # we can't use hef_gdir, because there the climate goes only until end of 2014 or sth. like that?
+            gdir = hef_gdir  # hef_gdir is of RGI50, but geodetic of RGI60, does this matter?
+            df = ['RGI60-11.00897']
+            cfg.PARAMS['use_multiprocessing'] = False
+            cfg.PARAMS['hydro_month_nh'] = 1
+            cfg.PARAMS['hydro_month_sh'] = 1
+        ref_mb_geodetic = pd_geodetic.loc[df[0]].dmdtda * 1000
+        cfg.PARAMS['baseline_climate'] = 'CRU'
+        tasks.process_cru_data(gdir)  # , y0=2000, y1=2019)
+        cfg.PARAMS['max_mu_star'] = 600
+        climate.mu_star_calibration_from_geodetic_mb(gdir, ref_mb=ref_mb_geodetic,
+                                                     ref_period='2000-01-01_2020-01-01',
+                                                     ignore_hydro_months=False)
+
+        h, w = gdir.get_inversion_flowline_hw()
+        mb = massbalance.PastMassBalance(gdir)
+        mb_modelled = mb.get_specific_mb(h, w, year=np.arange(2000, 2020, 1))
+
+        np.testing.assert_allclose(ref_mb_geodetic, mb_modelled.mean())
+
+        # before, the 21-year period was matched instead of 20-year period
+        # mb_modelled_wrong = mb.get_specific_mb(h, w, year=np.arange(1999,2020,1))
+        # np.testing.assert_allclose(ref_mb_geodetic, mb_modelled.mean())
 
 class TestModelFlowlines():
 


### PR DESCRIPTION
when using `match_geod_pergla`, so far, the MB mean from 1999 to end of 2019 was calibrated to match the geodetic estimates. Normally it should be 2000-2019, but `mb_climate_on_height` falsely used the year before y0 even if hydro_month is equal to 1. This resulted in a not perfectly calibrated mb model and was found out during the development of this notebook:  https://nbviewer.org/urls/cluster.klima.uni-bremen.de/~lschuster/error_analysis/working_glacier_gdirs_comparison.ipynb#id-dmdt-dmdtda-qc3. I proposed a correction for that. All old tests of OGGM still pass with this correction.  If I am right and the corrections have to be done, we need to recalibrate the preprocessed gdirs above level 2 that use `match_geod_pergla` ! 

I also wrote a test that checks if the 20-year modelled specific mass-balance is now equal to the reference geodetic calibration data. Now it perfectly matches, however, and this is also tested inside of OGGM:
- For the test, we need the newest climate data (till end of 2019), however inside of https://cluster.klima.uni-bremen.de/~oggm/test_climate/, for both ERA5 and CRU, the climate goes only till 2018 or 2014, 
     - Therefore, I use  `process_dummy_cru_file` to create a climate in the right time range and to test then if the calibration has worked
     - I will create new pre-processed directories without the small error, for that I also added the climate_qc_months to the diagnostics if historical_qc_months is called!
