### PR TITLE
Do not store NaNs if stop criterion is used

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -47,7 +47,9 @@ Enhancements
 - Added a new ``mu_star_calibration_from_geodetic_mb`` task which now calibrates
   each glacier individually from the reference geodetic MB data. This is a rather
   quick solution for now, but it opens new avenues (:pull:`1286`).
-  By `Fabien Maussion <https://github.com/fmaussion>`_
+  A bug in the new feature was later corrected (:pull:`1351`).
+  By `Fabien Maussion <https://github.com/fmaussion>`_ and
+  `Lilian Schuster <https://github.com/lilianschuster>`_
 - Added a new ``utils.get_geodetic_mb_dataframe`` which returns the
   reference geodetic MB data, currently from Hugonnet et al 2021.
   Also changed the behavior of ``cfg.DATA`` to be shared

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -1355,7 +1355,7 @@ class FlowlineModel(object):
                 ds['area_m2'] = ds['area_m2'].where(ds['volume_m3'] > 0, 0) * dx
                 if stop_criterion is not None:
                     # Remove probable NaNs
-                    fl_diag_dss[i] = ds.dropna('time', inplace=True)
+                    fl_diag_dss[i] = ds.dropna('time')
 
             # Write out?
             if fl_diag_path not in [True, None]:

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -1231,7 +1231,7 @@ class FlowlineModel(object):
         for i, (yr, mo) in enumerate(zip(monthly_time, months)):
 
             if yr > self.yr:
-                # Here we model run - otherwize (for spinup) we
+                # Here we model run - otherwise (for spinup) we
                 # constantly store the same data
                 self.run_until(yr)
 
@@ -1325,6 +1325,11 @@ class FlowlineModel(object):
                                                 coords=varcoords)
                 ds['ts_calving_bucket_m3'] = xr.DataArray(b, dims=('time', ),
                                                           coords=varcoords)
+
+                if stop_criterion is not None:
+                    # Remove probable NaNs
+                    ds = ds.dropna('time')
+
                 geom_ds.append(ds)
 
         # Add the spinup volume to the diag
@@ -1335,15 +1340,22 @@ class FlowlineModel(object):
                                           'not implemented yet.')
             diag_ds['volume_m3'].data[:] += spinup_vol
 
+        if stop_criterion is not None:
+            # Remove probable NaNs
+            diag_ds = diag_ds.dropna('time')
+
         # write output?
         if do_fl_diag:
             # Unit conversions for these
-            for ds in fl_diag_dss:
+            for i, ds in enumerate(fl_diag_dss):
                 dx = ds.attrs['map_dx'] * ds.attrs['dx']
                 # No inplace because the other dataset uses them
                 # These variables are always there (see above)
                 ds['volume_m3'] = ds['volume_m3'] * dx
                 ds['area_m2'] = ds['area_m2'].where(ds['volume_m3'] > 0, 0) * dx
+                if stop_criterion is not None:
+                    # Remove probable NaNs
+                    fl_diag_dss[i] = ds.dropna('time', inplace=True)
 
             # Write out?
             if fl_diag_path not in [True, None]:

--- a/oggm/tests/conftest.py
+++ b/oggm/tests/conftest.py
@@ -1,5 +1,5 @@
 """Pytest fixtures to be used in other test modules"""
-
+import copy
 import os
 import shutil
 import logging
@@ -243,6 +243,18 @@ def hef_gdir_base(request, test_dir):
         return init_hef()
 
 
+@pytest.fixture(scope='module')
+def hef_copy_gdir_base(request, test_dir):
+    """same as hef_gdir but with another RGI ID (for workflow testing)
+    """
+    try:
+        module = request.module
+        border = module.DOM_BORDER if module.DOM_BORDER is not None else 40
+        return init_hef(border=border, rgi_id='RGI50-11.99999')
+    except AttributeError:
+        return init_hef(rgi_id='RGI50-11.99999')
+
+
 @pytest.fixture(scope='class')
 def hef_gdir(hef_gdir_base, class_case_dir):
     """ Provides a copy of the base Hintereisenferner glacier directory in
@@ -250,4 +262,12 @@ def hef_gdir(hef_gdir_base, class_case_dir):
         the test class will use the same copy of this glacier directory.
     """
     return tasks.copy_to_basedir(hef_gdir_base, base_dir=class_case_dir,
+                                 setup='all')
+
+
+@pytest.fixture(scope='class')
+def hef_copy_gdir(hef_copy_gdir_base, class_case_dir):
+    """Same as hef_gdir but with another RGI ID (for testing)
+    """
+    return tasks.copy_to_basedir(hef_copy_gdir_base, base_dir=class_case_dir,
                                  setup='all')

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -2833,7 +2833,6 @@ class TestHEF:
 
     @pytest.mark.slow
     def test_stop_criterion(self, hef_gdir, inversion_params):
-
         # As long as hef_gdir uses 1, we need to use 1 here as well
         cfg.PARAMS['trapezoid_lambdas'] = 1
         init_present_time_glacier(hef_gdir)
@@ -2852,18 +2851,51 @@ class TestHEF:
         with xr.open_dataset(fp) as ds:
             ds_nostop = ds.load()
 
-        assert ds_stop.volume_m3.isnull().sum() > 50
+        assert ds_stop.volume_m3.isnull().sum() == 0
         assert ds_nostop.volume_m3.isnull().sum() == 0
 
-        ds_stop = ds_stop.volume_m3.isel(time=~ds_stop.volume_m3.isnull())
+        ds_stop = ds_stop.volume_m3
         ds_nostop = ds_nostop.volume_m3
         assert_allclose(ds_stop.isel(time=-1), ds_nostop.isel(time=-1), rtol=0.2)
+        assert ds_stop.time[-1] < 150
 
         if do_plot:
             ds_nostop.plot(label='NoStop')
             ds_stop.plot(label='Stop')
             plt.legend()
             plt.show()
+
+    @pytest.mark.slow
+    def test_compile_time_workflow(self, hef_gdir, hef_copy_gdir,
+                                     inversion_params):
+        # As long as hef_gdir uses 1, we need to use 1 here as well
+        cfg.PARAMS['trapezoid_lambdas'] = 1
+        init_present_time_glacier(hef_gdir)
+        init_present_time_glacier(hef_copy_gdir)
+        cfg.PARAMS['min_ice_thick_for_length'] = 1
+
+        run_from_climate_data(hef_gdir, ys=1985, ye=1995)
+        run_from_climate_data(hef_copy_gdir, ys=1990, ye=2000)
+
+        # Roundtrip
+        ds1 = utils.compile_run_output([hef_gdir, hef_copy_gdir])
+        ds2 = utils.compile_run_output([hef_copy_gdir, hef_gdir])
+        xr.testing.assert_allclose(ds1.sum(dim='rgi_id'), ds2.sum(dim='rgi_id'))
+
+        # If we were using xarray (which we should), we get:
+        ds = xr.open_mfdataset([gd.get_filepath('model_diagnostics') for gd in
+                                [hef_gdir, hef_copy_gdir]],
+                                combine='nested', concat_dim='rgi_id')
+        assert_allclose(ds.volume_m3.T, ds1.volume)
+        assert_allclose(ds.area_m2.T, ds1.area)
+        assert_allclose(ds.calving_m3.T, ds1.calving)
+
+        ds = xr.open_mfdataset([gd.get_filepath('model_diagnostics') for gd in
+                                [hef_copy_gdir, hef_gdir]],
+                                combine='nested', concat_dim='rgi_id')
+        assert_allclose(ds.volume_m3.T, ds2.volume)
+        assert_allclose(ds.area_m2.T, ds2.area)
+        assert_allclose(ds.calving_m3.T, ds2.calving)
 
     @pytest.mark.slow
     def test_equilibrium_glacier_wide(self, hef_gdir, inversion_params):
@@ -4096,7 +4128,8 @@ def merged_hef_cfg(class_case_dir):
 
 
 @pytest.mark.usefixtures('merged_hef_cfg')
-class TestMergedHEF():
+class TestMergedHEF:
+
     @pytest.mark.slow
     def test_merged_simulation(self):
         import geopandas as gpd

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -22,7 +22,7 @@ from oggm.cfg import SEC_IN_YEAR, SEC_IN_MONTH
 from oggm.utils import get_demo_file
 from oggm.exceptions import InvalidParamsError, InvalidWorkflowError
 
-from oggm.tests.funcs import get_test_dir, apply_test_ref_tstars
+from oggm.tests.funcs import get_test_dir
 from oggm.tests.funcs import (dummy_bumpy_bed, dummy_constant_bed,
                               dummy_constant_bed_cliff,
                               dummy_mixed_bed, bu_tidewater_bed,
@@ -38,7 +38,7 @@ from oggm.core.flowline import (FluxBasedModel, FlowlineModel, MassRedistributio
                                 flowline_from_dataset, FileModel,
                                 run_constant_climate, run_random_climate,
                                 run_from_climate_data, equilibrium_stop_criterion,
-                                run_dynamic_spinup)
+                                run_dynamic_spinup, run_with_hydro)
 
 FluxBasedModel = partial(FluxBasedModel, inplace=True)
 FlowlineModel = partial(FlowlineModel, inplace=True)
@@ -2866,16 +2866,18 @@ class TestHEF:
             plt.show()
 
     @pytest.mark.slow
-    def test_compile_time_workflow(self, hef_gdir, hef_copy_gdir,
-                                     inversion_params):
+    def test_compile_time_workflow(self, hef_gdir, hef_copy_gdir, inversion_params):
         # As long as hef_gdir uses 1, we need to use 1 here as well
         cfg.PARAMS['trapezoid_lambdas'] = 1
         init_present_time_glacier(hef_gdir)
         init_present_time_glacier(hef_copy_gdir)
         cfg.PARAMS['min_ice_thick_for_length'] = 1
+        cfg.PARAMS['store_model_geometry'] = True
 
-        run_from_climate_data(hef_gdir, ys=1985, ye=1995)
-        run_from_climate_data(hef_copy_gdir, ys=1990, ye=2000)
+        run_with_hydro(hef_gdir, run_task=run_from_climate_data,
+                       ys=1985, ye=1995, store_monthly_hydro=True)
+        run_with_hydro(hef_copy_gdir, run_task=run_from_climate_data,
+                       ys=1985, ye=1995, store_monthly_hydro=True)
 
         # Roundtrip
         ds1 = utils.compile_run_output([hef_gdir, hef_copy_gdir])
@@ -2883,16 +2885,14 @@ class TestHEF:
         xr.testing.assert_allclose(ds1.sum(dim='rgi_id'), ds2.sum(dim='rgi_id'))
 
         # If we were using xarray (which we should), we get:
-        ds = xr.open_mfdataset([gd.get_filepath('model_diagnostics') for gd in
-                                [hef_gdir, hef_copy_gdir]],
-                                combine='nested', concat_dim='rgi_id')
+        fps = [gd.get_filepath('model_diagnostics') for gd in [hef_gdir, hef_copy_gdir]]
+        ds = xr.open_mfdataset(fps, combine='nested', concat_dim='rgi_id')
         assert_allclose(ds.volume_m3.T, ds1.volume)
         assert_allclose(ds.area_m2.T, ds1.area)
         assert_allclose(ds.calving_m3.T, ds1.calving)
 
-        ds = xr.open_mfdataset([gd.get_filepath('model_diagnostics') for gd in
-                                [hef_copy_gdir, hef_gdir]],
-                                combine='nested', concat_dim='rgi_id')
+        fps = [gd.get_filepath('model_diagnostics') for gd in [hef_copy_gdir, hef_gdir]]
+        ds = xr.open_mfdataset(fps, combine='nested', concat_dim='rgi_id')
         assert_allclose(ds.volume_m3.T, ds2.volume)
         assert_allclose(ds.area_m2.T, ds2.area)
         assert_allclose(ds.calving_m3.T, ds2.calving)

--- a/oggm/tests/test_numerics.py
+++ b/oggm/tests/test_numerics.py
@@ -1259,11 +1259,11 @@ class TestIdealisedCases(unittest.TestCase):
         fl_ds = fl_model.run_until_and_store(1000, stop_criterion=zero_glacier_stop_criterion)
         dh_ds = dh_model.run_until_and_store(1000, stop_criterion=zero_glacier_stop_criterion)
 
-        assert fl_ds.volume_m3.isnull().sum() > 800
-        assert dh_ds.volume_m3.isnull().sum() > 450
+        assert fl_ds.volume_m3.isnull().sum() == 0
+        assert dh_ds.volume_m3.isnull().sum() == 0
 
-        fl_ds = fl_ds.volume_m3.isel(time=~fl_ds.volume_m3.isnull())
-        dh_ds = dh_ds.volume_m3.isel(time=~dh_ds.volume_m3.isnull())
+        fl_ds = fl_ds.volume_m3
+        dh_ds = dh_ds.volume_m3
 
         assert fl_ds.isel(time=-5) == 0
         assert dh_ds.isel(time=-5) == 0
@@ -1287,11 +1287,11 @@ class TestIdealisedCases(unittest.TestCase):
         fl_ds_ns = fl_model.run_until_and_store(800)
         dh_ds_ns = dh_model.run_until_and_store(800)
 
-        assert fl_ds.volume_m3.isnull().sum() > 600
-        assert dh_ds.volume_m3.isnull().sum() > 600
+        assert fl_ds.volume_m3.isnull().sum() == 0
+        assert dh_ds.volume_m3.isnull().sum() == 0
 
-        fl_ds = fl_ds.volume_m3.isel(time=~fl_ds.volume_m3.isnull())
-        dh_ds = dh_ds.volume_m3.isel(time=~dh_ds.volume_m3.isnull())
+        fl_ds = fl_ds.volume_m3
+        dh_ds = dh_ds.volume_m3
 
         fl_ds_ns = fl_ds_ns.volume_m3
         dh_ds_ns = dh_ds_ns.volume_m3

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -1053,21 +1053,46 @@ def compile_run_output(gdirs, path=True, input_filesuffix='',
     # Get the dimensions of all this
     rgi_ids = [gd.rgi_id for gd in gdirs]
 
-    # To find the longest time, sort the gdirs by date
-    sorted_gdir = sorted(gdirs, key=lambda gdir: gdir.rgi_date)
-    # The first gdir might have blown up, try some others
-    i = 0
-    while True:
-        if i >= len(sorted_gdir):
-            raise RuntimeError('Found no valid glaciers!')
+    # To find the longest time, we have to open all files unfortunately
+    time_info = {}
+    for gd in gdirs:
+        fp = gd.get_filepath('model_diagnostics', filesuffix=input_filesuffix)
         try:
-            ppath = sorted_gdir[i].get_filepath('model_diagnostics',
-                                                filesuffix=input_filesuffix)
-            with xr.open_dataset(ppath) as ds_diag:
-                ds_diag.time.values
-            break
-        except BaseException:
-            i += 1
+            with ncDataset(fp) as ds:
+                time = ds.variables['time'][:]
+                if 'time' not in time_info:
+                   time_info['time'] = time
+                   for cn in ['hydro_year', 'hydro_month',
+                              'calendar_year', 'calendar_month']:
+                       time_info[cn] = ds.variables[cn][:]
+                else:
+                    # Here we may need to append or add stuff
+                    ot = time_info['time']
+                    if time[0] > ot[-1] or ot[-1] < time[0]:
+                        raise InvalidWorkflowError('Trying to compile output '
+                                                   'without overlap.')
+                    if time[-1] > ot[-1]:
+                        p = np.nonzero(time == ot[-1])[0][0] + 1
+                        time_info['time'] = np.append(ot, time[p:])
+                        for cn in ['hydro_year', 'hydro_month',
+                                   'calendar_year', 'calendar_month']:
+                            time_info[cn] = np.append(time_info[cn],
+                                                      ds.variables[cn][p:])
+                    if time[0] < ot[0]:
+                        p = np.nonzero(time == ot[0])[0][0]
+                        time_info['time'] = np.append(time[:p], ot)
+                        for cn in ['hydro_year', 'hydro_month',
+                                   'calendar_year', 'calendar_month']:
+                            time_info[cn] = np.append(ds.variables[cn][:p],
+                                                      time_info[cn])
+
+            # If this worked, keep it as template
+            ppath = fp
+        except FileNotFoundError:
+            pass
+
+    if 'time' not in time_info:
+        raise RuntimeError('Found no valid glaciers!')
 
     # OK found it, open it and prepare the output
     with xr.open_dataset(ppath) as ds_diag:
@@ -1082,7 +1107,7 @@ def compile_run_output(gdirs, path=True, input_filesuffix='',
         ds.attrs['creation_date'] = strftime("%Y-%m-%d %H:%M:%S", gmtime())
 
         # Copy coordinates
-        time = ds_diag.time.values
+        time = time_info['time']
         ds.coords['time'] = ('time', time)
         ds['time'].attrs['description'] = 'Floating hydrological year'
         # New coord
@@ -1091,7 +1116,7 @@ def compile_run_output(gdirs, path=True, input_filesuffix='',
         # This is just taken from there
         for cn in ['hydro_year', 'hydro_month',
                    'calendar_year', 'calendar_month']:
-            ds.coords[cn] = ('time', ds_diag[cn].values)
+            ds.coords[cn] = ('time', time_info[cn])
             ds[cn].attrs['description'] = ds_diag[cn].attrs['description']
 
         # We decide on the name of "3d" variables in case we have daily
@@ -1146,15 +1171,17 @@ def compile_run_output(gdirs, path=True, input_filesuffix='',
         try:
             ppath = gdir.get_filepath('model_diagnostics',
                                       filesuffix=input_filesuffix)
-            with xr.open_dataset(ppath) as ds_diag:
-                nt = - len(ds_diag.volume_m3.values)
+            with ncDataset(ppath) as ds_diag:
+                it = ds_diag.variables['time'][:]
+                a = np.nonzero(time == it[0])[0][0]
+                b = np.nonzero(time == it[-1])[0][0] + 1
                 for vn, var in out_2d.items():
-                    var['data'][nt:, i] = ds_diag[vn].values
+                    var['data'][a:b, i] = ds_diag.variables[vn][:]
                 for vn, var in out_3d.items():
-                    var['data'][nt:, :, i] = ds_diag[vn].values
+                    var['data'][a:b, :, i] = ds_diag.variables[vn][:]
                 for vn, var in out_1d.items():
-                    var['data'][i] = ds_diag.attrs[vn]
-        except BaseException:
+                    var['data'][i] = ds_diag.getncattr(vn)
+        except FileNotFoundError:
             pass
 
     # To xarray

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -1055,16 +1055,16 @@ def compile_run_output(gdirs, path=True, input_filesuffix='',
 
     # To find the longest time, we have to open all files unfortunately
     time_info = {}
+    time_keys = ['hydro_year', 'hydro_month', 'calendar_year', 'calendar_month']
     for gd in gdirs:
         fp = gd.get_filepath('model_diagnostics', filesuffix=input_filesuffix)
         try:
             with ncDataset(fp) as ds:
                 time = ds.variables['time'][:]
                 if 'time' not in time_info:
-                   time_info['time'] = time
-                   for cn in ['hydro_year', 'hydro_month',
-                              'calendar_year', 'calendar_month']:
-                       time_info[cn] = ds.variables[cn][:]
+                    time_info['time'] = time
+                    for cn in time_keys:
+                        time_info[cn] = ds.variables[cn][:]
                 else:
                     # Here we may need to append or add stuff
                     ot = time_info['time']
@@ -1074,15 +1074,13 @@ def compile_run_output(gdirs, path=True, input_filesuffix='',
                     if time[-1] > ot[-1]:
                         p = np.nonzero(time == ot[-1])[0][0] + 1
                         time_info['time'] = np.append(ot, time[p:])
-                        for cn in ['hydro_year', 'hydro_month',
-                                   'calendar_year', 'calendar_month']:
+                        for cn in time_keys:
                             time_info[cn] = np.append(time_info[cn],
                                                       ds.variables[cn][p:])
                     if time[0] < ot[0]:
                         p = np.nonzero(time == ot[0])[0][0]
                         time_info['time'] = np.append(time[:p], ot)
-                        for cn in ['hydro_year', 'hydro_month',
-                                   'calendar_year', 'calendar_month']:
+                        for cn in time_keys:
                             time_info[cn] = np.append(ds.variables[cn][:p],
                                                       time_info[cn])
 


### PR DESCRIPTION
<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->

Closes https://github.com/OGGM/oggm/issues/1344

This turned out to be quite some work but I think (hope) its worth it. It is not the task of compile_run_output to deal with varying time indices instead of uselessly storing NaNs in flowline model outputs. 

- [x] Tests added/passed
- [ ] Fully documented
- [x] Entry in `whats-new.rst` 
