### PR TITLE
get ref mb profile with constant step size

### DIFF
--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -150,7 +150,7 @@ class TestInitPresentDayFlowline:
 
         mb_profile_constant_dh = gdir.get_ref_mb_profile(constant_dh=True)
         step_dh = mb_profile_constant_dh.columns[1:] - mb_profile_constant_dh.columns[:-1]
-        assert np.all(step_dh==50)
+        assert np.all(step_dh == 50)
         mb_profile_raw = gdir.get_ref_mb_profile()
 
         # Gradient

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -148,16 +148,33 @@ class TestInitPresentDayFlowline:
         # Bias
         assert np.abs(utils.md(tot_mb, refmb)) < 50
 
+        mb_profile_constant_dh = gdir.get_ref_mb_profile(constant_dh=True)
+        step_dh = mb_profile_constant_dh.columns[1:] - mb_profile_constant_dh.columns[:-1]
+        assert np.all(step_dh==50)
+        mb_profile_raw = gdir.get_ref_mb_profile()
+
         # Gradient
-        dfg = gdir.get_ref_mb_profile().mean()
+        dfg = mb_profile_raw.mean()
+        dfg_constant_dh = mb_profile_constant_dh.mean()
+
 
         # Take the altitudes below 3100 and fit a line
-        dfg = dfg[dfg.index < 3100]
         pok = np.where(hgts < 3100)
+        pok_constant_dh = np.where(dfg_constant_dh.index < 3100)
+
+        dfg = dfg[dfg.index < 3100]
+        dfg_constant_dh = dfg_constant_dh[dfg_constant_dh.index < 3100]
+
         from scipy.stats import linregress
         slope_obs, _, _, _, _ = linregress(dfg.index, dfg.values)
+        slope_obs_constant_dh, _, _, _, _ = linregress(dfg_constant_dh.index,
+                                                       dfg_constant_dh.values)
         slope_our, _, _, _, _ = linregress(hgts[pok], grads[pok])
+
         np.testing.assert_allclose(slope_obs, slope_our, rtol=0.15)
+        # the observed MB gradient and the interpolated observed one (with
+        # constant dh) should be very similar!
+        np.testing.assert_allclose(slope_obs, slope_obs_constant_dh, rtol=0.01)
 
 
 @pytest.fixture(scope='class')

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -69,7 +69,7 @@ logger = logging.getLogger('.'.join(__name__.split('.')[:-1]))
 # The given commit will be downloaded from github and used as source for
 # all sample data
 SAMPLE_DATA_GH_REPO = 'OGGM/oggm-sample-data'
-SAMPLE_DATA_COMMIT = 'df250ee69405c2108b6782781d6aa6c22aa3919d'
+SAMPLE_DATA_COMMIT = 'b3777c843a6b44a3bd288a680315adbffbe2e6bb'
 
 GDIR_L1L2_URL = ('https://cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.4/'
                  'L1-L2_files/centerlines/')

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -3252,7 +3252,7 @@ class GlacierDirectory(object):
             # list of years
             self._mbprofdf = pd.read_csv(reff, index_col=0)
 
-        elif self._mbprofdf_cte_dh is None and constant_dh is True:
+        if self._mbprofdf_cte_dh is None and constant_dh:
             flink, mbdatadir = get_wgms_files()
             c = 'RGI{}0_ID'.format(self.rgi_version[0])
             wid = flink.loc[flink[c] == self.rgi_id]

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -3280,7 +3280,7 @@ class GlacierDirectory(object):
             else:
                 # Some files are just empty
                 out = self._mbprofdf
-        elif constant_dh is True:
+        else:
             if len(self._mbprofdf_cte_dh) > 1:
                 out = self._mbprofdf_cte_dh.loc[y0:y1]
             else:

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -3235,7 +3235,7 @@ class GlacierDirectory(object):
             elevation-dependent point MB
         """
 
-        if self._mbprofdf is None and constant_dh is False:
+        if self._mbprofdf is None and not constant_dh:
             flink, mbdatadir = get_wgms_files()
             c = 'RGI{}0_ID'.format(self.rgi_version[0])
             wid = flink.loc[flink[c] == self.rgi_id]

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -2482,6 +2482,7 @@ class GlacierDirectory(object):
         # Optimization
         self._mbdf = None
         self._mbprofdf = None
+        self._mbprofdf_cte_dh = None
 
     def __repr__(self):
 
@@ -3216,7 +3217,7 @@ class GlacierDirectory(object):
             out = self._mbdf
         return out.dropna(subset=['ANNUAL_BALANCE'])
 
-    def get_ref_mb_profile(self, input_filesuffix=''):
+    def get_ref_mb_profile(self, input_filesuffix='', constant_dh=False):
         """Get the reference mb profile data from WGMS (if available!).
 
         Returns None if this glacier has no profile and an Error if it isn't
@@ -3227,10 +3228,14 @@ class GlacierDirectory(object):
         input_filesuffix : str
             input_filesuffix of the climate_historical that should be used. The
             default is to take the climate_historical without input_filesuffix
-
+        constant_dh : boolean
+            If set to True, it outputs the MB profiles with a constant step size
+            of dh=50m by using interpolation. This can be useful for comparisons
+            between years. Default is False which gives the raw
+            elevation-dependent point MB
         """
 
-        if self._mbprofdf is None:
+        if self._mbprofdf is None and constant_dh is False:
             flink, mbdatadir = get_wgms_files()
             c = 'RGI{}0_ID'.format(self.rgi_version[0])
             wid = flink.loc[flink[c] == self.rgi_id]
@@ -3247,16 +3252,40 @@ class GlacierDirectory(object):
             # list of years
             self._mbprofdf = pd.read_csv(reff, index_col=0)
 
+        elif self._mbprofdf_cte_dh is None and constant_dh is True:
+            flink, mbdatadir = get_wgms_files()
+            c = 'RGI{}0_ID'.format(self.rgi_version[0])
+            wid = flink.loc[flink[c] == self.rgi_id]
+            if len(wid) == 0:
+                raise RuntimeError('Not a reference glacier!')
+            wid = wid.WGMS_ID.values[0]
+
+            # file
+            mbdatadir = os.path.join(os.path.dirname(mbdatadir), 'mb_profiles_constant_dh')
+            reff = os.path.join(mbdatadir,
+                                'profile_constant_dh_WGMS-{:05d}.csv'.format(wid))
+            if not os.path.exists(reff):
+                return None
+            # list of years
+            self._mbprofdf_cte_dh = pd.read_csv(reff, index_col=0)
+
         ci = self.get_climate_info(input_filesuffix=input_filesuffix)
         if 'baseline_hydro_yr_0' not in ci:
             raise RuntimeError('Please process some climate data before call')
         y0 = ci['baseline_hydro_yr_0']
         y1 = ci['baseline_hydro_yr_1']
-        if len(self._mbprofdf) > 1:
-            out = self._mbprofdf.loc[y0:y1]
-        else:
-            # Some files are just empty
-            out = self._mbprofdf
+        if constant_dh is False:
+            if len(self._mbprofdf) > 1:
+                out = self._mbprofdf.loc[y0:y1]
+            else:
+                # Some files are just empty
+                out = self._mbprofdf
+        elif constant_dh is True:
+            if len(self._mbprofdf_cte_dh) > 1:
+                out = self._mbprofdf_cte_dh.loc[y0:y1]
+            else:
+                # Some files are just empty
+                out = self._mbprofdf_cte_dh
         out.columns = [float(c) for c in out.columns]
         return out.dropna(axis=1, how='all').dropna(axis=0, how='all')
 

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -3274,7 +3274,7 @@ class GlacierDirectory(object):
             raise RuntimeError('Please process some climate data before call')
         y0 = ci['baseline_hydro_yr_0']
         y1 = ci['baseline_hydro_yr_1']
-        if constant_dh is False:
+        if not constant_dh:
             if len(self._mbprofdf) > 1:
                 out = self._mbprofdf.loc[y0:y1]
             else:


### PR DESCRIPTION
- related to: https://github.com/OGGM/oggm-shop-notebooks/pull/5 and to https://github.com/OGGM/oggm-sample-data/pull/11
- allows to get the interpolated constant step size MB profiles (i.e. altitude difference for all profile levels is dh=50m) via `gdir.get_ref_mb_profile(constant_dh=True)`
- simple test added, but this will only work with the next pull request (with the updated oggm-sample-data download commit number)



- [x] Tests added/passed


