### PR TITLE
adds missing climate keywords to compile_fixed_geometry_mass_balance

### DIFF
--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -1658,7 +1658,7 @@ def compile_fixed_geometry_mass_balance(gdirs, filesuffix='',
         Set to "True" in order  to store the info in the working directory
         Set to a path to store the file to your chosen location (file
         extension matters)
-    csv: bool
+    csv : bool
         Set to store the data in csv instead of hdf.
     use_inversion_flowlines : bool
         whether to use the inversion flowlines or the model flowlines
@@ -1669,7 +1669,7 @@ def compile_fixed_geometry_mass_balance(gdirs, filesuffix='',
         end year of the model run (default: from the climate file)
     years : array of ints
         override ys and ye with the years of your choice
-     climate_filename : str
+    climate_filename : str
         name of the climate file, e.g. 'climate_historical' (default) or
         'gcm_data'
     climate_input_filesuffix: str

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -1640,7 +1640,9 @@ def compile_glacier_statistics(gdirs, filesuffix='', path=True,
 def compile_fixed_geometry_mass_balance(gdirs, filesuffix='',
                                         path=True, csv=False,
                                         use_inversion_flowlines=True,
-                                        ys=None, ye=None, years=None):
+                                        ys=None, ye=None, years=None,
+                                        climate_filename='climate_historical',
+                                        climate_input_filesuffix=''):
     """Compiles a table of specific mass-balance timeseries for all glaciers.
 
     The file is stored in a hdf file (not csv) per default. Use pd.read_hdf
@@ -1667,13 +1669,19 @@ def compile_fixed_geometry_mass_balance(gdirs, filesuffix='',
         end year of the model run (default: from the climate file)
     years : array of ints
         override ys and ye with the years of your choice
+     climate_filename : str
+        name of the climate file, e.g. 'climate_historical' (default) or
+        'gcm_data'
+    climate_input_filesuffix: str
+        filesuffix for the input climate file
     """
     from oggm.workflow import execute_entity_task
     from oggm.core.massbalance import fixed_geometry_mass_balance
 
     out_df = execute_entity_task(fixed_geometry_mass_balance, gdirs,
                                  use_inversion_flowlines=use_inversion_flowlines,
-                                 ys=ys, ye=ye, years=years)
+                                 ys=ys, ye=ye, years=years, climate_filename=climate_filename,
+                                 climate_input_filesuffix=climate_input_filesuffix)
 
     for idx, s in enumerate(out_df):
         if s is None:


### PR DESCRIPTION
This PR adds the missing keywords `climate_file` and `climate_input_filesuffix` to the `compile_fixed_geometry_mass_balance` function. 
