### PR TITLE
option to get mb profile with specific obs_ratio_needed

### DIFF
--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -153,29 +153,45 @@ class TestInitPresentDayFlowline:
         assert np.all(step_dh == 50)
         mb_profile_raw = gdir.get_ref_mb_profile()
 
+        mb_profile_constant_dh_filtered_0_6 = gdir.get_ref_mb_profile(constant_dh=True, obs_ratio_needed=0.6)
+        mb_profile_constant_dh_filtered_1= gdir.get_ref_mb_profile(constant_dh=True, obs_ratio_needed=1)
+        n = len(mb_profile_constant_dh.index)
+        n_obs_h_0_6 = mb_profile_constant_dh_filtered_0_6.describe().loc['count']
+        n_obs_h_1 = mb_profile_constant_dh_filtered_1.describe().loc['count']
+        assert np.all(n_obs_h_0_6 / n >= 0.6)
+        assert np.all(n_obs_h_1 / n >= 1)
+
+        # fake "filter" that is not really filtering should give the same estimate as default (filter = 0)
+        mb_profile_constant_dh_filtered_0 = gdir.get_ref_mb_profile(constant_dh=True, obs_ratio_needed=0.00001)
+        np.testing.assert_allclose(mb_profile_constant_dh_filtered_0, mb_profile_constant_dh)
+
         # Gradient
         dfg = mb_profile_raw.mean()
         dfg_constant_dh = mb_profile_constant_dh.mean()
-
+        dfg_constant_dh_0_6 = mb_profile_constant_dh_filtered_0_6.mean()
 
         # Take the altitudes below 3100 and fit a line
         pok = np.where(hgts < 3100)
-        pok_constant_dh = np.where(dfg_constant_dh.index < 3100)
 
         dfg = dfg[dfg.index < 3100]
         dfg_constant_dh = dfg_constant_dh[dfg_constant_dh.index < 3100]
+        dfg_constant_dh_0_6 = dfg_constant_dh_0_6[dfg_constant_dh_0_6.index < 3100]
 
         from scipy.stats import linregress
         slope_obs, _, _, _, _ = linregress(dfg.index, dfg.values)
         slope_obs_constant_dh, _, _, _, _ = linregress(dfg_constant_dh.index,
                                                        dfg_constant_dh.values)
+        slope_obs_constant_dh_0_6, _, _, _, _ = linregress(dfg_constant_dh_0_6.index,
+                                                       dfg_constant_dh_0_6.values)
         slope_our, _, _, _, _ = linregress(hgts[pok], grads[pok])
 
         np.testing.assert_allclose(slope_obs, slope_our, rtol=0.15)
         # the observed MB gradient and the interpolated observed one (with
         # constant dh) should be very similar!
         np.testing.assert_allclose(slope_obs, slope_obs_constant_dh, rtol=0.01)
-
+        # the filtered slope with obs_ratio_0_6 should be at least a bit similar to
+        # the one where all elevation band measurements are taken into account
+        np.testing.assert_allclose(slope_obs_constant_dh, slope_obs_constant_dh_0_6, rtol=0.2)
 
 @pytest.fixture(scope='class')
 def other_glacier_cfg():

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -3281,7 +3281,7 @@ class GlacierDirectory(object):
         obs_ratio_needed : float
             necessary relative amount of observations per elevation band in order
             to be included in the MB profile (0<=obs_ratio_needed<=1).
-            If obs_ratio_needed set to 0, the ouput shows all elevation-band
+            If obs_ratio_needed set to 0, the output shows all elevation-band
             observations (default is 0).
             When estimating mean MB profiles, it is advisable to set obs_ratio_needed
             to 0.6. E.g. if there are in total 5 years of measurements only those elevation

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -3262,7 +3262,7 @@ class GlacierDirectory(object):
             out = self._mbdf
         return out.dropna(subset=['ANNUAL_BALANCE'])
 
-    def get_ref_mb_profile(self, input_filesuffix='', constant_dh=False):
+    def get_ref_mb_profile(self, input_filesuffix='', constant_dh=False, obs_ratio_needed=0):
         """Get the reference mb profile data from WGMS (if available!).
 
         Returns None if this glacier has no profile and an Error if it isn't
@@ -3278,9 +3278,26 @@ class GlacierDirectory(object):
             of dh=50m by using interpolation. This can be useful for comparisons
             between years. Default is False which gives the raw
             elevation-dependent point MB
+        obs_ratio_needed : float
+            necessary relative amount of observations per elevation band in order
+            to be included in the MB profile (0<=obs_ratio_needed<=1).
+            If obs_ratio_needed set to 0, the ouput shows all elevation-band
+            observations (default is 0).
+            When estimating mean MB profiles, it is advisable to set obs_ratio_needed
+            to 0.6. E.g. if there are in total 5 years of measurements only those elevation
+            bands with at least 3 years of measurements are used. If obs_ratio_needed is not
+            0, constant_dh has to be set to True.
         """
 
-        if self._mbprofdf is None and not constant_dh:
+        if obs_ratio_needed != 0 and constant_dh is False:
+            raise InvalidParamsError('If a filter is applied, you have to set'
+                                     ' constant_dh to True')
+        if obs_ratio_needed<0 or obs_ratio_needed>1:
+            raise InvalidParamsError('obs_ratio_needed is the ratio of necessary relative amount'
+                                     'of observations per elevation band. It has to be between'
+                                     '0 and 1!')
+
+        if self._mbprofdf is None and constant_dh is False:
             flink, mbdatadir = get_wgms_files()
             c = 'RGI{}0_ID'.format(self.rgi_version[0])
             wid = flink.loc[flink[c] == self.rgi_id]
@@ -3297,7 +3314,7 @@ class GlacierDirectory(object):
             # list of years
             self._mbprofdf = pd.read_csv(reff, index_col=0)
 
-        if self._mbprofdf_cte_dh is None and constant_dh:
+        elif self._mbprofdf_cte_dh is None and constant_dh is True:
             flink, mbdatadir = get_wgms_files()
             c = 'RGI{}0_ID'.format(self.rgi_version[0])
             wid = flink.loc[flink[c] == self.rgi_id]
@@ -3319,20 +3336,32 @@ class GlacierDirectory(object):
             raise RuntimeError('Please process some climate data before call')
         y0 = ci['baseline_hydro_yr_0']
         y1 = ci['baseline_hydro_yr_1']
-        if not constant_dh:
+        if constant_dh is False:
             if len(self._mbprofdf) > 1:
                 out = self._mbprofdf.loc[y0:y1]
             else:
                 # Some files are just empty
                 out = self._mbprofdf
-        else:
+        elif constant_dh is True:
             if len(self._mbprofdf_cte_dh) > 1:
                 out = self._mbprofdf_cte_dh.loc[y0:y1]
+                if obs_ratio_needed != 0:
+                    # amount of years with any observation
+                    n_obs = len(out.index)
+                    # amount of years with observations for each elevation band
+                    n_obs_h = out.describe().loc['count']
+                    # relative amount of observations per elevation band
+                    rel_obs_h = n_obs_h / n_obs
+                    # select only those elevation bands with a specific ratio
+                    # of years with available measurements
+                    out = out[rel_obs_h[rel_obs_h >= obs_ratio_needed].index]
+
             else:
                 # Some files are just empty
                 out = self._mbprofdf_cte_dh
         out.columns = [float(c) for c in out.columns]
         return out.dropna(axis=1, how='all').dropna(axis=0, how='all')
+
 
     def get_ref_length_data(self):
         """Get the glacier length data from P. Leclercq's data base.


### PR DESCRIPTION
I added the option of setting a necessary relative amount of observations per elevation band in order to be included in the MB profile (0<=obs_ratio_needed<=1). This is now an argument inside of `gdir.get_ref_mb_profile(obs_ratio_needed=0)`.  It acts like a filter: When estimating mean MB profiles, it is advisable to set obs_ratio_needed to 0.6. E.g. if there are in total 5 years of measurements only those elevation bands with at least 3 years of measurements are used. Some tests are added. 

- [x] Tests added/passed


