### PR TITLE
renamed ys to spinup_start_yr in dynamic_spinup

### DIFF
--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -606,7 +606,7 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
         workflow.execute_entity_task(tasks.run_dynamic_spinup, gdirs,
                                      evolution_model=evolution_model,
                                      minimise_for=dynamic_spinup,
-                                     ys=dynamic_spinup_start_year,
+                                     spinup_start_yr=dynamic_spinup_start_year,
                                      spinup_period=None,
                                      output_filesuffix='_dynamic_spinup',
                                      )

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -3760,7 +3760,7 @@ def run_dynamic_spinup(gdir, init_model_filesuffix=None,
                        init_model_fls=None,
                        climate_input_filesuffix='',
                        evolution_model=FluxBasedModel,
-                       spinup_period=20, ys=None, min_spinup_period=10,
+                       spinup_period=20, spinup_start_yr=None, min_spinup_period=10,
                        yr_rgi=None, minimise_for='area', precision_percent=1,
                        first_guess_t_bias=-2, t_bias_max_step_length=2,
                        maxiter=30, output_filesuffix='_dynamic_spinup',
@@ -3789,18 +3789,18 @@ def run_dynamic_spinup(gdir, init_model_filesuffix=None,
         filesuffix for the input climate file
     evolution_model : :class:oggm.core.FlowlineModel
         which evolution model to use. Default: FluxBasedModel
-    spinup_period : int or None
+    spinup_period : int
         The period how long the spinup should run. Start date of historical run
         is defined "yr_rgi - spinup_period". Minimum allowed value is 10. If
         the provided climate data starts at year later than
         (yr_rgi - spinup_period) the spinup_period is set to
-        (yr_rgi - yr_climate_start). Caution only spinup_period OR ys can be
-        given (the other must be None).
+        (yr_rgi - yr_climate_start). Caution if spinup_start_yr is set the
+        spinup_period is ignored.
         Default is 20.
-    ys : int or None
+    spinup_start_yr : int or None
         The start year of the dynamic spinup. If the provided year is before
         the provided climate data starts the year of the climate data is used.
-        Caution only spinup_period OR ys can be given (the other must be None).
+        If set it overrides the spinup_period.
         Default is None.
     min_spinup_period : int
         If the dynamic spinup function fails with the initial 'spinup_period'
@@ -3856,12 +3856,6 @@ def run_dynamic_spinup(gdir, init_model_filesuffix=None,
         The final dynamically spined-up model. Type depends on the selected
         evolution_model, by default a FluxBasedModel.
     """
-
-    # Check that only one of spinup_period OR ys is given
-    if spinup_period is not None and ys is not None:
-        raise InvalidParamsError('Only spinup_period OR ys is allowed!')
-    if spinup_period is None and ys is None:
-        raise InvalidParamsError('One of spinup_period OR ys must be provided!')
 
     if yr_rgi is None:
         yr_rgi = gdir.rgi_date + 1  # + 1 converted to hydro years
@@ -4323,10 +4317,10 @@ def run_dynamic_spinup(gdir, init_model_filesuffix=None,
     # (first a spinup period between initial period and 'min_spinup_period'
     # years and the second try is to use a period of 'min_spinup_period' years,
     # if it still fails the actual error is raised)
-    if spinup_period is not None:
-        spinup_period_initial = min(spinup_period, yr_rgi - yr_min)
+    if spinup_start_yr is not None:
+        spinup_period_initial = min(yr_rgi - spinup_start_yr, yr_rgi - yr_min)
     else:
-        spinup_period_initial = min(yr_rgi - ys, yr_rgi - yr_min)
+        spinup_period_initial = min(spinup_period, yr_rgi - yr_min)
     if spinup_period_initial <= min_spinup_period:
         spinup_periods_to_try = [min_spinup_period]
     else:

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -3297,7 +3297,7 @@ class TestHEF:
 
     @pytest.mark.parametrize('minimise_for', ['area', 'volume'])
     @pytest.mark.slow
-    def test_dynamic_spinup(self, hef_gdir, hef_copy_gdir, minimise_for):
+    def test_dynamic_spinup(self, hef_gdir, minimise_for):
 
         # value we want to match after dynamic spinup
         fls = hef_gdir.read_pickle('model_flowlines')
@@ -3368,40 +3368,23 @@ class TestHEF:
             assert fmod.last_yr == yr_rgi
             assert len(model_dynamic_spinup.fls) == len(fmod.fls)
 
-        # test if ys is handled correctly
-        ys = yr_rgi - 20
+        # test if spinup_start_yr is handled correctly and overrides the spinup_period
+        spinup_start_yr = yr_rgi - 20
         model_dynamic_spinup_ys = run_dynamic_spinup(
             hef_gdir,
-            spinup_period=None,
-            ys=ys,
+            spinup_period=40,
+            spinup_start_yr=spinup_start_yr,
             yr_rgi=yr_rgi,
             minimise_for=minimise_for,
             precision_percent=precision_percent,
             output_filesuffix='_dynamic_spinup_ys',)
-        # check that is the same if we provide ys instead of spinup_period
+        # check that is the same if we provide spinup_start_yr instead of spinup_period
         assert np.isclose(model_dynamic_spinup_ys.volume_km3,
                           model_dynamic_spinup.volume_km3)
         assert np.isclose(model_dynamic_spinup_ys.area_km2,
                           model_dynamic_spinup.area_km2)
         assert np.isclose(model_dynamic_spinup_ys.yr,
                           model_dynamic_spinup.yr)
-        # check that the right errors are raised if none or if both are given,
-        # using hef_copy_gdir here to not generate a 'error_msg' in hef_gdir,
-        # this would cause the test_output_management to fail
-        with pytest.raises(InvalidParamsError,
-                           match='Only spinup_period OR ys is allowed!'):
-            run_dynamic_spinup(hef_copy_gdir,
-                               spinup_period=20,
-                               ys=ys,
-                               yr_rgi=yr_rgi,
-                               minimise_for=minimise_for,)
-        with pytest.raises(InvalidParamsError,
-                           match='One of spinup_period OR ys must be provided!'):
-            run_dynamic_spinup(hef_copy_gdir,
-                               spinup_period=None,
-                               ys=None,
-                               yr_rgi=yr_rgi,
-                               minimise_for=minimise_for,)
 
         # Here start with test if errors are handled correctly by the dynamic
         # spinup function and if 'ignore_errors' works


### PR DESCRIPTION
Renamed `ys` to `spinup_start_yr` in dynamic_spinup function, and if set it overrides the `spinup_period`. I also chaged ys in the `run_prepro_levels` function. Lets see if all tests pass...

- [x] Tests added/passed
- [ ] Fully documented
- [ ] Entry in `whats-new.rst` 
