### PR TITLE
Adds new functionalities to dynamic spinup

### DIFF
--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -3762,7 +3762,7 @@ def run_dynamic_spinup(gdir, init_model_filesuffix=None,
                        evolution_model=FluxBasedModel,
                        spinup_period=20, spinup_start_yr=None, min_spinup_period=10,
                        yr_rgi=None, minimise_for='area', precision_percent=1,
-                       precision_min_absolute=1, min_ice_thickness=10,
+                       precision_absolute=1, min_ice_thickness=10,
                        first_guess_t_bias=-2, t_bias_max_step_length=2,
                        maxiter=30, output_filesuffix='_dynamic_spinup',
                        store_model_geometry=True, store_fl_diagnostics=None,
@@ -3819,14 +3819,14 @@ def run_dynamic_spinup(gdir, init_model_filesuffix=None,
         Gives the precision we want to match in percent. The algorithm makes
         sure that the resulting relative mismatch is smaller than
         precision_percent, but also that the absolute value is smaller than
-        precision_min_absolute.
+        precision_absolute.
         Default is 1, meaning the difference must be within 1% of the given
         value (area or volume).
-    precision_min_absolute : float
+    precision_absolute : float
         Gives an minimum absolute value to match. The algorithm makes sure that
         the resulting relative mismatch is smaller than precision_percent, but
-        also that the absolute value is smaller than precision_min_absolute.
-        The unit of precision_min_absolute depends on minimise_for (if 'area' in
+        also that the absolute value is smaller than precision_absolute.
+        The unit of precision_absolute depends on minimise_for (if 'area' in
         km2, if 'volume' in km3)
         Default is 1.
     min_ice_thickness : float
@@ -4002,9 +4002,9 @@ def run_dynamic_spinup(gdir, init_model_filesuffix=None,
                                     for f in fls_ref])
 
     # here we adjust the used precision_percent to make sure the resulting
-    # absolute mismatch is smaller than precision_min_absolute
+    # absolute mismatch is smaller than precision_absolute
     precision_percent = min(precision_percent,
-                            precision_min_absolute / reference_value * 100)
+                            precision_absolute / reference_value * 100)
 
     # only used to check performance of function
     forward_model_runs = [0]

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -4001,6 +4001,15 @@ def run_dynamic_spinup(gdir, init_model_filesuffix=None,
     other_reference_value = np.sum([getattr(f, f'{other_variable}_{other_unit}')
                                     for f in fls_ref])
 
+    # if reference value is zero no dynamic spinup is possible
+    if reference_value == 0.:
+        if ignore_errors:
+            model_dynamic_spinup_end = save_model_without_dynamic_spinup()
+            return model_dynamic_spinup_end
+        else:
+            raise RuntimeError('The given reference value is Zero, no dynamic '
+                               'spinup possible!')
+
     # here we adjust the used precision_percent to make sure the resulting
     # absolute mismatch is smaller than precision_absolute
     precision_percent = min(precision_percent,
@@ -4151,11 +4160,6 @@ def run_dynamic_spinup(gdir, init_model_filesuffix=None,
                    (iteration < max_iterations)):
                 try:
                     tmp_mismatch, is_ice_free_spinup = fct_to_minimise(t_bias)
-
-                    # check if mismatch is inf -> reference value is 0
-                    if np.isinf(tmp_mismatch):
-                        raise RuntimeError('Mismatch is INF, this indicates '
-                                           'that the reference value is 0.!')
 
                     # no error occurred, so we are not outside the domain
                     is_out_of_domain = False

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -3425,8 +3425,8 @@ class TestHEF:
             'RGI60-04.05259': 'The difference between the rgi_date '
                               'and the start year of the climate data is to '
                               'small to run a dynamic spinup!',
-            'RGI60-04.00381': 'Mismatch is INF, this indicates '
-                              'that the reference value is 0.!',
+            'RGI60-04.00381': 'The given reference value is Zero, no dynamic '
+                              'spinup possible!',
             'RGI60-04.00331': 'Could not find mismatch smaller'
                               f' {precision_percent}%',
             'RGI60-04.07198': 'Not able to minimise! Problem is unknown, '

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -80,13 +80,13 @@ class TestInitPresentDayFlowline:
             np.testing.assert_allclose(ref, fl.dis_on_line,
                                        rtol=0.001,
                                        atol=0.01)
-            assert(len(fl.surface_h) ==
-                   len(fl.bed_h) ==
-                   len(fl.bed_shape) ==
-                   len(fl.dis_on_line) ==
-                   len(fl.widths) ==
-                   len(fl.bin_area_m2)
-                   )
+            assert (len(fl.surface_h) ==
+                    len(fl.bed_h) ==
+                    len(fl.bed_shape) ==
+                    len(fl.dis_on_line) ==
+                    len(fl.widths) ==
+                    len(fl.bin_area_m2)
+                    )
 
             assert np.all(fl.widths >= 0)
             vol += fl.volume_m3
@@ -196,6 +196,7 @@ class TestInitPresentDayFlowline:
         # the one where all elevation band measurements are taken into account
         np.testing.assert_allclose(slope_obs_constant_dh, slope_obs_constant_dh_0_6, rtol=0.2)
 
+
 @pytest.fixture(scope='class')
 def other_glacier_cfg():
     cfg.initialize()
@@ -241,14 +242,14 @@ class TestInitFlowlineOtherGlacier:
         myarea = 0.
         cls = gdir.read_pickle('inversion_flowlines')
         for cl in cls:
-            myarea += np.sum(cl.widths * cl.dx * gdir.grid.dx**2)
+            myarea += np.sum(cl.widths * cl.dx * gdir.grid.dx ** 2)
 
         np.testing.assert_allclose(myarea, gdir.rgi_area_m2, rtol=1e-2)
 
         myarea = 0.
         cls = gdir.read_pickle('inversion_flowlines')
         for cl in cls:
-            myarea += np.sum(cl.widths * cl.dx * gdir.grid.dx**2)
+            myarea += np.sum(cl.widths * cl.dx * gdir.grid.dx ** 2)
 
         np.testing.assert_allclose(myarea, gdir.rgi_area_m2, rtol=1e-2)
 
@@ -262,11 +263,11 @@ class TestInitFlowlineOtherGlacier:
             np.testing.assert_allclose(ref, fl.dis_on_line,
                                        rtol=0.001,
                                        atol=0.01)
-            assert(len(fl.surface_h) ==
-                   len(fl.bed_h) ==
-                   len(fl.bed_shape) ==
-                   len(fl.dis_on_line) ==
-                   len(fl.widths))
+            assert (len(fl.surface_h) ==
+                    len(fl.bed_h) ==
+                    len(fl.bed_shape) ==
+                    len(fl.dis_on_line) ==
+                    len(fl.widths))
 
             assert np.all(fl.widths >= 0)
             vol += fl.volume_km3
@@ -274,7 +275,7 @@ class TestInitFlowlineOtherGlacier:
 
         rtol = 0.08
         np.testing.assert_allclose(gdir.rgi_area_km2, area, rtol=rtol)
-        np.testing.assert_allclose(v*1e-9, vol, rtol=rtol)
+        np.testing.assert_allclose(v * 1e-9, vol, rtol=rtol)
 
 
 class TestMassBalanceModels:
@@ -300,7 +301,7 @@ class TestMassBalanceModels:
                                                       year_range=yrp)
 
         mb_mod = massbalance.PastMassBalance(gdir, bias=0)
-        for i, yr in enumerate(np.arange(yrp[0], yrp[1]+1)):
+        for i, yr in enumerate(np.arange(yrp[0], yrp[1] + 1)):
             ref_mb_on_h = p[:, i] - mu_star * t[:, i]
             my_mb_on_h = mb_mod.get_annual_mb(h, yr) * F
             np.testing.assert_allclose(ref_mb_on_h, my_mb_on_h,
@@ -310,7 +311,7 @@ class TestMassBalanceModels:
             assert_allclose(totest[0], 0, atol=1)
 
         mb_mod = massbalance.PastMassBalance(gdir)
-        for i, yr in enumerate(np.arange(yrp[0], yrp[1]+1)):
+        for i, yr in enumerate(np.arange(yrp[0], yrp[1] + 1)):
             ref_mb_on_h = p[:, i] - mu_star * t[:, i]
             my_mb_on_h = mb_mod.get_annual_mb(h, yr) * F
             np.testing.assert_allclose(ref_mb_on_h, my_mb_on_h + bias,
@@ -319,10 +320,10 @@ class TestMassBalanceModels:
             totest = mb_mod.get_annual_mb([ela_z], year=yr) * F
             assert_allclose(totest[0], 0, atol=1)
 
-        for i, yr in enumerate(np.arange(yrp[0], yrp[1]+1)):
+        for i, yr in enumerate(np.arange(yrp[0], yrp[1] + 1)):
 
             ref_mb_on_h = p[:, i] - mu_star * t[:, i]
-            my_mb_on_h = ref_mb_on_h*0.
+            my_mb_on_h = ref_mb_on_h * 0.
             for m in np.arange(12):
                 yrm = utils.date_to_floatyear(yr, m + 1)
                 tmp = mb_mod.get_monthly_mb(h, yrm) * SEC_IN_MONTH * rho
@@ -762,16 +763,16 @@ class TestMassBalanceModels:
         np.testing.assert_allclose(np.std(mb_ts), np.std(mb_ts2), rtol=0.1)
 
         # Monthly
-        time = pd.date_range('1/1/1973', periods=31*12, freq='MS')
+        time = pd.date_range('1/1/1973', periods=31 * 12, freq='MS')
         yrs = utils.date_to_floatyear(time.year, time.month)
 
         ref_mb = np.zeros(12)
         my_mb = np.zeros(12)
         for yr, m in zip(yrs, time.month):
-            ref_mb[m-1] += np.average(mb_ref.get_monthly_mb(h, yr) *
-                                      SEC_IN_MONTH, weights=w)
-            my_mb[m-1] += np.average(mb_mod.get_monthly_mb(h, yr) *
-                                     SEC_IN_MONTH, weights=w)
+            ref_mb[m - 1] += np.average(mb_ref.get_monthly_mb(h, yr) *
+                                        SEC_IN_MONTH, weights=w)
+            my_mb[m - 1] += np.average(mb_mod.get_monthly_mb(h, yr) *
+                                       SEC_IN_MONTH, weights=w)
         my_mb = my_mb / 31
         ref_mb = ref_mb / 31
         assert utils.rmsd(ref_mb, my_mb) < 0.1
@@ -855,17 +856,17 @@ class TestMassBalanceModels:
 
         # test uniqueness
         # size
-        assert(len(list(mb_mod._state_yr.values())) ==
-               np.unique(list(mb_mod._state_yr.values())).size)
+        assert (len(list(mb_mod._state_yr.values())) ==
+                np.unique(list(mb_mod._state_yr.values())).size)
         # size2
-        assert(len(list(mb_mod2._state_yr.values())) ==
-               np.unique(list(mb_mod2._state_yr.values())).size)
+        assert (len(list(mb_mod2._state_yr.values())) ==
+                np.unique(list(mb_mod2._state_yr.values())).size)
         # state years 1 vs 2
-        assert(np.all(np.unique(list(mb_mod._state_yr.values())) ==
-                      np.unique(list(mb_mod2._state_yr.values()))))
+        assert (np.all(np.unique(list(mb_mod._state_yr.values())) ==
+                       np.unique(list(mb_mod2._state_yr.values()))))
         # state years 1 vs reference model
-        assert(np.all(np.unique(list(mb_mod._state_yr.values())) ==
-                      ref_mod.years))
+        assert (np.all(np.unique(list(mb_mod._state_yr.values())) ==
+                       ref_mod.years))
 
         # test ela vs specific mb
         elats = mb_mod.get_ela(yrs[:200])
@@ -982,7 +983,7 @@ class TestMassBalanceModels:
         h, w = gdir.get_inversion_flowline_hw()
 
         # Climate period, 10 day timestep
-        yrs = np.arange(1850, 2003, 10/365)
+        yrs = np.arange(1850, 2003, 10 / 365)
 
         # models
         start_time = time.time()
@@ -1033,6 +1034,7 @@ class TestMassBalanceModels:
         # before, the 21-year period was matched instead of the 20-year period
         # mb_modelled_wrong = mb.get_specific_mb(h, w, year=np.arange(1999,2020,1))
         # np.testing.assert_allclose(ref_mb_geodetic, mb_modelled.mean())
+
 
 class TestModelFlowlines():
 
@@ -1104,12 +1106,12 @@ class TestModelFlowlines():
 
         # More adventurous
         rec.section = section / 2
-        assert_allclose(rec.thick, thick/2)
+        assert_allclose(rec.thick, thick / 2)
         assert_allclose(rec.widths, widths)
         assert_allclose(rec.widths_m, widths_m)
-        assert_allclose(rec.section, section/2)
+        assert_allclose(rec.section, section / 2)
         assert_allclose(rec.area_m2, area_m2.sum())
-        assert_allclose(rec.volume_m3, (vol_m3/2).sum())
+        assert_allclose(rec.volume_m3, (vol_m3 / 2).sum())
 
         # Water level
         rec = RectangularBedFlowline(line=line, dx=dx, map_dx=map_dx,
@@ -1142,7 +1144,7 @@ class TestModelFlowlines():
         widths[:30] = 40
         widths[-30:] = 10
 
-        lambdas = bed_h*0.
+        lambdas = bed_h * 0.
         is_trap = np.ones(len(lambdas), dtype=bool)
 
         # tests
@@ -1202,12 +1204,12 @@ class TestModelFlowlines():
 
             # More adventurous
             rec.section = section / 2
-            assert_allclose(rec.thick, thick/2)
+            assert_allclose(rec.thick, thick / 2)
             assert_allclose(rec.widths, widths)
             assert_allclose(rec.widths_m, widths_m)
-            assert_allclose(rec.section, section/2)
+            assert_allclose(rec.section, section / 2)
             assert_allclose(rec.area_m2, area_m2.sum())
-            assert_allclose(rec.volume_m3, (vol_m3/2).sum())
+            assert_allclose(rec.volume_m3, (vol_m3 / 2).sum())
 
     def test_trapeze_mixed_lambda1(self):
 
@@ -1227,7 +1229,7 @@ class TestModelFlowlines():
         widths_0[:30] = 40
         widths_0[-30:] = 10
 
-        lambdas = bed_h*0. + 1
+        lambdas = bed_h * 0. + 1
 
         # tests
         thick = surface_h - bed_h
@@ -1299,7 +1301,7 @@ class TestModelFlowlines():
         surface_h[:20] += 50
         surface_h[-20:] -= 80
 
-        shapes = bed_h*0. + 0.003
+        shapes = bed_h * 0. + 0.003
         shapes[:30] = 0.002
         shapes[-30:] = 0.004
 
@@ -1355,7 +1357,7 @@ class TestModelFlowlines():
         surface_h[:20] += 50
         surface_h[-20:] -= 80
 
-        shapes = bed_h*0. + 0.003
+        shapes = bed_h * 0. + 0.003
         shapes[:30] = 0.002
         shapes[-30:] = 0.004
 
@@ -1423,7 +1425,7 @@ class TestModelFlowlines():
         widths_0[:30] = 40
         widths_0[-30:] = 10
 
-        lambdas = bed_h*0. + 1
+        lambdas = bed_h * 0. + 1
         lambdas[0:50] = 0
 
         thick = surface_h - bed_h
@@ -1436,7 +1438,7 @@ class TestModelFlowlines():
                                       bed_h=bed_h, widths=widths,
                                       lambdas=lambdas)
 
-        shapes = bed_h*0. + 0.003
+        shapes = bed_h * 0. + 0.003
         shapes[-30:] = 0.004
 
         # tests
@@ -2185,7 +2187,7 @@ class TestIdealisedInversion():
 
         inv = inversion_gdir.read_pickle('inversion_output')[-1]
         bed_shape_gl = 4 * inv['thick'] / \
-            (flo.widths * inversion_gdir.grid.dx) ** 2
+                       (flo.widths * inversion_gdir.grid.dx) ** 2
         bed_shape_ref = (4 * fl.thick[pg] /
                          (flo.widths * inversion_gdir.grid.dx) ** 2)
 
@@ -2266,7 +2268,7 @@ class TestIdealisedInversion():
 
         inv = inversion_gdir.read_pickle('inversion_output')[-1]
         bed_shape_gl = 4 * inv['thick'] / \
-            (flo.widths * inversion_gdir.grid.dx) ** 2
+                       (flo.widths * inversion_gdir.grid.dx) ** 2
         bed_shape_ref = (4 * fl.thick[pg] /
                          (flo.widths * inversion_gdir.grid.dx) ** 2)
 
@@ -2326,7 +2328,7 @@ class TestIdealisedInversion():
 
         inv = inversion_gdir.read_pickle('inversion_output')[-1]
         bed_shape_gl = 4 * inv['thick'] / \
-            (flo.widths * inversion_gdir.grid.dx) ** 2
+                       (flo.widths * inversion_gdir.grid.dx) ** 2
         bed_shape_ref = (4 * fl.thick[pg] /
                          (flo.widths * inversion_gdir.grid.dx) ** 2)
 
@@ -2736,7 +2738,7 @@ class TestIdealisedInversion():
         assert v > model.volume_m3
         ocls = inversion_gdir.read_pickle('inversion_output')
         ithick = ocls[0]['thick']
-        assert np.mean(ithick) > np.mean(model.fls[0].thick)*1.1
+        assert np.mean(ithick) > np.mean(model.fls[0].thick) * 1.1
         if do_plot:  # pragma: no cover
             self.simple_plot(model, inversion_gdir)
 
@@ -2766,12 +2768,12 @@ class TestIdealisedInversion():
         assert_allclose(v, model.volume_m3, rtol=0.01)
 
         inv = inversion_gdir.read_pickle('inversion_output')[-1]
-        bed_shape_gl = 4*inv['thick']/(flo.widths*inversion_gdir.grid.dx)**2
+        bed_shape_gl = 4 * inv['thick'] / (flo.widths * inversion_gdir.grid.dx) ** 2
 
         ithick = inv['thick']
         fls = dummy_parabolic_bed(map_dx=inversion_gdir.grid.dx,
                                   from_other_shape=bed_shape_gl[:-2],
-                                  from_other_bed=(sh-ithick)[:-2])
+                                  from_other_bed=(sh - ithick)[:-2])
         model2 = FluxBasedModel(fls, mb_model=mb, y0=0.)
         model2.run_until_equilibrium()
         assert_allclose(model2.volume_m3, model.volume_m3, rtol=0.01)
@@ -3321,6 +3323,7 @@ class TestHEF:
         # this value is chosen in a way that it effects the result in the 'area'
         # run but not in the 'volume' run
         precision_min_absolute = 0.1
+        min_ice_thickness = 10
         assert hef_gdir.rgi_date == 2003
         # is needed because the test climate dataset has ye = 2003 (in hydro
         # years would be 2004)
@@ -3334,13 +3337,24 @@ class TestHEF:
                 minimise_for=minimise_for,
                 precision_percent=precision_percent,
                 precision_min_absolute=precision_min_absolute,
+                min_ice_thickness=min_ice_thickness,
                 output_filesuffix='_dynamic_spinup',
                 store_model_evolution=store_model_evolution)
 
             # check if resulting model match wanted value with prescribed precision
-            assert np.isclose(getattr(model_dynamic_spinup, var_name), ref_value,
-                              rtol=precision_percent/100, atol=0)
-            assert np.isclose(getattr(model_dynamic_spinup, var_name), ref_value,
+            if var_name == 'area_km2':
+                model_value = np.sum(
+                    [np.sum(fl.bin_area_m2[fl.thick > min_ice_thickness])
+                     for fl in model_dynamic_spinup.fls]) * 1e-6
+            elif var_name == 'volume_km3':
+                model_value = np.sum(
+                    [np.sum((fl.section * fl.dx_meter)[fl.thick > min_ice_thickness])
+                     for fl in model_dynamic_spinup.fls]) * 1e-9
+            else:
+                raise NotImplementedError(f'{var_name}')
+            assert np.isclose(model_value, ref_value,
+                              rtol=precision_percent / 100, atol=0)
+            assert np.isclose(model_value, ref_value,
                               rtol=0, atol=precision_min_absolute)
             assert model_dynamic_spinup.yr == yr_rgi
             assert len(model_dynamic_spinup.fls) == len(fls)
@@ -3389,7 +3403,8 @@ class TestHEF:
             minimise_for=minimise_for,
             precision_percent=precision_percent,
             precision_min_absolute=precision_min_absolute,
-            output_filesuffix='_dynamic_spinup_ys',)
+            min_ice_thickness=min_ice_thickness,
+            output_filesuffix='_dynamic_spinup_ys', )
         # check that is the same if we provide spinup_start_yr instead of spinup_period
         assert np.isclose(model_dynamic_spinup_ys.volume_km3,
                           model_dynamic_spinup.volume_km3)
@@ -3446,12 +3461,13 @@ class TestHEF:
             # not all combinations raise an error, but still test special cases
             if (((minimise_for == 'area') &
                  (gdir.rgi_id == 'RGI60-04.07198')) |
-                ((minimise_for == 'volume') &
-                 (gdir.rgi_id in ['RGI60-04.00044', 'RGI60-02.09397',
-                                  'RGI60-04.00331']))):
+                    ((minimise_for == 'volume') &
+                     (gdir.rgi_id in ['RGI60-04.00044', 'RGI60-02.09397',
+                                      'RGI60-04.00331']))):
                 run_dynamic_spinup(gdir,
                                    minimise_for=minimise_for,
                                    precision_percent=precision_percent,
+                                   min_ice_thickness=0,
                                    output_filesuffix='_dynamic_spinup',
                                    maxiter=10,
                                    ignore_errors=ignore_errors,
@@ -3463,6 +3479,7 @@ class TestHEF:
                     run_dynamic_spinup(gdir,
                                        minimise_for=minimise_for,
                                        precision_percent=precision_percent,
+                                       min_ice_thickness=0,
                                        output_filesuffix='_dynamic_spinup',
                                        maxiter=10,
                                        ignore_errors=ignore_errors,
@@ -3473,7 +3490,7 @@ class TestHEF:
                                  'model_diagnostics']:
                     assert not os.path.exists(
                         gdir.get_filepath(filename,
-                                          filesuffix='_dynamic_spinup',))
+                                          filesuffix='_dynamic_spinup', ))
 
         # check that ignore_error is working correctly
         ignore_errors = True
@@ -3531,7 +3548,6 @@ class TestHEF:
         fh = gdir.get_filepath('climate_historical')
         fcesm = gdir.get_filepath('gcm_data')
         with xr.open_dataset(fh) as hist, xr.open_dataset(fcesm) as cesm:
-
             # Let's do some basic checks
             shist = hist.sel(time=slice('1961', '1990'))
             scesm = cesm.sel(time=slice('1961', '1990'))
@@ -3609,7 +3625,7 @@ class TestHEF:
         ds3 = utils.compile_run_output([gdir], path=False,
                                        input_filesuffix='_afterspinup')
         assert (ds1.volume.isel(rgi_id=0, time=-1).data <
-                0.75*ds3.volume.isel(rgi_id=0, time=-1).data)
+                0.75 * ds3.volume.isel(rgi_id=0, time=-1).data)
         ds3.close()
 
         # Try the compile optimisation
@@ -3656,7 +3672,7 @@ class TestHEF:
         if do_plot:
             plt.figure()
             for ds, lab in zip(out, feedbacks):
-                (ds.volume*1e-9).plot(label=lab)
+                (ds.volume * 1e-9).plot(label=lab)
             plt.xlabel('Vol (km3)')
             plt.legend()
             plt.show()
@@ -3748,6 +3764,7 @@ class TestHEF:
                                            ods[vn].sel(time=1990) -
                                            ods[vn].sel(time=1980),
                                            rtol=rtol)
+
 
 @pytest.mark.usefixtures('with_class_wd')
 class TestHydro:
@@ -3877,7 +3894,7 @@ class TestHydro:
         init_present_time_glacier(gdir)
         tasks.run_with_hydro(gdir, run_task=tasks.run_constant_climate,
                              store_monthly_hydro=store_monthly_hydro,
-                             nyears=100, y0=2003-5, halfsize=5,
+                             nyears=100, y0=2003 - 5, halfsize=5,
                              output_filesuffix='_const')
 
         with xr.open_dataset(gdir.get_filepath('model_diagnostics',
@@ -4166,7 +4183,7 @@ class TestHydro:
         init_present_time_glacier(gdir)
         tasks.run_with_hydro(gdir, run_task=tasks.run_random_climate,
                              store_monthly_hydro=store_monthly_hydro,
-                             seed=0, nyears=100, y0=2003-5, halfsize=5,
+                             seed=0, nyears=100, y0=2003 - 5, halfsize=5,
                              output_filesuffix='_rand')
 
         with xr.open_dataset(gdir.get_filepath('model_diagnostics',
@@ -4245,12 +4262,12 @@ class TestHydro:
             tasks.run_with_hydro(gdir, run_task=tasks.run_constant_climate,
                                  bias=mb_bias,
                                  store_monthly_hydro=False,
-                                 nyears=20, y0=2003-5, halfsize=5,
+                                 nyears=20, y0=2003 - 5, halfsize=5,
                                  output_filesuffix='_annual')
             tasks.run_with_hydro(gdir, run_task=tasks.run_constant_climate,
                                  bias=mb_bias,
                                  store_monthly_hydro=True,
-                                 nyears=20, y0=2003-5, halfsize=5,
+                                 nyears=20, y0=2003 - 5, halfsize=5,
                                  output_filesuffix='_monthly')
         elif mb_type == 'hist':
             tasks.run_with_hydro(gdir, run_task=tasks.run_from_climate_data,
@@ -4393,11 +4410,11 @@ class TestMassRedis:
 
                 f, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 4))
                 v.plot(ax=ax1,
-                       color=['C0']*2+['C1']*2+['C3']*2,
+                       color=['C0'] * 2 + ['C1'] * 2 + ['C3'] * 2,
                        style=['-', ':'] * 3)
                 ax1.set_title(f'Volume, advance_method={advance_method}')
                 l.plot(ax=ax2,
-                       color=['C0']*2+['C1']*2+['C3']*2,
+                       color=['C0'] * 2 + ['C1'] * 2 + ['C3'] * 2,
                        style=['-', ':'] * 3)
                 ax2.set_title(f'Length, advance_method={advance_method}')
                 plt.show()
@@ -4405,7 +4422,6 @@ class TestMassRedis:
 
 @pytest.fixture(scope='class')
 def merged_hef_cfg(class_case_dir):
-
     # Init
     cfg.initialize()
     cfg.set_intersects_db(get_demo_file('rgi_intersect_oetztal.shp'))

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -3322,7 +3322,7 @@ class TestHEF:
         precision_percent = 10
         # this value is chosen in a way that it effects the result in the 'area'
         # run but not in the 'volume' run
-        precision_min_absolute = 0.1
+        precision_absolute = 0.1
         min_ice_thickness = 10
         assert hef_gdir.rgi_date == 2003
         # is needed because the test climate dataset has ye = 2003 (in hydro
@@ -3336,7 +3336,7 @@ class TestHEF:
                 yr_rgi=yr_rgi,
                 minimise_for=minimise_for,
                 precision_percent=precision_percent,
-                precision_min_absolute=precision_min_absolute,
+                precision_absolute=precision_absolute,
                 min_ice_thickness=min_ice_thickness,
                 output_filesuffix='_dynamic_spinup',
                 store_model_evolution=store_model_evolution)
@@ -3355,7 +3355,7 @@ class TestHEF:
             assert np.isclose(model_value, ref_value,
                               rtol=precision_percent / 100, atol=0)
             assert np.isclose(model_value, ref_value,
-                              rtol=0, atol=precision_min_absolute)
+                              rtol=0, atol=precision_absolute)
             assert model_dynamic_spinup.yr == yr_rgi
             assert len(model_dynamic_spinup.fls) == len(fls)
             # but surface_h should not be the same
@@ -3402,7 +3402,7 @@ class TestHEF:
             yr_rgi=yr_rgi,
             minimise_for=minimise_for,
             precision_percent=precision_percent,
-            precision_min_absolute=precision_min_absolute,
+            precision_absolute=precision_absolute,
             min_ice_thickness=min_ice_thickness,
             output_filesuffix='_dynamic_spinup_ys', )
         # check that is the same if we provide spinup_start_yr instead of spinup_period

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -3318,6 +3318,9 @@ class TestHEF:
             ref_value += getattr(fl, var_name)
 
         precision_percent = 10
+        # this value is chosen in a way that it effects the result in the 'area'
+        # run but not in the 'volume' run
+        precision_min_absolute = 0.1
         assert hef_gdir.rgi_date == 2003
         # is needed because the test climate dataset has ye = 2003 (in hydro
         # years would be 2004)
@@ -3330,12 +3333,15 @@ class TestHEF:
                 yr_rgi=yr_rgi,
                 minimise_for=minimise_for,
                 precision_percent=precision_percent,
+                precision_min_absolute=precision_min_absolute,
                 output_filesuffix='_dynamic_spinup',
                 store_model_evolution=store_model_evolution)
 
             # check if resulting model match wanted value with prescribed precision
             assert np.isclose(getattr(model_dynamic_spinup, var_name), ref_value,
                               rtol=precision_percent/100, atol=0)
+            assert np.isclose(getattr(model_dynamic_spinup, var_name), ref_value,
+                              rtol=0, atol=precision_min_absolute)
             assert model_dynamic_spinup.yr == yr_rgi
             assert len(model_dynamic_spinup.fls) == len(fls)
             # but surface_h should not be the same
@@ -3382,6 +3388,7 @@ class TestHEF:
             yr_rgi=yr_rgi,
             minimise_for=minimise_for,
             precision_percent=precision_percent,
+            precision_min_absolute=precision_min_absolute,
             output_filesuffix='_dynamic_spinup_ys',)
         # check that is the same if we provide spinup_start_yr instead of spinup_period
         assert np.isclose(model_dynamic_spinup_ys.volume_km3,


### PR DESCRIPTION
In this PR I add two new options to the dynamic spinup function. First, you can now define an absolute precision to match in addition to a percentage value. And second, you can now define a minimum ice thickness, for filtering out potential seasonal spikes.
Let's see if all tests pass!

- [ ] Tests added/passed
- [ ] Fully documented
- [ ] Entry in `whats-new.rst` 
