### PR TITLE
Numeric instability filter

### DIFF
--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -569,6 +569,19 @@ def initialize_minimal(file=None, logging_level='INFO', params=None,
     PARAMS[k] = cp[k]
     k = 'glacier_length_method'
     PARAMS[k] = cp[k]
+    k = 'use_instability_smoothing'
+    if cp[k] == 'False':
+        PARAMS[k] = cp.as_bool[k]
+    else:
+        PARAMS[k] = cp[k]
+    k = 'instability_min_length'
+    PARAMS[k] = cp.as_int[k]
+    k = 'instability_smoothing_window'
+    PARAMS[k] = cp.as_int[k]
+    k = 'instability_smoothing_steps'
+    PARAMS[k] = cp.as_int[k]
+    k = 'instability_smoothing_mass_redis_fct'
+    PARAMS[k] = cp[k]
 
     # Others
     PARAMS['tidewater_type'] = cp.as_int('tidewater_type')
@@ -593,7 +606,12 @@ def initialize_minimal(file=None, logging_level='INFO', params=None,
            'use_inversion_params_for_run', 'ref_mb_valid_window',
            'tidewater_type', 'store_model_geometry',
            'store_diagnostic_variables', 'store_fl_diagnostic_variables',
-           'geodetic_mb_period', 'store_fl_diagnostics']
+           'geodetic_mb_period', 'store_fl_diagnostics',
+           'use_instability_smoothing',
+           'instability_min_length',
+           'instability_smoothing_window',
+           'instability_smoothing_steps',
+           'instability_smoothing_mass_redis_fct']
     for k in ltr:
         cp.pop(k, None)
 

--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -571,15 +571,15 @@ def initialize_minimal(file=None, logging_level='INFO', params=None,
     PARAMS[k] = cp[k]
     k = 'use_instability_smoothing'
     if cp[k] == 'False':
-        PARAMS[k] = cp.as_bool[k]
+        PARAMS[k] = cp.as_bool(k)
     else:
         PARAMS[k] = cp[k]
     k = 'instability_min_length'
-    PARAMS[k] = cp.as_int[k]
+    PARAMS[k] = cp.as_int(k)
     k = 'instability_smoothing_window'
-    PARAMS[k] = cp.as_int[k]
+    PARAMS[k] = cp.as_int(k)
     k = 'instability_smoothing_steps'
-    PARAMS[k] = cp.as_int[k]
+    PARAMS[k] = cp.as_int(k)
     k = 'instability_smoothing_mass_redis_fct'
     PARAMS[k] = cp[k]
 

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -2207,9 +2207,8 @@ class FluxBasedModel(FlowlineModel):
                 """
                 fl_change = copy.deepcopy(fl_smoothed)
                 fl_change.thick[start: end - 1] = utils.clip_min(
-                        fl_smoothed.surface_h[start: end - 1] +
-                        surface_h_change * coeffs -
-                        fl.bed_h[start: end - 1], 0)
+                    fl_smoothed.surface_h[start: end - 1] + surface_h_change *
+                    coeffs - fl.bed_h[start: end - 1], 0)
                 return (np.sum(fl_change.section[start: end - 1] -
                                fl_smoothed.section[start: end - 1]) -
                         total_delta)

--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -330,6 +330,36 @@ glacier_length_method = naive
 # flowline module) are realized with the same parameters as for the inversion
 # It's a good idea for operational runs.
 use_inversion_params_for_run = True
+# Numeric instability smoothing options (instabilities are detected with u_stag
+# and smoothed with slope_stag, currently only implemented for the
+# FluxBasedModel)
+# Should the numeric solutions should be checked and smoothed for instabilities
+# Options are:
+# - 'False' do not smooth instabilities
+# - 'each_timestep' smooth for instabilities after each time step
+# - 'yearly' smooth instabilities after each year
+use_instability_smoothing = False
+# Defines a threshold grid point number for instabilities. An instability is only
+# detected as such if it occurs at least for this number of grid points.
+instability_min_length = 5
+# Defines how many grid points before and after each instability grid point
+# should is used for smoothing (using a running mean). Therefore this defines
+# how many 'good' grid points are included before and after the instability.
+# Moreover this defines the minimum number of 'good' grid points between two
+# consecutive instabilities, otherwise they will be merged and considered as
+# one larger instability
+instability_smoothing_window = 3
+# Defines how often the instability should be smoothed using a running mean.
+instability_smoothing_steps = 2
+# This decides how the mass difference due to the instability smoothing should
+# be distributed along the instability grid points.
+# Options: 'gaussian', 'sinus', 'equal'
+instability_smoothing_mass_redis_fct = 'gaussian'
+# If the mass distribution should be done with a 'gaussian' defines the limits.
+# The larger this value the smoother the transition at the edges of the
+# instability, but also the larger the gradient of mass distribution inside the
+# instability
+instability_smoothing_mass_redis_gaus_lim = 2
 
 ### Tidewater glaciers options
 

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -60,6 +60,9 @@ class TestFuncs(object):
         ts = pd.Series([-2., -1., 1., 2., 3][::-1], index=np.arange(5))
         sc = utils.signchange(ts)
         assert_array_equal(sc, [0, 0, 0, 1, 0])
+        ts = pd.Series([0., 0., 0., 0., 0], index=np.arange(5))
+        sc = utils.signchange(ts)
+        assert_array_equal(sc, [0, 0, 0, 0, 0])
 
     def test_smooth(self):
         a = np.array([1., 4, 7, 7, 4, 1])

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -361,6 +361,47 @@ class TestFuncs(object):
         assert_allclose(df.cenlon, cgidf['Glc_Long'])
         assert_allclose(df.rgi_area_km2, cgidf['Glc_Area'] * 1e-6, rtol=1e-3)
 
+    def test_detect_instabilities(self):
+        # test no instability
+        start, length = utils.detect_instabilities(np.arange(0, 100, 1))
+        assert start is None
+        assert length is None
+
+        # test one instability
+        test_array = np.array([0., 1., 2., 1., 2., 1., 0.])
+        start, length = utils.detect_instabilities(test_array, min_length=4)
+        assert np.all(np.equal(start, np.array([2])))
+        assert np.all(np.equal(length, np.array([4])))
+
+        # test two instabilities wide separated
+        test_array = np.array([0., 1., 2., 1., 2., 3., 4., 5., 4., 5., 4., 3.])
+        start, length = utils.detect_instabilities(test_array, min_length=3,
+                                                   min_distance=2)
+        assert np.all(np.equal(start, np.array([2, 7])))
+        assert np.all(np.equal(length, np.array([3, 4])))
+
+        # test two instabilitiew close
+        start, length = utils.detect_instabilities(test_array, min_length=3,
+                                                   min_distance=3)
+        assert np.all(np.equal(start, np.array([2])))
+        assert np.all(np.equal(length, np.array([9])))
+
+        # test three instabilities, two are close
+        test_array = np.array([0., 1., 2., 1., 2., 3., 4., 5., 4., 5., 4., 3.,
+                               2., 1., 0., 1., 0., 1., 2., 3.])
+        start, length = utils.detect_instabilities(test_array, min_length=3,
+                                                   min_distance=3)
+        assert np.all(np.equal(start, np.array([2, 14])))
+        assert np.all(np.equal(length, np.array([9, 4])))
+
+        # test three instabilities, three are close
+        test_array = np.array([0., 1., 2., 1., 2., 3., 4., 5., 4., 5., 4., 3.,
+                               2., 1., 0., 1., 0., 1., 2., 3.])
+        start, length = utils.detect_instabilities(test_array, min_length=3,
+                                                   min_distance=4)
+        assert np.all(np.equal(start, np.array([2])))
+        assert np.all(np.equal(length, np.array([16])))
+
 
 class TestInitialize(unittest.TestCase):
 

--- a/oggm/utils/_funcs.py
+++ b/oggm/utils/_funcs.py
@@ -435,6 +435,9 @@ def signchange(ts):
     """
     asign = np.sign(ts)
     sz = asign == 0
+    # check if the given array contains only zeros
+    if sz.all():
+        return np.zeros(len(ts)).astype(int)
     while sz.any():
         asign[sz] = np.roll(asign, 1)[sz]
         sz = asign == 0


### PR DESCRIPTION
This is the first attempt at implementing a filter that checks for numeric instabilities and filters them out. This is still work in progress, but for discussing the design and implementation I open it in its really early phase.

The principle Idea: An instability is defined as a zigzag pattern in the ice velocity. If this zigzag pattern is visible over a minimum number of grid points it is classified as an instability. To filter this out the surface slope is smoothed in two steps. First a running mean is used which considers some grid points before and after the instability (for a smooth transition). Afterwards, these smoothed slopes are used to recalculate the surface heights and a mass conserving step is conducted. This step compares the mass before and after the smoothing and redistributes the difference along all instability grid points (using a gaussian shape to ensure a smooth transition between good grid points and the instability grid points).

With the current implementation, you can choose to:
- do no smoothing `False` (as it was until now)
- smooth `'yearly'`
- smooth `'each_timestep'`

Possible other options could become in the future (maybe useful for global runs):
- smooth all instabilities if `max(u)` is contained in instability
- smooth only instability which contains `max(u)`

The changes in the source code (which can be discussed):
- small changes to utils `signchange` function to be able to use it not only with time series but also with numpy arrays, and also included the treatment (and added a test) if the given array contains only zeros
- included a function in utils that find zigzag patterns in a given array
- included some parameters in params.cfg for instability smoothing options, some of them can maybe be deleted after testing, but for testing, I find it easier to have easy excess to them
- added a dummy method `smooth_instabilities_in_flowlines()` to the `FlowlineModel` class, which should be implemented in the child classes
- in the `FlowlineModel` method `run_until` I added the options to smooth instabilities yearly or at each time step (is calling `smooth_instabilities_in_flowlines()` method then)
- in the `FluxBasedModel` I implemented the `smooth_instabilities_in_flowlines()` method
- For testing purposes, I added in `flowline_model_run` and `dynamic spinup` a diagnostic variable that indicates if smoothing was used or not

What to discuss further (from my point of view):
- How should the smoothing be tested on runs? Currently only tested on one glacier, so I think there will be other issues popping up when testing it on a larger scale.
- How should the smoothing function should be tested with pytest?
- Is this methodologically acceptable?


Must Dos:
- [x] Tests added for `detect_instabilities`
- [ ] Tests added for smoothing function
- [ ] Fully documented
- [ ] Entry in `whats-new.rst` 
