### PR TITLE
Change default `mb_years` in #L1613 of climate.py

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -15,6 +15,10 @@ Enhancements
 Bug fixes
 ~~~~~~~~~
 
+- corrected a but in ``apparent_mb_from_any_mb``, where only two years of MB
+  would be used instead of a range of years (:pull:`1426`).
+  By `Bowen <https://github.com/bowenbelongstonature>`_
+
 v1.5.3 (02.04.2022)
 -------------------
 

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -1999,7 +1999,7 @@ class TestClimate(unittest.TestCase):
         np.testing.assert_allclose(mb_new.bias, 0)
 
         # Check that inversion works
-        climate.apparent_mb_from_any_mb(gdir, mb_years=np.arange(1953, 2003, 1))
+        climate.apparent_mb_from_any_mb(gdir, mb_years=[1953, 2003])
 
         # Artificially make some arms even lower to have multiple branches
         fls = gdir.read_pickle('inversion_flowlines')
@@ -2024,7 +2024,7 @@ class TestClimate(unittest.TestCase):
         np.testing.assert_allclose(mb_new.bias, 0)
 
         # Check that inversion works but it logs a warning
-        climate.apparent_mb_from_any_mb(gdir, mb_years=np.arange(1953, 2003, 1))
+        climate.apparent_mb_from_any_mb(gdir, mb_years=[1953, 2003])
 
     @pytest.mark.slow
     def test_local_t_star_fallback(self):


### PR DESCRIPTION
Make sure `mb_years` get an array and raise an error when the count/length of years given to `apparent_mb_from_any_mb` is smaller than 10.


<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->


- [ ] Tests added/passed
- [ ] Fully documented
- [ ] Entry in `whats-new.rst` 
