### PR TITLE
update documentation

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -49,7 +49,7 @@ want to clone your fork to your machine::
 
     git clone git@github.com:your-GitHub-username/oggm.git oggm-yourname
     cd oggm-yourname
-    git remote add upstream git://github.com/OGGM/oggm.git
+    git remote add upstream https://github.com/OGGM/oggm.git
 
 This creates the directory `oggm-yourname` and connects your repository to
 the upstream (main project) oggm repository (with the `your-GitHub-username`


### PR DESCRIPTION
`git remote add upstream git://github.com/OGGM/oggm.git` doesn't work properly anymore. When entering `git fetch upstream`
I received the following error.:

fatal: unable to connect to [github.com](http://github.com/):
[github.com](http://github.com/)[0: 140.82.121.4]: errno=Connection timed out

Using `git remote add upstream https://github.com/OGGM/oggm.git` instead avoids getting this error.

This #PR makes that update in the documentation.

Thanks @TimoRoth!