### PR TITLE
add water_level to FileModel

### DIFF
--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -2123,6 +2123,7 @@ class FileModel(object):
         try:
             with xr.open_dataset(path) as ds:
                 self._calving_m3_since_y0 = ds.calving_m3.values
+                self.water_level=ds.water_level
                 self.do_calving = True
         except AttributeError:
             self._calving_m3_since_y0 = 0

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -2128,6 +2128,7 @@ class FileModel(object):
         except AttributeError:
             self._calving_m3_since_y0 = 0
             self.do_calving = False
+            self.water_level = 0
 
         # time
         self.reset_y0()

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -2123,7 +2123,7 @@ class FileModel(object):
         try:
             with xr.open_dataset(path) as ds:
                 self._calving_m3_since_y0 = ds.calving_m3.values
-                self.water_level=ds.water_level
+                self.water_level = ds.water_level
                 self.do_calving = True
         except AttributeError:
             self._calving_m3_since_y0 = 0


### PR DESCRIPTION
This commit add the water_level attribute to the FileModel. This is a first step to close #1449, but did not solve the problem directly. It only solves the error from `graphics.plot_modeloutput_section`. 

Closes https://github.com/OGGM/oggm/issues/1449

