### PR TITLE
Some bug fixes for dynamic mu star calibration

### DIFF
--- a/oggm/core/dynamic_spinup.py
+++ b/oggm/core/dynamic_spinup.py
@@ -1052,7 +1052,11 @@ def dynamic_mu_star_run_with_dynamic_spinup(
         min_ice_thickness = 0
 
     # Here we start with the actual model run
-    define_new_mu_star_in_gdir(gdir, mu_star)
+    if mu_star == gdir.read_json('local_mustar')['mu_star_glacierwide']:
+        # we do not need to define a new mu_star or do an inversion
+        do_inversion = False
+    else:
+        define_new_mu_star_in_gdir(gdir, mu_star)
 
     # this variable is used if an inverison is conducted to keep the original
     # model_flowline unchanged (-> to be able to conduct different dynamic

--- a/oggm/core/dynamic_spinup.py
+++ b/oggm/core/dynamic_spinup.py
@@ -40,7 +40,7 @@ def run_dynamic_spinup(gdir, init_model_filesuffix=None, init_model_yr=None,
                        store_model_geometry=True, store_fl_diagnostics=None,
                        store_model_evolution=True, ignore_errors=False,
                        return_t_bias_best=False, ye=None,
-                       model_flowline_filesuffix='',
+                       model_flowline_filesuffix='', make_compatible=False,
                        **kwargs):
     """Dynamically spinup the glacier to match area or volume at the RGI date.
 
@@ -178,6 +178,13 @@ def run_dynamic_spinup(gdir, init_model_filesuffix=None, init_model_yr=None,
         suffix to the model_flowlines filename to use (if no other flowlines
         are provided with init_model_filesuffix or init_model_fls).
         Default is ''
+    make_compatible : bool
+        if set to true this will add all variables to the resulting dataset
+        so it could be combined with any other one. This is necessary if
+        different spinup methods are used. For example if using the dynamic
+        spinup and setting fixed geoemtry spinup as fallback, the variable
+        'is_fixed_geometry_spinup' must be added to the dynamic spinup so
+        it is possible to compile both glaciers together.
     kwargs : dict
         kwargs to pass to the evolution_model instance
 
@@ -305,7 +312,8 @@ def run_dynamic_spinup(gdir, init_model_filesuffix=None, init_model_yr=None,
                 yr_run,
                 geom_path=geom_path,
                 diag_path=diag_path,
-                fl_diag_path=fl_diag_path)
+                fl_diag_path=fl_diag_path,
+                make_compatible=make_compatible)
 
         return model_dynamic_spinup_end
 
@@ -395,7 +403,8 @@ def run_dynamic_spinup(gdir, init_model_filesuffix=None, init_model_yr=None,
                 geom_path=geom_path,
                 diag_path=diag_path,
                 fl_diag_path=fl_diag_path,
-                dynamic_spinup_min_ice_thick=min_ice_thickness)
+                dynamic_spinup_min_ice_thick=min_ice_thickness,
+                make_compatible=make_compatible)
             if type(ds) == tuple:
                 ds = ds[0]
             model_area_km2 = ds.area_m2_min_h.loc[yr_rgi].values * 1e-6
@@ -1099,6 +1108,7 @@ def dynamic_mu_star_run_with_dynamic_spinup(
             store_model_geometry=store_model_geometry,
             store_fl_diagnostics=store_fl_diagnostics,
             model_flowline_filesuffix=model_flowline_filesuffix,
+            make_compatible=True,
             **kwargs)
         # save the temperature bias which was successful in the last iteration
         # as we expect we are not so far away in the next iteration (only
@@ -1277,7 +1287,8 @@ def dynamic_mu_star_run_with_dynamic_spinup_fallback(
             evolution_model=evolution_model,
             spinup_period=spinup_period,
             spinup_start_yr=ys,
-            min_spinup_period=min_spinup_period, yr_rgi=yr_rgi,
+            min_spinup_period=min_spinup_period,
+            yr_rgi=yr_rgi,
             minimise_for=minimise_for,
             precision_percent=precision_percent_dyn_spinup,
             precision_absolute=precision_absolute_dyn_spinup,
@@ -1288,7 +1299,10 @@ def dynamic_mu_star_run_with_dynamic_spinup_fallback(
             output_filesuffix=output_filesuffix,
             store_model_geometry=store_model_geometry,
             store_fl_diagnostics=store_fl_diagnostics,
-            ignore_errors=False, ye=ye, **kwargs)
+            ignore_errors=False,
+            ye=ye,
+            make_compatible=True,
+            **kwargs)
 
         gdir.add_to_diagnostics('used_spinup_option', 'dynamic spinup only')
 

--- a/oggm/core/dynamic_spinup.py
+++ b/oggm/core/dynamic_spinup.py
@@ -1079,6 +1079,7 @@ def dynamic_mu_star_run_with_dynamic_spinup(
     try:
         model, last_best_t_bias = run_dynamic_spinup(
             gdir,
+            continue_on_error=False,  # force to raise an error in @entity_task
             init_model_fls=fls_init,
             climate_input_filesuffix=climate_input_filesuffix,
             evolution_model=evolution_model, spinup_period=spinup_period,
@@ -1270,6 +1271,7 @@ def dynamic_mu_star_run_with_dynamic_spinup_fallback(
     try:
         model_end = run_dynamic_spinup(
             gdir,
+            continue_on_error=False,  # force to raise an error in @entity_task
             init_model_fls=fls_init,
             climate_input_filesuffix=climate_input_filesuffix,
             evolution_model=evolution_model,
@@ -1390,7 +1392,10 @@ def dynamic_mu_star_run(
 
     # conduct model run
     try:
-        model = run_from_climate_data(gdir, ys=ys, ye=ye,
+        model = run_from_climate_data(gdir,
+                                      # force to raise an error in @entity_task
+                                      continue_on_error=False,
+                                      ys=ys, ye=ye,
                                       output_filesuffix=output_filesuffix,
                                       init_model_fls=fls_init,
                                       evolution_model=evolution_model,
@@ -1458,7 +1463,10 @@ def dynamic_mu_star_run_fallback(
 
     # conduct model run
     try:
-        model = run_from_climate_data(gdir, ys=ys, ye=ye,
+        model = run_from_climate_data(gdir,
+                                      # force to raise an error in @entity_task
+                                      continue_on_error=False,
+                                      ys=ys, ye=ye,
                                       output_filesuffix=output_filesuffix,
                                       init_model_fls=fls_init,
                                       evolution_model=evolution_model,

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -933,6 +933,7 @@ class FlowlineModel(object):
                             stop_criterion=None,
                             fixed_geometry_spinup_yr=None,
                             dynamic_spinup_min_ice_thick=None,
+                            make_compatible=False
                             ):
         """Runs the model and returns intermediate steps in xarray datasets.
 
@@ -991,6 +992,13 @@ class FlowlineModel(object):
             area or the total volume. This is useful to smooth out yearly
             fluctuations when matching to observations. The names of this new
             variables include the suffix _min_h (e.g. 'area_m2_min_h')
+        make_compatible : bool
+            if set to true this will add all variables to the resulting dataset
+            so it could be combined with any other one. This is necessary if
+            different spinup methods are used. For example if using the dynamic
+            spinup and setting fixed geoemtry spinup as fallback, the variable
+            'is_fixed_geometry_spinup' must be added to the dynamic spinup so
+            it is possible to compile both glaciers together.
         Returns
         -------
         geom_ds : xarray.Dataset or None
@@ -1157,6 +1165,12 @@ class FlowlineModel(object):
 
         if do_fixed_spinup:
             is_spinup_time = monthly_time < self.yr
+            diag_ds['is_fixed_geometry_spinup'] = ('time', is_spinup_time)
+            desc = 'Part of the series which are spinup'
+            diag_ds['is_fixed_geometry_spinup'].attrs['description'] = desc
+            diag_ds['is_fixed_geometry_spinup'].attrs['unit'] = '-'
+        elif make_compatible:
+            is_spinup_time = np.full(len(monthly_time), False, dtype=np.bool)
             diag_ds['is_fixed_geometry_spinup'] = ('time', is_spinup_time)
             desc = 'Part of the series which are spinup'
             diag_ds['is_fixed_geometry_spinup'].attrs['description'] = desc

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -3774,13 +3774,13 @@ class TestHEF:
             gdir, max_mu_star=1000.,
             run_function=dynamic_mu_star_run_with_dynamic_spinup,
             kwargs_run_function={'minimise_for': minimise_for,
-                                 'precision_percent_dyn_spinup': precision_percent,
-                                 'precision_absolute_dyn_spinup': precision_absolute,
+                                 'precision_percent': precision_percent,
+                                 'precision_absolute': precision_absolute,
                                  'do_inversion': do_inversion},
             fallback_function=dynamic_mu_star_run_with_dynamic_spinup_fallback,
             kwargs_fallback_function={'minimise_for': minimise_for,
-                                      'precision_percent_dyn_spinup': precision_percent,
-                                      'precision_absolute_dyn_spinup': precision_absolute,
+                                      'precision_percent': precision_percent,
+                                      'precision_absolute': precision_absolute,
                                       'do_inversion': do_inversion},
             output_filesuffix='_dyn_mu_calib_spinup_inversion',
             ys=1979, ye=ye)
@@ -3834,13 +3834,13 @@ class TestHEF:
                     gdir, max_mu_star=1000.,
                     run_function=dynamic_mu_star_run_with_dynamic_spinup,
                     kwargs_run_function={'minimise_for': minimise_for,
-                                         'precision_percent_dyn_spinup': precision_percent,
-                                         'precision_absolute_dyn_spinup': precision_absolute,
+                                         'precision_percent': precision_percent,
+                                         'precision_absolute': precision_absolute,
                                          'do_inversion': do_inversion},
                     fallback_function=dynamic_mu_star_run_with_dynamic_spinup_fallback,
                     kwargs_fallback_function={'minimise_for': minimise_for,
-                                              'precision_percent_dyn_spinup': precision_percent,
-                                              'precision_absolute_dyn_spinup': precision_absolute,
+                                              'precision_percent': precision_percent,
+                                              'precision_absolute': precision_absolute,
                                               'do_inversion': do_inversion},
                     output_filesuffix='_dyn_mu_calib_spinup_inversion',
                     ys=1979, ye=ye, init_model_fls=fls)
@@ -3860,13 +3860,13 @@ class TestHEF:
             err_ref_dmdtda=err_ref_dmdtda + delta_err_ref_dmdtda,
             run_function=dynamic_mu_star_run_with_dynamic_spinup,
             kwargs_run_function={'minimise_for': minimise_for,
-                                 'precision_percent_dyn_spinup': precision_percent,
-                                 'precision_absolute_dyn_spinup': precision_absolute,
+                                 'precision_percent': precision_percent,
+                                 'precision_absolute': precision_absolute,
                                  'do_inversion': do_inversion},
             fallback_function=dynamic_mu_star_run_with_dynamic_spinup_fallback,
             kwargs_fallback_function={'minimise_for': minimise_for,
-                                      'precision_percent_dyn_spinup': precision_percent,
-                                      'precision_absolute_dyn_spinup': precision_absolute,
+                                      'precision_percent': precision_percent,
+                                      'precision_absolute': precision_absolute,
                                       'do_inversion': do_inversion},
             output_filesuffix='_dyn_mu_calib_spinup_inversion_user_dmdtda',
             ys=1979, ye=ye)
@@ -3902,25 +3902,25 @@ class TestHEF:
                 output_filesuffix='_dyn_mu_calib_spinup_inversion_error',
                 ignore_errors=False,
                 ref_dmdtda=ref_dmdtda, err_ref_dmdtda=0.000001,
-                maxiter_mu_star=2)
+                maxiter=2)
         # test that fallback function works as expected if ignore_error=True and
         # if the first guess can improve (but not enough)
         model_fallback = run_dynamic_mu_star_calibration(
             gdir, max_mu_star=1000.,
             run_function=dynamic_mu_star_run_with_dynamic_spinup,
             kwargs_run_function={'minimise_for': minimise_for,
-                                 'precision_percent_dyn_spinup': precision_percent,
-                                 'precision_absolute_dyn_spinup': precision_absolute,
+                                 'precision_percent': precision_percent,
+                                 'precision_absolute': precision_absolute,
                                  'do_inversion': do_inversion},
             fallback_function=dynamic_mu_star_run_with_dynamic_spinup_fallback,
             kwargs_fallback_function={'minimise_for': minimise_for,
-                                      'precision_percent_dyn_spinup': precision_percent,
-                                      'precision_absolute_dyn_spinup': precision_absolute,
+                                      'precision_percent': precision_percent,
+                                      'precision_absolute': precision_absolute,
                                       'do_inversion': do_inversion},
             output_filesuffix='_dyn_mu_calib_spinup_inversion_error',
             ignore_errors=True,
             ref_dmdtda=ref_dmdtda, err_ref_dmdtda=0.000001,
-            maxiter_mu_star=2)
+            maxiter=2)
         assert isinstance(model_fallback, oggm.core.flowline.FluxBasedModel)
         assert gdir.get_diagnostics()['used_spinup_option'] == \
                'dynamic mu_star calibration (part success)'
@@ -3944,20 +3944,20 @@ class TestHEF:
             gdir, max_mu_star=1000.,
             run_function=dynamic_mu_star_run_with_dynamic_spinup,
             kwargs_run_function={'minimise_for': minimise_for,
-                                 'precision_percent_dyn_spinup': 0.1,
-                                 'precision_absolute_dyn_spinup': 0.0001,
-                                 'maxiter_dyn_spinup': 2,
+                                 'precision_percent': 0.1,
+                                 'precision_absolute': 0.0001,
+                                 'maxiter': 2,
                                  'do_inversion': do_inversion},
             fallback_function=dynamic_mu_star_run_with_dynamic_spinup_fallback,
             kwargs_fallback_function={'minimise_for': minimise_for,
-                                      'precision_percent_dyn_spinup': 0.1,
-                                      'precision_absolute_dyn_spinup': 0.0001,
-                                      'maxiter_dyn_spinup': 2,
+                                      'precision_percent': 0.1,
+                                      'precision_absolute': 0.0001,
+                                      'maxiter': 2,
                                       'do_inversion': do_inversion},
             output_filesuffix='_dyn_mu_calib_spinup_inversion_error',
             ignore_errors=True,
             ref_dmdtda=ref_dmdtda, err_ref_dmdtda=0.000001,
-            maxiter_mu_star=2)
+            maxiter=2)
         assert isinstance(model_fallback, oggm.core.flowline.FluxBasedModel)
         assert gdir.get_diagnostics()['used_spinup_option'] == \
                'fixed geometry spinup'
@@ -4151,7 +4151,7 @@ class TestHEF:
                 output_filesuffix='_dyn_mu_calib_error',
                 ignore_errors=False,
                 ref_dmdtda=ref_dmdtda, err_ref_dmdtda=0.000001,
-                maxiter_mu_star=2)
+                maxiter=2)
         # test that fallback function works as expected if ignore_error=True and
         # if the first guess can improve (but not enough)
         model_fallback = run_dynamic_mu_star_calibration(
@@ -4161,7 +4161,7 @@ class TestHEF:
             output_filesuffix='_dyn_mu_calib_spinup_inversion_error',
             ignore_errors=True,
             ref_dmdtda=ref_dmdtda, err_ref_dmdtda=0.000001,
-            maxiter_mu_star=2)
+            maxiter=2)
         assert isinstance(model_fallback, oggm.core.flowline.FluxBasedModel)
         assert gdir.get_diagnostics()['used_spinup_option'] == \
                'dynamic mu_star calibration (part success)'
@@ -4176,7 +4176,7 @@ class TestHEF:
             output_filesuffix='_dyn_mu_calib_error',
             ignore_errors=True,
             ref_dmdtda=ref_dmdtda, err_ref_dmdtda=0.000001,
-            maxiter_mu_star=2)
+            maxiter=2)
         assert isinstance(model_fallback, oggm.core.flowline.FluxBasedModel)
         assert gdir.get_diagnostics()['used_spinup_option'] == 'no spinup'
 

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -1247,7 +1247,7 @@ class TestPreproCLI(unittest.TestCase):
         # Around RGI date they are close
         # have to exclude rgi_id 'RGI60-11.00719_d02', because no dmdtda data
         assert_allclose(dss.sel(time=2004).area[1:], dse.sel(time=2004).area[1:], rtol=0.01)
-        assert_allclose(dss.sel(time=2004).length[1:], dse.sel(time=2004).length[1:], atol=805)
+        assert_allclose(dss.sel(time=2004).length[1:], dse.sel(time=2004).length[1:], atol=940)
         assert_allclose(dss.sel(time=2004).volume[1:], dse.sel(time=2004).volume[1:], rtol=0.21)
 
         # Over the period they are... close enough

--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -223,7 +223,6 @@ class TestFullRun(unittest.TestCase):
             gdirs, ignore_missing=True,
             volume_m3_reference=user_provided_volume_m3)
 
-        df = df.dropna()
         np.testing.assert_allclose(user_provided_volume_m3,
                                    df.vol_oggm_m3.sum(),
                                    rtol=0.01)

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -740,7 +740,12 @@ def calibrate_inversion_from_consensus(gdirs, ignore_missing=True,
                         filter_inversion_output=filter_inversion_output)
         odf = df.copy()
         odf['oggm'] = execute_entity_task(tasks.get_inversion_volume, gdirs)
-        return odf.dropna()
+        # if the user provides a glacier volume all glaciers are considered,
+        # dropna() below exclude glaciers where no ITMIX volume is available
+        if volume_m3_reference is None:
+            return odf.dropna()
+        else:
+            return odf
 
     def to_minimize(x):
         log.workflow('Consensus estimate optimisation with '


### PR DESCRIPTION

- [x] Tests added/passed

Some more bug fixes for `run_dynamic_mu_star_calibration`:
- now properly works with `cfg.PARAMS['continue_on_error'] = True`, meaning do not stop execution if `run_dynamic_spinup` `entity_task` raise an error, as error management is included in `run_dynamic_mu_star_calibration`
- fixed compatibility issue if different spinup strategies should be compiled together. The problem is that the fixed geometry spinup introduces an extra variable `'is_fixed_geometry_spinup'` in the dataset, and to compile it together there is now an option to add this variable also to the dynamic spinup run
- there where an issue in `calibrate_inversion_from_consensus` if the user provides their own volume but there is no ITMIX volume available. Now the ITMIX volume is completely ignored if the user provides a volume.
- changed some variable names for more consistency between the two dynamic tasks
