### PR TITLE
Fix various doc and source comment typos

### DIFF
--- a/docs/_code/prepare_climate.py
+++ b/docs/_code/prepare_climate.py
@@ -56,7 +56,7 @@ selind = np.searchsorted(years, mbdf.index)
 temp_yr = np.mean(temp_yr[selind])
 prcp_yr = np.mean(prcp_yr[selind])
 
-# Average oberved mass balance
+# Average observed mass balance
 ref_mb = mbdf.ANNUAL_BALANCE.mean()
 mb_per_mu = prcp_yr - mu_yr_clim * temp_yr
 

--- a/docs/mass-balance-toys.rst
+++ b/docs/mass-balance-toys.rst
@@ -5,7 +5,7 @@
 
 OGGM comes with a suite of simplified models allowing to run idealized or
 simplified experiments very useful for testing or teaching. Like all
-other mass balance models in OGGM, they folow the
+other mass balance models in OGGM, they follow the
 :py:class:`~oggm.MassBalanceModel` interface.
 
 .. autosummary::

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -146,7 +146,7 @@ Enhancements & bug fixes
   By `Fabien Maussion <https://github.com/fmaussion>`_
 - Added the 30m version of the
   `Copernicus DEM <https://spacedata.copernicus.eu>`_.
-  This DEM can be set with ``source='COPDEM30'`` and can be usefull for smaller sized glaciers.
+  This DEM can be set with ``source='COPDEM30'`` and can be useful for smaller sized glaciers.
   An account with Copernicus is required to access the DEM (free for academics).
   (:pull:`1364`). By `Matthias Dusch <https://github.com/matthiasdusch>`_
 - Added a new `merge_consecutive_run_outputs` entity task which allows to merge

--- a/oggm/core/centerlines.py
+++ b/oggm/core/centerlines.py
@@ -2059,7 +2059,7 @@ def intersect_downstream_lines(gdir, candidates=None):
         list of tributary rgi_ids
     """
 
-    # make sure tributaries are iteratable
+    # make sure tributaries are iterable
     candidates = utils.tolist(candidates)
 
     # Buffer in pixels around the flowline

--- a/oggm/core/climate.py
+++ b/oggm/core/climate.py
@@ -802,7 +802,7 @@ def t_star_from_refmb(gdir, mbdf=None, glacierwide=None,
     # which years to look at
     ref_years = mbdf.index.values
 
-    # Average oberved mass balance
+    # Average observed mass balance
     ref_mb = np.mean(mbdf)
 
     # Compute one mu candidate per year and the associated statistics
@@ -1556,7 +1556,7 @@ def mu_star_calibration_from_geodetic_mb(gdir,
 
         # We have just picked the first, but to be fair it is arbitrary
         # We could also pick one randomly... but here we rather prefer to have
-        # the smallest ref_hgt change as possible (hence smalles temp. bias change)
+        # the smallest ref_hgt change as possible (hence smallest temp. bias change)
         mu_star = sel_mus[0]
         # Final correction of the data
         with utils.ncDataset(fpath, 'a') as nc:

--- a/oggm/core/dynamic_spinup.py
+++ b/oggm/core/dynamic_spinup.py
@@ -133,7 +133,7 @@ def run_dynamic_spinup(gdir, init_model_filesuffix=None, init_model_yr=None,
         MassBalanceModel in °C.
         Default is -2.
     t_bias_max_step_length : float
-        Defines the maximums allowed change of t_bias between two iteratons. Is
+        Defines the maximums allowed change of t_bias between two iterations. Is
         needed to avoid to large changes.
         Default is 2.
     maxiter : int
@@ -182,7 +182,7 @@ def run_dynamic_spinup(gdir, init_model_filesuffix=None, init_model_yr=None,
         if set to true this will add all variables to the resulting dataset
         so it could be combined with any other one. This is necessary if
         different spinup methods are used. For example if using the dynamic
-        spinup and setting fixed geoemtry spinup as fallback, the variable
+        spinup and setting fixed geometry spinup as fallback, the variable
         'is_fixed_geometry_spinup' must be added to the dynamic spinup so
         it is possible to compile both glaciers together.
     kwargs : dict
@@ -741,7 +741,7 @@ def run_dynamic_spinup(gdir, init_model_filesuffix=None, init_model_yr=None,
             if abs(mismatch[-1]) < precision_percent:
                 return t_bias_guess, mismatch
 
-        # Ok when we end here the spinup could not find satifying match after
+        # Ok when we end here the spinup could not find satisfying match after
         # maxiter(ations)
         raise RuntimeError(f'Could not find mismatch smaller '
                            f'{precision_percent}% (only '
@@ -994,7 +994,7 @@ def dynamic_mu_star_run_with_dynamic_spinup(
         MassBalanceModel in °C.
         Default is -2.
     t_bias_max_step_length : float
-        Defines the maximums allowed change of t_bias between two iteratons. Is
+        Defines the maximums allowed change of t_bias between two iterations. Is
         needed to avoid to large changes.
         Default is 2
     maxiter : int
@@ -1246,7 +1246,7 @@ def dynamic_mu_star_run_with_dynamic_spinup_fallback(
         MassBalanceModel in °C.
         Default is -2.
     t_bias_max_step_length : float
-        Defines the maximums allowed change of t_bias between two iteratons. Is
+        Defines the maximums allowed change of t_bias between two iterations. Is
         needed to avoid to large changes.
         Default is 2
     maxiter : int
@@ -1279,7 +1279,7 @@ def dynamic_mu_star_run_with_dynamic_spinup_fallback(
                            'calibrate_inversion_from_consensus provided in '
                            'local_variables!')
 
-    # revert gdir to original state if neccessary
+    # revert gdir to original state if necessary
     if mu_star != gdir.read_json('local_mustar')['mu_star_glacierwide']:
         define_new_mu_star_in_gdir(gdir, mu_star)
         if do_inversion:
@@ -1351,7 +1351,7 @@ def dynamic_mu_star_run_with_dynamic_spinup_fallback(
 
         gdir.add_to_diagnostics('used_spinup_option', 'fixed geometry spinup')
 
-        # set all dynamic diagnostics to None if there where some succesful
+        # set all dynamic diagnostics to None if there where some successful
         # runs
         diag = gdir.get_diagnostics()
         if minimise_for == 'area':
@@ -1416,7 +1416,7 @@ def dynamic_mu_star_run(
         this function in 'run_dynamic_mu_star_calibration'.
     yr_rgi : int or None
         The rgi year of the gdir.
-        Dafault is None
+        Default is None
     kwargs : dict
         kwargs to pass to the evolution_model instance
 
@@ -1492,7 +1492,7 @@ def dynamic_mu_star_run_fallback(
         Default is FluxBasedModel
     yr_rgi : int or None
         The rgi year of the gdir.
-        Dafault is None
+        Default is None
     kwargs : dict
         kwargs to pass to the evolution_model instance
 
@@ -1578,7 +1578,7 @@ def run_dynamic_mu_star_calibration(
         Upper absolute limit for mu*
         Default is None (-> cfg.PARAMS['max_mu_star'])
     mu_star_max_step_length : float
-        Defines the maximum allowed change of mu_star between two iteratons.
+        Defines the maximum allowed change of mu_star between two iterations.
         Is needed to avoid to large changes.
         Default is 5
     maxiter : int

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -996,7 +996,7 @@ class FlowlineModel(object):
             if set to true this will add all variables to the resulting dataset
             so it could be combined with any other one. This is necessary if
             different spinup methods are used. For example if using the dynamic
-            spinup and setting fixed geoemtry spinup as fallback, the variable
+            spinup and setting fixed geometry spinup as fallback, the variable
             'is_fixed_geometry_spinup' must be added to the dynamic spinup so
             it is possible to compile both glaciers together.
         Returns
@@ -1020,7 +1020,7 @@ class FlowlineModel(object):
                                      'mass balance model with an unambiguous '
                                      'hemisphere.')
 
-        # This is only needed for consistancy to be able to merge two runs
+        # This is only needed for consistency to be able to merge two runs
         if dynamic_spinup_min_ice_thick is None:
             dynamic_spinup_min_ice_thick = cfg.PARAMS['dynamic_spinup_min_ice_thick']
 
@@ -1457,7 +1457,7 @@ class FlowlineModel(object):
     def run_until_equilibrium(self, rate=0.001, ystep=5, max_ite=200):
         """ Runs the model until an equilibrium state is reached.
 
-        Be careful: This only works for CONSTANT (not time-dependant)
+        Be careful: This only works for CONSTANT (not time-dependent)
         mass balance models.
         Otherwise the returned state will not be in equilibrium! Don't try to
         calculate an equilibrium state with a RandomMassBalance model!
@@ -1940,7 +1940,7 @@ class FluxBasedModel(FlowlineModel):
             - slope: -
             - ice_flux, tributary_flux: m3 of *ice* per second
             - ice_velocity: m per second (depth-section integrated)
-            - surface_ice_velocity: m per second (corrected for surface - simplifed)
+            - surface_ice_velocity: m per second (corrected for surface - simplified)
         """
         import pandas as pd
 

--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -207,7 +207,7 @@ temp_melt = -1.
 # Needs to be set empty if use_winter_prcp_factor is True
 prcp_scaling_factor = 2.5
 
-# Use a precipitation dependant factor (unique per glacier)
+# Use a precipitation dependent factor (unique per glacier)
 # The values below have been calibrated on W5E5 data only and should not
 # be used with other datasets
 use_winter_prcp_factor = False

--- a/oggm/shop/w5e5.py
+++ b/oggm/shop/w5e5.py
@@ -125,7 +125,7 @@ def process_gswp3_w5e5_data(gdir, y0=None, y1=None, output_filesuffix=None):
             ds = ds.sel(longitude=lon, latitude=lat, method='nearest')
             # normally if I do the flattening, this here should not occur
 
-        # because of the flattening, there is no time dependece of lon and lat anymore!
+        # because of the flattening, there is no time dependence of lon and lat anymore!
         ds['longitude'] = ds.longitude  # .isel(time=0)
         ds['latitude'] = ds.latitude  # .isel(time=0)
 

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -3522,7 +3522,7 @@ class TestHEF:
                                        ignore_errors=ignore_errors,
                                        min_spinup_period=min_spinup_period,
                                        )
-                # check that all _dynamic_spinup files are deleted if error occured
+                # check that all _dynamic_spinup files are deleted if error occurred
                 for filename in ['model_geometry', 'fl_diagnostics',
                                  'model_diagnostics']:
                     assert not os.path.exists(
@@ -4354,7 +4354,7 @@ class TestHEF:
                                output_filesuffix=feedback,
                                store_monthly_step=True)))
         with warnings.catch_warnings():
-            # Waring about MB model update
+            # Warning about MB model update
             warnings.filterwarnings("ignore", category=UserWarning)
             workflow.execute_parallel_tasks(hef_gdir, tasks)
 
@@ -4785,7 +4785,7 @@ class TestHydro:
             odf_run = ds[sel_vars].to_dataframe().iloc[:-1]
 
         assert odf_hist.index[0] == 1980
-        assert odf_hist.index[-1] == 1998  # this matches becaus last year is removed above
+        assert odf_hist.index[-1] == 1998  # this matches because last year is removed above
         assert odf_run.index[0] == 1999
 
         odf = pd.concat([odf_hist, odf_run])

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -661,7 +661,7 @@ def get_centerline_lonlat(gdir,
     ensure_exterior_match : per design, OGGM centerlines match the underlying
     DEM grid. This may imply that they do not "touch" the exterior outlines
     of the glacier in vector space. Set this to True to correct for that.
-    geometrical_widths_output : for the geometrical witdths
+    geometrical_widths_output : for the geometrical widths
     corrected_widths_output : for the corrected widths
 
     Returns
@@ -3797,7 +3797,7 @@ def initialize_merged_gdir(main, tribs=[], glcdf=None,
     # If its a dict, select the relevant ones
     if isinstance(tribs, dict):
         tribs = tribs[main.rgi_id]
-    # make sure tributaries are iteratable
+    # make sure tributaries are iterable
     tribs = tolist(tribs)
 
     # read flowlines of the Main glacier


### PR DESCRIPTION
Found via `codespell -q 3 -L alos,asign,nd,ot,ro`