### PR TITLE
Add pytest.oggm wrapper

### DIFF
--- a/oggm/tests/__main__.py
+++ b/oggm/tests/__main__.py
@@ -1,0 +1,11 @@
+import os
+import sys
+
+HERE = os.path.dirname(__file__)
+
+def main():
+    import pytest
+    return pytest.main([HERE] + sys.argv[1:])
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,3 +51,4 @@ console_scripts =
     oggm_prepro = oggm.cli.prepro_levels:main
     oggm_benchmark = oggm.cli.benchmark:main
     oggm_netrc_credentials = oggm.cli.netrc_credentials:cli
+    pytest.oggm = oggm.tests.__main__:main


### PR DESCRIPTION
This implements the workaround from https://stackoverflow.com/questions/41270604/using-command-line-parameters-with-pytest-pyargs/43747114#43747114 for being able to test an installed oggm module.

It adds a pytest.oggm wrapper, which you use instead of `pytest --pyargs oggm`, and it ensures the installed version is actually tested, and not a mix of it with your local clone, or a plain failure if there is no local clone.