### PR TITLE
Add pytest.oggm wrapper

### DIFF
--- a/deployment/docker/test.sh
+++ b/deployment/docker/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -e
-exec pytest --mpl-oggm --mpl-upload --pyargs oggm
+exec pytest.oggm --mpl-oggm --mpl-upload

--- a/docs/installing-oggm.rst
+++ b/docs/installing-oggm.rst
@@ -206,7 +206,7 @@ Test OGGM
 You can test your OGGM installation by running the following command from
 anywhere (don't forget to activate your environment first)::
 
-    pytest --pyargs oggm
+    pytest.oggm
 
 The tests can run for about 10 minutes (`we are trying to reduce this <https://github.com/OGGM/oggm/issues/1063>`_).
 If everything worked fine, you should see something like::
@@ -248,7 +248,7 @@ as long as the tests end without errors.
 This runs a minimal suite of tests. If you want to run the entire test suite
 (including graphics and slow running tests), type::
 
-    pytest --pyargs oggm --run-slow --mpl
+    pytest.oggm --run-slow --mpl
 
 **Congrats**, you are now set-up for the :doc:`getting-started` section!
 
@@ -377,6 +377,6 @@ Installing them with pip or conda should be much easier.
 Running the tests in this minimal environment works the same. Simply run
 from a terminal::
 
-    pytest --pyargs oggm
+    pytest.oggm
 
 The number of tests will be much smaller!

--- a/docs/oeps/oep--0001-dependencies.rst
+++ b/docs/oeps/oep--0001-dependencies.rst
@@ -193,7 +193,7 @@ Check install (goal 10)
 The user will have two complementary ways to test the correct installation
 of OGGM:
 
-- `pytest --pyargs oggm --run-slow --mpl` will run the test suite. This test
+- `pytest.oggm --run-slow --mpl` will run the test suite. This test
   suite does not contain quantitative tests, i.e. it does not guarantee
   consistency of model results across platforms
 - `oggm.check_install()` will be a top level function performing quantitative 

--- a/docs/practicalities.rst
+++ b/docs/practicalities.rst
@@ -196,7 +196,7 @@ Then, in your script, so something similar to::
       pip install --upgrade pip setuptools
       # OPTIONAL: install another OGGM version (here provided by its git commit hash)
       pip install "git+https://github.com/OGGM/oggm.git@ce22ceb77f3f6ffc865be65964b568835617db0d"
-      # Finally, you can test OGGM with `pytest --pyargs oggm`, or run your script:
+      # Finally, you can test OGGM with `pytest.oggm`, or run your script:
       YOUR_RUN_SCRIPT_HERE
     EOF
 
@@ -231,7 +231,7 @@ Some explanations:
   `git tag <https://stackoverflow.com/questions/13685920/install-specific-git-commit-with-pip>`_
   as well). If you do that, you might want to run the tests once first to make sure 
   that it works as expected. You can do that by replacing ``YOUR_RUN_SCRIPT_HERE``
-  with ``pytest --pyargs oggm --run-slow``!
+  with ``pytest.oggm --run-slow``!
 - finally, the `YOUR_RUN_SCRIPT_HERE` is the actual command you want to run
   from this container! Most of the time, it will be a call to your python
   script.

--- a/oggm/tests/__main__.py
+++ b/oggm/tests/__main__.py
@@ -1,0 +1,13 @@
+import os
+import sys
+
+HERE = os.path.dirname(__file__)
+
+
+def main():
+    import pytest
+    return pytest.main([HERE] + sys.argv[1:])
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,3 +51,4 @@ console_scripts =
     oggm_prepro = oggm.cli.prepro_levels:main
     oggm_benchmark = oggm.cli.benchmark:main
     oggm_netrc_credentials = oggm.cli.netrc_credentials:cli
+    pytest.oggm = oggm.tests.__main__:main


### PR DESCRIPTION
This implements the workaround from https://stackoverflow.com/questions/41270604/using-command-line-parameters-with-pytest-pyargs/43747114#43747114 for being able to test an installed oggm module.

It adds a pytest.oggm wrapper, which you use instead of `pytest --pyargs oggm`, and it ensures the installed version is actually tested, and not a mix of it with your local clone, or a plain failure if there is no local clone.