### PR TITLE
Better isolate tests from one another

### DIFF
--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -833,13 +833,13 @@ def pack_config():
 
     return {
         'IS_INITIALIZED': IS_INITIALIZED,
-        'PARAMS': PARAMS,
-        'PATHS': PATHS,
-        'LRUHANDLERS': LRUHANDLERS,
-        'DATA': DATA,
+        'PARAMS': dict(PARAMS),
+        'PATHS': dict(PATHS),
+        'LRUHANDLERS': dict(LRUHANDLERS),
+        'DATA': dict(DATA),
         'BASENAMES': dict(BASENAMES),
-        'DL_VERIFIED': DL_VERIFIED,
-        'DEM_SOURCE_TABLE': DEM_SOURCE_TABLE
+        'DL_VERIFIED': dict(DL_VERIFIED),
+        'DEM_SOURCE_TABLE': dict(DEM_SOURCE_TABLE)
     }
 
 
@@ -850,12 +850,25 @@ def unpack_config(cfg_dict):
     global DL_VERIFIED, DEM_SOURCE_TABLE
 
     IS_INITIALIZED = cfg_dict['IS_INITIALIZED']
-    PARAMS = cfg_dict['PARAMS']
-    PATHS = cfg_dict['PATHS']
-    LRUHANDLERS = cfg_dict['LRUHANDLERS']
-    DATA = cfg_dict['DATA']
-    DL_VERIFIED = cfg_dict['DL_VERIFIED']
-    DEM_SOURCE_TABLE = cfg_dict['DEM_SOURCE_TABLE']
+
+    prev_log = PARAMS.do_log
+    PARAMS.do_log = False
+
+    PARAMS.clear()
+    PATHS.clear()
+    LRUHANDLERS.clear()
+    DATA.clear()
+    DL_VERIFIED.clear()
+    DEM_SOURCE_TABLE.clear()
+
+    PARAMS.update(cfg_dict['PARAMS'])
+    PATHS.update(cfg_dict['PATHS'])
+    LRUHANDLERS.update(cfg_dict['LRUHANDLERS'])
+    DATA.update(cfg_dict['DATA'])
+    DL_VERIFIED.update(cfg_dict['DL_VERIFIED'])
+    DEM_SOURCE_TABLE.update(cfg_dict['DEM_SOURCE_TABLE'])
+
+    PARAMS.do_log = prev_log
 
     # BASENAMES is a DocumentedDict, which cannot be pickled because
     # set intentionally mismatches with get

--- a/oggm/tests/conftest.py
+++ b/oggm/tests/conftest.py
@@ -99,6 +99,22 @@ def pytest_collection_modifyitems(config, items):
                 item.add_marker(graphic_marker)
 
 
+@pytest.fixture(scope='function', autouse=True)
+def restore_oggm_cfg():
+    """Ensures a test cannot pollute cfg for other tests running after it"""
+    old_cfg = cfg.pack_config()
+    yield
+    cfg.unpack_config(old_cfg)
+
+
+@pytest.fixture(scope='class', autouse=True)
+def restore_oggm_class_cfg():
+    """Ensures a test-class cannot pollute cfg for other tests running after it"""
+    old_cfg = cfg.pack_config()
+    yield
+    cfg.unpack_config(old_cfg)
+
+
 @pytest.fixture(autouse=True)
 def patch_data_urls(monkeypatch):
     """This makes sure we never download the big files with our tests"""

--- a/oggm/tests/conftest.py
+++ b/oggm/tests/conftest.py
@@ -19,6 +19,7 @@ from oggm import utils
 from oggm.utils import mkdir, _downloads
 from oggm.utils import oggm_urlretrieve
 from oggm.tests import HAS_MPL_FOR_TESTS, HAS_INTERNET
+from oggm.workflow import reset_multiprocessing
 
 logger = logging.getLogger(__name__)
 
@@ -103,6 +104,7 @@ def pytest_collection_modifyitems(config, items):
 def restore_oggm_cfg():
     """Ensures a test cannot pollute cfg for other tests running after it"""
     old_cfg = cfg.pack_config()
+    reset_multiprocessing()
     yield
     cfg.unpack_config(old_cfg)
 


### PR DESCRIPTION
Resets multiprocessing before every test and ensures per-class and per-test cfg changes don't leak into other tests.