### PR TITLE
Change default params

### DIFF
--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -548,6 +548,7 @@ def initialize_minimal(file=None, logging_level='INFO', params=None,
     PARAMS['store_fl_diagnostics'] = cp.as_bool('store_fl_diagnostics')
 
     # Climate
+    PARAMS['use_tstar_calibration'] = cp.as_bool('use_tstar_calibration')
     PARAMS['baseline_climate'] = cp['baseline_climate'].strip().upper()
     PARAMS['hydro_month_nh'] = cp.as_int('hydro_month_nh')
     PARAMS['hydro_month_sh'] = cp.as_int('hydro_month_sh')
@@ -606,7 +607,7 @@ def initialize_minimal(file=None, logging_level='INFO', params=None,
            'use_intersects', 'filter_min_slope', 'clip_tidewater_border',
            'auto_skip_task', 'correct_for_neg_flux', 'filter_for_neg_flux',
            'rgi_version', 'dl_verify', 'use_mp_spawn', 'calving_use_limiter',
-           'use_shape_factor_for_inversion', 'use_rgi_area',
+           'use_shape_factor_for_inversion', 'use_rgi_area', 'use_tstar_calibration',
            'use_shape_factor_for_fluxbasedmodel', 'baseline_climate',
            'calving_line_extension', 'use_kcalving_for_run', 'lru_maxsize',
            'free_board_marine_terminating', 'use_kcalving_for_inversion',

--- a/oggm/cli/benchmark.py
+++ b/oggm/cli/benchmark.py
@@ -31,7 +31,7 @@ def _add_time_to_df(df, index, t):
 def run_benchmark(rgi_version=None, rgi_reg=None, border=None,
                   output_folder='', working_dir='', is_test=False,
                   test_rgidf=None, test_intersects_file=None,
-                  test_topofile=None):
+                  override_params=None, test_topofile=None):
     """Does the actual job.
 
     Parameters
@@ -54,6 +54,8 @@ def run_benchmark(rgi_version=None, rgi_reg=None, border=None,
         for testing purposes only
     test_topofile : str
         for testing purposes only
+    override_params : dict
+        a dict of parameters to override.
     """
 
     # Module logger
@@ -63,11 +65,14 @@ def run_benchmark(rgi_version=None, rgi_reg=None, border=None,
     params = {}
 
     # Local paths
+    if override_params is None:
+        override_params = {}
+
     utils.mkdir(working_dir)
-    params['working_dir'] = working_dir
+    override_params['working_dir'] = working_dir
 
     # Initialize OGGM and set up the run parameters
-    cfg.initialize(logging_level='WORKFLOW', params=params, future=True)
+    cfg.initialize(logging_level='WORKFLOW', params=override_params, future=True)
 
     # Use multiprocessing?
     cfg.PARAMS['use_multiprocessing'] = True

--- a/oggm/core/climate.py
+++ b/oggm/core/climate.py
@@ -787,6 +787,10 @@ def t_star_from_refmb(gdir, mbdf=None, glacierwide=None,
 
     from oggm.core.massbalance import MultipleFlowlineMassBalance
 
+    if not cfg.PARAMS['use_tstar_calibration']:
+        raise InvalidParamsError('If using "old" mu* calibration, set '
+                                 "PARAMS['use_tstar_calibration'] to True.")
+
     if glacierwide is None:
         glacierwide = cfg.PARAMS['tstar_search_glacierwide']
 
@@ -975,6 +979,9 @@ def local_t_star(gdir, *, ref_df=None, tstar=None, bias=None,
     max_mu_star: bool, optional
         defaults to cfg.PARAMS['max_mu_star']
     """
+    if not cfg.PARAMS['use_tstar_calibration']:
+        raise InvalidParamsError('If using "old" mu* calibration, set '
+                                 "PARAMS['use_tstar_calibration'] to True.")
 
     if tstar is None or bias is None:
         # Do our own interpolation
@@ -1249,6 +1256,10 @@ def mu_star_calibration(gdir, min_mu_star=None, max_mu_star=None):
     max_mu_star: bool, optional
         defaults to cfg.PARAMS['max_mu_star']
     """
+
+    if not cfg.PARAMS['use_tstar_calibration']:
+        raise InvalidParamsError('If using "old" mu* calibration, set '
+                                 "PARAMS['use_tstar_calibration'] to True.")
 
     # Interpolated data
     df = gdir.read_json('local_mustar')

--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -165,14 +165,71 @@ base_binsize = 50.
 smooth_widths_window_size = 1
 
 ### CLIMATE params
+
 # Baseline climate is the reference climate data to use for this workflow.
-# Options include CRU, HISTALP, ERA5, ERA5L, CERA+ERA5, CERA+ERA5L
+# Options: CRU, HISTALP, ERA5, ERA5L, CERA+ERA5, CERA+ERA5L, W5E5, GSWP3_W5E5
 # Leave empty if you want to do your own cuisine.
-baseline_climate = CRU
+baseline_climate = W5E5
+
 # Hydrological year definition
-hydro_month_nh = 10
-hydro_month_sh = 4
-# specify here the start and end year where oggm will search for tstar
+# For the typical hydro-year definition, use:
+# hydro_month_nh = 10
+# hydro_month_sh = 4
+hydro_month_nh = 1
+hydro_month_sh = 1
+
+# which temperature gradient? if false, use temp_default_gradient. If true,
+# compute by regression of the 9 surrounding grid points (not recommended)
+temp_use_local_gradient = False
+temp_default_gradient = -0.0065
+# the linear regression can lead to quite strange results... this helps
+# you to clip them to more realistic values:
+temp_local_gradient_bounds = -0.009, -0.003
+# other parameters
+temp_all_solid = 0.
+temp_all_liq = 2.
+temp_melt = -1.
+
+# precipitation correction: set to a float for a constant scaling factor
+# Needs to be set empty if use_winter_prcp_factor is True
+prcp_scaling_factor = 2.5
+
+# Use a precipitation dependent factor (unique per glacier)
+# The values below have been calibrated on W5E5 data - they are less likely
+# to work on other datasets.
+use_winter_prcp_factor = True
+winter_prcp_factor_ab = -1.0614, 3.9200
+winter_prcp_factor_range = 0.1, 10
+
+# historical climate quality check - this parameter ensures that there is
+# at least N months per year where melt and/or accumulation can occur
+climate_qc_months = 0
+# Bounds on mu*
+# Values out of these limits are considered bad and will lead to a correction
+# of the local temperature to allow for values in this range.
+# If "old" style tstar calibration is used this should be much larger.
+min_mu_star = 75.
+max_mu_star = 500.
+# When matching geodetic MB on a glacier per glacier basis, which period
+# to use. Available in the current data are:
+# '2000-01-01_2010-01-01', '2010-01-01_2020-01-01', '2000-01-01_2020-01-01'
+geodetic_mb_period = 2000-01-01_2020-01-01
+# Whether to clip mu to a min of min_mu_star (only recommended for calving exps)
+clip_mu_star = False
+# fraction of the original (non-calving) mu* for this glacier that
+# you are ready to allow for. Totally arbitrary.
+calving_min_mu_star_frac = 0.7
+
+# Use compression for climate files?
+# Can be set to `False` if you have to read the data a lot, i.e. for the
+# cross-validation experiment
+compress_climate_netcdf = True
+
+## "Old" calibration: tstar and all
+# This calibration method made sense before geodetic data were available
+# This is not so the case anymore.
+use_tstar_calibration = False
+# Specify here the start and end year where oggm will search for tstar
 # candidates (note that the window will be reduced by mu_star_halfperiod on
 # each side of the window). Set to 0, 0 for the default (the entire available
 # data space)
@@ -191,52 +248,10 @@ tstar_search_glacierwide = True
 # Biases are interpolated from t* locations to the glacier without observations
 # The good idea is to use this biases in the model
 use_bias_for_run = True
-# which temperature gradient? if false, use temp_default_gradient. If true,
-# compute by regression of the 9 surrounding grid points (not recommended)
-temp_use_local_gradient = False
-temp_default_gradient = -0.0065
-# the linear regression can lead to quite strange results... this helps
-# you to clip them to more realistic values:
-temp_local_gradient_bounds = -0.009, -0.003
-# other parameters
-temp_all_solid = 0.
-temp_all_liq = 2.
-temp_melt = -1.
-
-# precipitation correction: set to a float for a constant scaling factor
-# Needs to be set empty if use_winter_prcp_factor is True
-prcp_scaling_factor = 2.5
-
-# Use a precipitation dependent factor (unique per glacier)
-# The values below have been calibrated on W5E5 data only and should not
-# be used with other datasets
-use_winter_prcp_factor = False
-winter_prcp_factor_ab = -1.0614, 3.9200
-winter_prcp_factor_range = 0.1, 10
-
 # Should we use the default, pre-calibrated reference tstars or are we
 # running the calibration ourselves? The default should be False, which
 # raises a warning when trying to calibrate.
 run_mb_calibration = False
-# historical climate quality check - this parameter ensures that there is
-# at least N months per year where melt and/or accumulation can occur
-climate_qc_months = 3
-# Bounds on mu*
-# Values out of these limits are considered bad and will lead to an error
-# When matching geodetic MB on a glacier per glacier basis, this should
-# be rather like 20, 600
-min_mu_star = 5.
-max_mu_star = 10000.
-# When matching geodetic MB on a glacier per glacier basis, which period
-# to use. Available in the current data are:
-# '2000-01-01_2010-01-01', '2010-01-01_2020-01-01', '2000-01-01_2020-01-01'
-geodetic_mb_period = 2000-01-01_2020-01-01
-# Whether to clip mu to a min of min_mu_star (only recommended for calving exps)
-clip_mu_star = False
-# fraction of the original (non-calving) mu* for this glacier that
-# you are ready to allow for. Totally arbitrary.
-calving_min_mu_star_frac = 0.7
-
 # For some glacier geometries, having one mu* for the entire glacier implies
 # that some tributaries should not exist and have a negative mass flux
 # at the terminus of their flowline.
@@ -247,10 +262,6 @@ correct_for_neg_flux = True
 # tributary entirely (works only if correct_for_neg_flux is False).
 # This changes the flowlines number and geometry in non predictable ways.
 filter_for_neg_flux = False
-# Use compression for climate files?
-# Can be set to `False` if you have to read the data a lot, i.e. for the
-# cross-validation experiment
-compress_climate_netcdf = True
 
 ### Ice dynamics params
 ## ice density in kg m-3

--- a/oggm/tests/funcs.py
+++ b/oggm/tests/funcs.py
@@ -350,6 +350,12 @@ def init_hef(reset=False, border=40, logging_level='INFO', rgi_id=None):
     cfg.PARAMS['trapezoid_lambdas'] = 1
     cfg.PARAMS['border'] = border
 
+    cfg.PARAMS['use_tstar_calibration'] = True
+    cfg.PARAMS['use_winter_prcp_factor'] = False
+    cfg.PARAMS['hydro_month_nh'] = 10
+    cfg.PARAMS['hydro_month_sh'] = 4
+    cfg.PARAMS['climate_qc_months'] = 3
+
     hef_file = get_demo_file('Hintereisferner_RGI5.shp')
     entity = gpd.read_file(hef_file).iloc[0]
 
@@ -439,6 +445,12 @@ def init_columbia(reset=False):
     cfg.PARAMS['border'] = 10
     cfg.PARAMS['use_kcalving_for_inversion'] = True
     cfg.PARAMS['use_kcalving_for_run'] = True
+    cfg.PARAMS['use_tstar_calibration'] = True
+    cfg.PARAMS['use_winter_prcp_factor'] = False
+    cfg.PARAMS['hydro_month_nh'] = 10
+    cfg.PARAMS['hydro_month_sh'] = 4
+    cfg.PARAMS['min_mu_star'] = 25
+    cfg.PARAMS['max_mu_star'] = 10000
 
     entity = gpd.read_file(get_demo_file('01_rgi60_Columbia.shp')).iloc[0]
     gdir = oggm.GlacierDirectory(entity, reset=reset)
@@ -476,6 +488,14 @@ def init_columbia_eb(dir_name, reset=False):
     cfg.PARAMS['border'] = 10
     cfg.PARAMS['use_kcalving_for_inversion'] = True
     cfg.PARAMS['use_kcalving_for_run'] = True
+    cfg.PARAMS['use_tstar_calibration'] = True
+    cfg.PARAMS['use_winter_prcp_factor'] = False
+    cfg.PARAMS['hydro_month_nh'] = 10
+    cfg.PARAMS['hydro_month_sh'] = 4
+    cfg.PARAMS['min_mu_star'] = 5
+    cfg.PARAMS['max_mu_star'] = 10000
+    cfg.PARAMS['climate_qc_months'] = 3
+    cfg.PARAMS['baseline_climate'] = 'CRU'
 
     entity = gpd.read_file(get_demo_file('01_rgi60_Columbia.shp')).iloc[0]
     gdir = oggm.GlacierDirectory(entity)

--- a/oggm/tests/test_benchmarks.py
+++ b/oggm/tests/test_benchmarks.py
@@ -55,6 +55,7 @@ class TestSouthGlacier(unittest.TestCase):
         cfg.PARAMS['hydro_month_nh'] = 10
         cfg.PARAMS['hydro_month_sh'] = 4
         cfg.PARAMS['climate_qc_months'] = 3
+        cfg.PARAMS['baseline_climate'] = 'CRU'
         apply_test_ref_tstars()
 
         self.tf = get_demo_file('cru_ts4.01.1901.2016.SouthGlacier.tmp.dat.nc')
@@ -475,6 +476,8 @@ class TestCoxeGlacier(unittest.TestCase):
         cfg.PARAMS['hydro_month_nh'] = 10
         cfg.PARAMS['hydro_month_sh'] = 4
         cfg.PARAMS['climate_qc_months'] = 3
+        cfg.PARAMS['min_mu_star'] = 25
+        cfg.PARAMS['baseline_climate'] = 'CRU'
         apply_test_ref_tstars()
 
     def tearDown(self):

--- a/oggm/tests/test_benchmarks.py
+++ b/oggm/tests/test_benchmarks.py
@@ -50,6 +50,11 @@ class TestSouthGlacier(unittest.TestCase):
         cfg.PATHS['working_dir'] = self.testdir
         cfg.PATHS['dem_file'] = get_demo_file('dem_SouthGlacier.tif')
         cfg.PARAMS['border'] = 10
+        cfg.PARAMS['use_tstar_calibration'] = True
+        cfg.PARAMS['use_winter_prcp_factor'] = False
+        cfg.PARAMS['hydro_month_nh'] = 10
+        cfg.PARAMS['hydro_month_sh'] = 4
+        cfg.PARAMS['climate_qc_months'] = 3
         apply_test_ref_tstars()
 
         self.tf = get_demo_file('cru_ts4.01.1901.2016.SouthGlacier.tmp.dat.nc')
@@ -465,6 +470,11 @@ class TestCoxeGlacier(unittest.TestCase):
         cfg.PATHS['working_dir'] = self.testdir
         cfg.PARAMS['use_kcalving_for_inversion'] = True
         cfg.PARAMS['use_kcalving_for_run'] = True
+        cfg.PARAMS['use_tstar_calibration'] = True
+        cfg.PARAMS['use_winter_prcp_factor'] = False
+        cfg.PARAMS['hydro_month_nh'] = 10
+        cfg.PARAMS['hydro_month_sh'] = 4
+        cfg.PARAMS['climate_qc_months'] = 3
         apply_test_ref_tstars()
 
     def tearDown(self):

--- a/oggm/tests/test_graphics.py
+++ b/oggm/tests/test_graphics.py
@@ -178,6 +178,11 @@ def test_multiple_inversion():
     cfg.PARAMS['border'] = 40
     cfg.PARAMS['baseline_climate'] = 'CUSTOM'
     cfg.PARAMS['trapezoid_lambdas'] = 1
+    cfg.PARAMS['use_tstar_calibration'] = True
+    cfg.PARAMS['use_winter_prcp_factor'] = False
+    cfg.PARAMS['hydro_month_nh'] = 10
+    cfg.PARAMS['hydro_month_sh'] = 4
+    cfg.PARAMS['climate_qc_months'] = 3
     cfg.PATHS['working_dir'] = testdir
     apply_test_ref_tstars()
 
@@ -258,6 +263,11 @@ def test_multiple_models():
     cfg.PATHS['working_dir'] = testdir
     cfg.PARAMS['baseline_climate'] = 'CUSTOM'
     cfg.PARAMS['trapezoid_lambdas'] = 1
+    cfg.PARAMS['use_tstar_calibration'] = True
+    cfg.PARAMS['use_winter_prcp_factor'] = False
+    cfg.PARAMS['hydro_month_nh'] = 10
+    cfg.PARAMS['hydro_month_sh'] = 4
+    cfg.PARAMS['climate_qc_months'] = 3
     cfg.PARAMS['border'] = 40
     apply_test_ref_tstars()
 
@@ -343,6 +353,11 @@ def test_chhota_shigri():
     cfg.PARAMS['use_intersects'] = False
     cfg.PATHS['working_dir'] = testdir
     cfg.PARAMS['trapezoid_lambdas'] = 1
+    cfg.PARAMS['use_tstar_calibration'] = True
+    cfg.PARAMS['use_winter_prcp_factor'] = False
+    cfg.PARAMS['hydro_month_nh'] = 10
+    cfg.PARAMS['hydro_month_sh'] = 4
+    cfg.PARAMS['climate_qc_months'] = 3
 
     hef_file = get_demo_file('divides_RGI50-14.15990.shp')
     df = gpd.read_file(hef_file)
@@ -385,6 +400,11 @@ def test_ice_cap():
     cfg.PARAMS['border'] = 60
     cfg.PATHS['working_dir'] = testdir
     cfg.PARAMS['trapezoid_lambdas'] = 1
+    cfg.PARAMS['use_tstar_calibration'] = True
+    cfg.PARAMS['use_winter_prcp_factor'] = False
+    cfg.PARAMS['hydro_month_nh'] = 10
+    cfg.PARAMS['hydro_month_sh'] = 4
+    cfg.PARAMS['climate_qc_months'] = 3
 
     df = gpd.read_file(get_demo_file('divides_RGI50-05.08389.shp'))
     df['Area'] = df.Area * 1e-6  # cause it was in m2
@@ -425,6 +445,11 @@ def test_coxe():
     cfg.PARAMS['use_kcalving_for_inversion'] = True
     cfg.PARAMS['use_kcalving_for_run'] = True
     cfg.PARAMS['trapezoid_lambdas'] = 1
+    cfg.PARAMS['use_tstar_calibration'] = True
+    cfg.PARAMS['use_winter_prcp_factor'] = False
+    cfg.PARAMS['hydro_month_nh'] = 10
+    cfg.PARAMS['hydro_month_sh'] = 4
+    cfg.PARAMS['climate_qc_months'] = 3
 
     hef_file = get_demo_file('rgi_RGI50-01.10299.shp')
     entity = gpd.read_file(hef_file).iloc[0]

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -213,6 +213,13 @@ def other_glacier_cfg():
     cfg.set_intersects_db(get_demo_file('rgi_intersect_oetztal.shp'))
     cfg.PATHS['dem_file'] = get_demo_file('srtm_oetztal.tif')
     cfg.PATHS['climate_file'] = get_demo_file('histalp_merged_hef.nc')
+    cfg.PARAMS['use_tstar_calibration'] = True
+    cfg.PARAMS['use_winter_prcp_factor'] = False
+    cfg.PARAMS['hydro_month_nh'] = 10
+    cfg.PARAMS['hydro_month_sh'] = 4
+    cfg.PARAMS['min_mu_star'] = 25
+    cfg.PARAMS['max_mu_star'] = 10000
+    cfg.PARAMS['baseline_climate'] = 'CRU'
 
 
 @pytest.mark.usefixtures('other_glacier_cfg')
@@ -5207,6 +5214,11 @@ class TestMassRedis:
         cfg.PARAMS['baseline_climate'] = ''
         cfg.PARAMS['use_multiprocessing'] = False
         cfg.PARAMS['min_ice_thick_for_length'] = 5
+        cfg.PARAMS['use_tstar_calibration'] = True
+        cfg.PARAMS['use_winter_prcp_factor'] = False
+        cfg.PARAMS['hydro_month_nh'] = 10
+        cfg.PARAMS['hydro_month_sh'] = 4
+        cfg.PARAMS['climate_qc_months'] = 3
 
         hef_file = get_demo_file('Hintereisferner_RGI5.shp')
         entity = gpd.read_file(hef_file).iloc[0]
@@ -5304,6 +5316,11 @@ def merged_hef_cfg(class_case_dir):
     cfg.PARAMS['prcp_scaling_factor'] = 1.75
     cfg.PARAMS['temp_melt'] = -1.75
     cfg.PARAMS['run_mb_calibration'] = True
+    cfg.PARAMS['use_tstar_calibration'] = True
+    cfg.PARAMS['use_winter_prcp_factor'] = False
+    cfg.PARAMS['hydro_month_nh'] = 10
+    cfg.PARAMS['hydro_month_sh'] = 4
+    cfg.PARAMS['climate_qc_months'] = 3
 
 
 @pytest.mark.usefixtures('merged_hef_cfg')

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -807,6 +807,11 @@ class TestElevationBandFlowlines(unittest.TestCase):
         cfg.PATHS['climate_file'] = get_demo_file('histalp_merged_hef.nc')
         cfg.PARAMS['baseline_climate'] = ''
 
+        cfg.PARAMS['use_tstar_calibration'] = True
+        cfg.PARAMS['use_winter_prcp_factor'] = False
+        cfg.PARAMS['hydro_month_nh'] = 10
+        cfg.PARAMS['hydro_month_sh'] = 4
+
     def tearDown(self):
         self.rm_dir()
 
@@ -1180,6 +1185,11 @@ class TestClimate(unittest.TestCase):
         cfg.PATHS['climate_file'] = get_demo_file('histalp_merged_hef.nc')
         cfg.PARAMS['border'] = 10
         cfg.PARAMS['baseline_climate'] = ''
+
+        cfg.PARAMS['use_tstar_calibration'] = True
+        cfg.PARAMS['use_winter_prcp_factor'] = False
+        cfg.PARAMS['hydro_month_nh'] = 10
+        cfg.PARAMS['hydro_month_sh'] = 4
 
     def tearDown(self):
         self.rm_dir()
@@ -1692,6 +1702,8 @@ class TestClimate(unittest.TestCase):
 
     def test_climate_qc(self):
 
+        cfg.PARAMS['climate_qc_months'] = 3
+
         hef_file = get_demo_file('Hintereisferner_RGI5.shp')
         entity = gpd.read_file(hef_file).iloc[0]
 
@@ -1759,6 +1771,9 @@ class TestClimate(unittest.TestCase):
 
     @pytest.mark.slow
     def test_find_tstars_multiple_mus(self):
+
+        cfg.PARAMS['min_mu_star'] = 25
+        cfg.PARAMS['max_mu_star'] = 10000
 
         hef_file = get_demo_file('Hintereisferner_RGI5.shp')
         entity = gpd.read_file(hef_file).iloc[0]
@@ -2223,6 +2238,13 @@ class TestFilterNegFlux(unittest.TestCase):
         cfg.PARAMS['baseline_climate'] = ''
         cfg.PARAMS['border'] = 10
 
+        cfg.PARAMS['use_tstar_calibration'] = True
+        cfg.PARAMS['use_winter_prcp_factor'] = False
+        cfg.PARAMS['hydro_month_nh'] = 10
+        cfg.PARAMS['hydro_month_sh'] = 4
+        cfg.PARAMS['min_mu_star'] = 25
+        cfg.PARAMS['max_mu_star'] = 10000
+
     def tearDown(self):
         self.rm_dir()
 
@@ -2402,6 +2424,11 @@ class TestInversion(unittest.TestCase):
         cfg.PATHS['climate_file'] = get_demo_file('histalp_merged_hef.nc')
         cfg.PARAMS['baseline_climate'] = ''
         cfg.PARAMS['border'] = 10
+
+        cfg.PARAMS['use_tstar_calibration'] = True
+        cfg.PARAMS['use_winter_prcp_factor'] = False
+        cfg.PARAMS['hydro_month_nh'] = 10
+        cfg.PARAMS['hydro_month_sh'] = 4
 
     def tearDown(self):
         self.rm_dir()
@@ -2975,6 +3002,13 @@ class TestCoxeCalving(unittest.TestCase):
         cfg.PATHS['dem_file'] = get_demo_file('dem_RGI50-01.10299.tif')
         cfg.PATHS['working_dir'] = self.testdir
         cfg.PARAMS['border'] = 40
+
+        cfg.PARAMS['use_tstar_calibration'] = True
+        cfg.PARAMS['use_winter_prcp_factor'] = False
+        cfg.PARAMS['hydro_month_nh'] = 10
+        cfg.PARAMS['hydro_month_sh'] = 4
+        cfg.PARAMS['min_mu_star'] = 25
+        cfg.PARAMS['max_mu_star'] = 10000
 
     def tearDown(self):
         self.rm_dir()

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -1703,6 +1703,8 @@ class TestClimate(unittest.TestCase):
     def test_climate_qc(self):
 
         cfg.PARAMS['climate_qc_months'] = 3
+        cfg.PARAMS['min_mu_star'] = 25
+        cfg.PARAMS['max_mu_star'] = 10000
 
         hef_file = get_demo_file('Hintereisferner_RGI5.shp')
         entity = gpd.read_file(hef_file).iloc[0]
@@ -3419,6 +3421,13 @@ class TestGrindelInvert(unittest.TestCase):
         cfg.PARAMS['section_smoothing'] = 0.
         cfg.PARAMS['prcp_scaling_factor'] = 1
 
+        cfg.PARAMS['use_tstar_calibration'] = True
+        cfg.PARAMS['use_winter_prcp_factor'] = False
+        cfg.PARAMS['hydro_month_nh'] = 10
+        cfg.PARAMS['hydro_month_sh'] = 4
+        cfg.PARAMS['min_mu_star'] = 25
+        cfg.PARAMS['max_mu_star'] = 10000
+
     def tearDown(self):
         self.rm_dir()
 
@@ -3580,6 +3589,14 @@ class TestGCMClimate(unittest.TestCase):
         cfg.PATHS['dem_file'] = get_demo_file('hef_srtm.tif')
         cfg.PATHS['climate_file'] = ''
         cfg.PARAMS['border'] = 10
+
+        cfg.PARAMS['use_tstar_calibration'] = True
+        cfg.PARAMS['use_winter_prcp_factor'] = False
+        cfg.PARAMS['hydro_month_nh'] = 10
+        cfg.PARAMS['hydro_month_sh'] = 4
+        cfg.PARAMS['min_mu_star'] = 25
+        cfg.PARAMS['max_mu_star'] = 10000
+        cfg.PARAMS['baseline_climate'] = 'CRU'
 
     def tearDown(self):
         self.rm_dir()

--- a/oggm/tests/test_shop.py
+++ b/oggm/tests/test_shop.py
@@ -334,6 +334,8 @@ class Test_ecmwf:
         cfg.PARAMS['use_intersects'] = False
         cfg.PATHS['working_dir'] = class_case_dir
         cfg.PATHS['dem_file'] = get_demo_file('hef_srtm.tif')
+        cfg.PARAMS['hydro_month_nh'] = 10
+        cfg.PARAMS['hydro_month_sh'] = 4
 
         hef_file = get_demo_file('Hintereisferner_RGI5.shp')
 
@@ -454,6 +456,8 @@ class Test_ecmwf:
         cfg.PARAMS['use_intersects'] = False
         cfg.PATHS['working_dir'] = class_case_dir
         cfg.PATHS['dem_file'] = get_demo_file('hef_srtm.tif')
+        cfg.PARAMS['hydro_month_nh'] = 10
+        cfg.PARAMS['hydro_month_sh'] = 4
 
         hef_file = get_demo_file('Hintereisferner_RGI5.shp')
         gdir = workflow.init_glacier_directories(gpd.read_file(hef_file))[0]

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -395,6 +395,8 @@ class TestInitialize(unittest.TestCase):
             self.assertFalse(cfg.PATHS['working_dir'])
 
     def test_params_warn(self):
+        cfg.PARAMS['hydro_month_nh'] = 10
+        cfg.PARAMS['hydro_month_sh'] = 4
         with pytest.raises(InvalidWorkflowError):
             cfg.PARAMS['hydro_month_sh'] = 1
         cfg.PARAMS['hydro_month_nh'] = 1
@@ -1022,7 +1024,15 @@ class TestPreproCLI(unittest.TestCase):
         run_prepro_levels(rgi_version='61', rgi_reg='11', border=20,
                           output_folder=odir, working_dir=wdir, is_test=True,
                           test_rgidf=rgidf, test_intersects_file=inter,
-                          test_topofile=topof, match_regional_geodetic_mb='hugonnet')
+                          test_topofile=topof, match_regional_geodetic_mb='hugonnet',
+                          override_params={'hydro_month_nh': 1,
+                                           'geodetic_mb_period':
+                                               '2000-01-01_2010-01-01',
+                                           'baseline_climate': 'CRU',
+                                           'use_tstar_calibration': True,
+                                           'use_winter_prcp_factor': False,
+                                           }
+                          )
 
         df = pd.read_csv(os.path.join(odir, 'RGI61', 'b_020', 'L3', 'summary',
                                       'climate_statistics_11.csv'))
@@ -1174,7 +1184,11 @@ class TestPreproCLI(unittest.TestCase):
                           test_topofile=topof, elev_bands=True,
                           override_params={'hydro_month_nh': 1,
                                            'geodetic_mb_period':
-                                           '2000-01-01_2010-01-01'})
+                                           '2000-01-01_2010-01-01',
+                                           'baseline_climate': 'CRU',
+                                           'use_tstar_calibration': True,
+                                           'use_winter_prcp_factor': False,
+                                           })
 
         df = pd.read_csv(os.path.join(odir, 'RGI61', bstr, 'L0', 'summary',
                                       'glacier_statistics_11.csv'))
@@ -1286,6 +1300,9 @@ class TestPreproCLI(unittest.TestCase):
                   'geodetic_mb_period': '2000-01-01_2010-01-01',
                   'hydro_month_nh': 1,
                   'hydro_month_sh': 1,
+                  'baseline_climate': 'CRU',
+                  'use_tstar_calibration': True,
+                  'use_winter_prcp_factor': False,
                   }
         # Remove bad actors
         rgidf = rgidf.loc[~rgidf.RGIId.str.contains('_d0')]
@@ -1386,7 +1403,15 @@ class TestPreproCLI(unittest.TestCase):
                           output_folder=odir, working_dir=wdir, is_test=True,
                           test_rgidf=rgidf, test_intersects_file=inter,
                           start_level=1, start_base_url=base_url,
-                          logging_level='INFO', max_level=5)
+                          logging_level='INFO', max_level=5,
+                          override_params={'hydro_month_nh': 1,
+                                           'geodetic_mb_period':
+                                               '2000-01-01_2010-01-01',
+                                           'baseline_climate': 'CRU',
+                                           'use_tstar_calibration': True,
+                                           'use_winter_prcp_factor': False,
+                                           }
+                          )
 
         assert not os.path.isdir(os.path.join(odir, 'RGI61', 'b_020', 'L1'))
         assert os.path.isdir(os.path.join(odir, 'RGI61', 'b_020', 'L2'))

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -1613,7 +1613,11 @@ class TestBenchmarkCLI(unittest.TestCase):
         run_benchmark(rgi_version=None, rgi_reg='11', border=80,
                       output_folder=odir, working_dir=wdir, is_test=True,
                       test_rgidf=rgidf, test_intersects_file=inter,
-                      test_topofile=topof)
+                      test_topofile=topof,
+                      override_params={'baseline_climate': 'CRU',
+                                       'use_tstar_calibration': True,
+                                       'use_winter_prcp_factor': False,
+                                       })
 
         df = pd.read_csv(os.path.join(odir, 'benchmarks_b080.csv'),
                          index_col=0)

--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -90,6 +90,7 @@ def up_to_climate(reset=False, use_mp=None):
     cfg.PARAMS['hydro_month_nh'] = 10
     cfg.PARAMS['hydro_month_sh'] = 4
     cfg.PARAMS['climate_qc_months'] = 3
+    cfg.PARAMS['baseline_climate'] = 'CRU'
 
     # Go
     gdirs = workflow.init_glacier_directories(rgidf)

--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -85,6 +85,11 @@ def up_to_climate(reset=False, use_mp=None):
     cfg.PARAMS['use_kcalving_for_inversion'] = True
     cfg.PARAMS['use_kcalving_for_run'] = True
     cfg.PARAMS['store_model_geometry'] = True
+    cfg.PARAMS['use_tstar_calibration'] = True
+    cfg.PARAMS['use_winter_prcp_factor'] = False
+    cfg.PARAMS['hydro_month_nh'] = 10
+    cfg.PARAMS['hydro_month_sh'] = 4
+    cfg.PARAMS['climate_qc_months'] = 3
 
     # Go
     gdirs = workflow.init_glacier_directories(rgidf)

--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -90,6 +90,7 @@ def up_to_climate(reset=False, use_mp=None):
     cfg.PARAMS['hydro_month_nh'] = 10
     cfg.PARAMS['hydro_month_sh'] = 4
     cfg.PARAMS['climate_qc_months'] = 3
+    cfg.PARAMS['min_mu_star'] = 10
     cfg.PARAMS['baseline_climate'] = 'CRU'
 
     # Go


### PR DESCRIPTION
<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->

Quite a major change in the default MB params. Summary:
- calendar year is now the default instead of hydrological year
- the default workflow is calibration with geodetic MB
- default climate data is W5E5
- precipitation factor is glacier specific

Main, HUGE remaining question: the "physical" bounds on mu* -> this parameter is now set between 75 and 500, which is completely arbitrary and, in particular in its lower bound, might have quite an influence on the outcome... 