### PR TITLE
Introduce scaling factor for err_dmdtda and suppress logging, both in dynamic mu star calibration

### DIFF
--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -84,7 +84,8 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
                       add_consensus=False, start_level=None,
                       start_base_url=None, max_level=5, ref_tstars_base_url='',
                       logging_level='WORKFLOW', disable_dl_verify=False,
-                      dynamic_spinup=False, dynamic_spinup_start_year=1979,
+                      dynamic_spinup=False, err_dmdtda_scaling_factor=1,
+                      dynamic_spinup_start_year=1979,
                       continue_on_error=True):
     """Generate the preprocessed OGGM glacier directories for this OGGM version
 
@@ -154,8 +155,11 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
         a dict of parameters to override.
     disable_dl_verify : bool
         disable the hash verification of OGGM downloads
-    dynamic_spinup: str
-        include a dynamic spinup matching 'area' OR 'volume' at the RGI-date
+    dynamic_spinup : str
+        include a dynamic spinup matching 'area/dmdtda' OR 'volume/dmdtda' at
+        the RGI-date
+    err_dmdtda_scaling_factor : float
+        scaling factor to reduce individual geodetic mass balance uncertainty
     dynamic_spinup_start_year : int
         if dynamic_spinup is set, define the starting year for the simulation.
         The default is 1979, unless the climate data starts later.
@@ -645,6 +649,7 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
 
             workflow.execute_entity_task(
                 tasks.run_dynamic_mu_star_calibration, gdirs,
+                err_dmdtda_scaling_factor=err_dmdtda_scaling_factor,
                 ys=dynamic_spinup_start_year, ye=ye,
                 max_mu_star=used_max_mu_star,
                 kwargs_run_function={'evolution_model': evolution_model,
@@ -835,6 +840,11 @@ def parse_args(args):
                              "the RGI-date, AND mass-change from Hugonnet "
                              "in the period 2000-2019 (dynamic mu* "
                              "calibration).")
+    parser.add_argument('--err-dmdtda-scaling-factor', type=float, default=1,
+                        help="scaling factor to account for correlated "
+                             "uncertainties of geodetic mass balance "
+                             "observations when looking at regional scale. "
+                             "Should be smaller or equal 1.")
     parser.add_argument('--dynamic-spinup-start-year', type=int, default=1979,
                         help="if --dynamic-spinup is set, define the starting"
                              "year for the simulation. The default is 1979, "
@@ -894,6 +904,7 @@ def parse_args(args):
                 ref_tstars_base_url=args.ref_tstars_base_url,
                 evolution_model=args.evolution_model,
                 dynamic_spinup=dynamic_spinup,
+                err_dmdtda_scaling_factor=args.err_dmdtda_scaling_factor,
                 dynamic_spinup_start_year=args.dynamic_spinup_start_year,
                 )
 

--- a/oggm/core/dynamic_spinup.py
+++ b/oggm/core/dynamic_spinup.py
@@ -1524,7 +1524,7 @@ def dynamic_mu_star_run_fallback(
 
 @entity_task(log, writes=['inversion_flowlines'])
 def run_dynamic_mu_star_calibration(
-        gdir, ref_dmdtda=None, err_ref_dmdtda=None,
+        gdir, ref_dmdtda=None, err_ref_dmdtda=None, err_dmdtda_scaling_factor=1,
         ref_period='', ignore_hydro_months=False, min_mu_star=None,
         max_mu_star=None, mu_star_max_step_length=5, maxiter=20,
         ignore_errors=False, output_filesuffix='_dynamic_mu_star',
@@ -1563,6 +1563,20 @@ def run_dynamic_mu_star_calibration(
         yr-1). Must always be a positive number. If None the data from Hugonett
         2021 is used.
         Default is None
+    err_dmdtda_scaling_factor : float
+        The error of the geodetic mass balance is multiplied by this factor.
+        When looking at more glaciers you should set this factor smaller than
+        1 (Default), but the smaller this factor the more glaciers will fail
+        during calibration. The factor is only used if ref_dmdtda = None and
+        err_ref_dmdtda = None.
+        The idea is that we reduce the uncertainty of individual observations
+        to count for correlated uncertainties when looking at regional or
+        global scales. If err_scaling_factor is 1 (Default) and you look at the
+        results of more than one glacier this equals that all errors are
+        uncorrelated. Therefore the result will be outside the uncertainty
+        boundaries given in Hugonett 2021 e.g. for the global estimate, because
+        some correlation of the individual errors is assumed during aggregation
+        of glaciers to regions (for more details see paper Hugonett 2021).
     ref_period : str
         If ref_dmdtda is None one of '2000-01-01_2010-01-01',
         '2010-01-01_2020-01-01', '2000-01-01_2020-01-01'. If ref_dmdtda is
@@ -1697,6 +1711,7 @@ def run_dynamic_mu_star_calibration(
         err_ref_dmdtda = float(df_ref_dmdtda.loc[df_ref_dmdtda['period'] ==
                                                  ref_period]['err_dmdtda'])
         err_ref_dmdtda *= 1000  # kg m-2 yr-1
+        err_ref_dmdtda *= err_dmdtda_scaling_factor
 
     if err_ref_dmdtda <= 0:
         raise RuntimeError('The provided error for the geodetic mass-balance '

--- a/oggm/core/dynamic_spinup.py
+++ b/oggm/core/dynamic_spinup.py
@@ -1291,11 +1291,13 @@ def dynamic_mu_star_run_with_dynamic_spinup_fallback(
         define_new_mu_star_in_gdir(gdir, mu_star)
         if do_inversion:
             with utils.DisableLogger():
-                apparent_mb_from_any_mb(gdir)
+                apparent_mb_from_any_mb(gdir,
+                                        add_to_log_file=False)
                 calibrate_inversion_from_consensus(
                     [gdir], apply_fs_on_mismatch=True, error_on_mismatch=False,
                     filter_inversion_output=True,
-                    volume_m3_reference=local_variables['vol_m3_ref'])
+                    volume_m3_reference=local_variables['vol_m3_ref'],
+                    add_to_log_file=False)
     if os.path.isfile(os.path.join(gdir.dir,
                                    'model_flowlines_dyn_mu_calib.pkl')):
         os.remove(os.path.join(gdir.dir,
@@ -1317,6 +1319,7 @@ def dynamic_mu_star_run_with_dynamic_spinup_fallback(
         model_end = run_dynamic_spinup(
             gdir,
             continue_on_error=False,  # force to raise an error in @entity_task
+            add_to_log_file=False,
             init_model_fls=fls_init,
             climate_input_filesuffix=climate_input_filesuffix,
             evolution_model=evolution_model,
@@ -1349,7 +1352,9 @@ def dynamic_mu_star_run_with_dynamic_spinup_fallback(
                     'try is to conduct a run until ye without a dynamic '
                     'spinup.')
         model_end = run_from_climate_data(
-            gdir, min_ys=yr_clim_min, ye=ye,
+            gdir,
+            add_to_log_file=False,
+            min_ys=yr_clim_min, ye=ye,
             output_filesuffix=output_filesuffix,
             climate_input_filesuffix=climate_input_filesuffix,
             store_model_geometry=store_model_geometry,
@@ -1446,6 +1451,7 @@ def dynamic_mu_star_run(
         model = run_from_climate_data(gdir,
                                       # force to raise an error in @entity_task
                                       continue_on_error=False,
+                                      add_to_log_file=False,
                                       ys=ys, ye=ye,
                                       output_filesuffix=output_filesuffix,
                                       init_model_fls=fls_init,
@@ -1456,8 +1462,9 @@ def dynamic_mu_star_run(
                            f'(Message: {e})')
 
     # calculate dmdtda from previous simulation here
-    ds = utils.compile_run_output(gdir, input_filesuffix=output_filesuffix,
-                                  path=False)
+    with utils.DisableLogger():
+        ds = utils.compile_run_output(gdir, input_filesuffix=output_filesuffix,
+                                      path=False)
     dmdtda_mdl = ((ds.volume.loc[yr1_ref_mb].values -
                    ds.volume.loc[yr0_ref_mb].values) /
                   gdir.rgi_area_m2 /
@@ -1517,6 +1524,7 @@ def dynamic_mu_star_run_fallback(
         model = run_from_climate_data(gdir,
                                       # force to raise an error in @entity_task
                                       continue_on_error=False,
+                                      add_to_log_file=False,
                                       ys=ys, ye=ye,
                                       output_filesuffix=output_filesuffix,
                                       init_model_fls=fls_init,

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -493,7 +493,8 @@ class entity_task(object):
                 if cfg.PARAMS['task_timeout'] > 0:
                     signal.alarm(0)
                 if task_name != 'gdir_to_tar':
-                    gdir.log(task_name, task_time=ex_t)
+                    if add_to_log_file:
+                        gdir.log(task_name, task_time=ex_t)
             except Exception as err:
                 # Something happened
                 out = None


### PR DESCRIPTION
Here I introduce a scaling factor for the individual uncertainty of dmdtda in the dynamic mu star calibration. The idea is to account for the correlation of individual errors of glacier observations when aggregating regional or globally. If we use the original individual uncertainty and calibrate mu star to fit inside this and afterwards sum all glaciers up we are outside the global uncertainty range. Because by fitting all glaciers inside their individual errors and summing the results up we assume all errors are completely uncorrelated, and therefore we are not inside the aggregated correlated uncertainties given by Huggonet 2021 on a global scale (see this issue https://github.com/OGGM/oggm/issues/1478). To account for this the new scaling factor should be set smaller 1. But the smaller the scaling factor the harder it will become to dynamically calibrate mu star. (We need to do some experiments to find a sweet spot.)

Further, I suppress unnecessary logging messages now during the dynamic mu star calibration. For this, I mainly had to include one line in `class entity_task` as there was already a kwarg available `add_to_log_file`, but it was only used if the task raise an error and I now added the functionality also if the task is successful. (This is related to https://github.com/OGGM/oggm/issues/1476)

- [x] Tests added/passed
- [ ] Fully documented
- [ ] Entry in `whats-new.rst` 
