### PR TITLE
adding trapezoidal downstream line

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -55,6 +55,10 @@ Enhancements
   By `Patrick Schmitt <https://github.com/pat-schmitt>`_
 - Added support for Millan et al 2022 velocity and thickness in the shop (:pull:`1443`).
   By `Fabien Maussion <https://github.com/fmaussion>`_
+- Added trapezoidal downstream line (:pull:`1491`). Can be selected with
+  ``cfg.PARAMS['downstream_line_shape']``, with the options ``'parabol'`` (default)
+  or ``'trapezoidal'`` before calling ``init_present_time_glacier(gdir)``.
+  By `Patrick Schmitt <https://github.com/pat-schmitt>`_
 
 Bug fixes
 ~~~~~~~~~

--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -526,6 +526,7 @@ def initialize_minimal(file=None, logging_level='INFO', params=None,
     PARAMS['mpi_recv_buf_size'] = cp.as_int('mpi_recv_buf_size')
     PARAMS['use_multiple_flowlines'] = cp.as_bool('use_multiple_flowlines')
     PARAMS['filter_min_slope'] = cp.as_bool('filter_min_slope')
+    PARAMS['downstream_line_shape'] = cp['downstream_line_shape']
     PARAMS['auto_skip_task'] = cp.as_bool('auto_skip_task')
     PARAMS['correct_for_neg_flux'] = cp.as_bool('correct_for_neg_flux')
     PARAMS['filter_for_neg_flux'] = cp.as_bool('filter_for_neg_flux')
@@ -595,7 +596,7 @@ def initialize_minimal(file=None, logging_level='INFO', params=None,
     except ValueError:
         PARAMS['prcp_scaling_factor'] = None
 
-     # Delete non-floats
+    # Delete non-floats
     ltr = ['working_dir', 'dem_file', 'climate_file', 'use_tar_shapefiles',
            'grid_dx_method', 'run_mb_calibration', 'compress_climate_netcdf',
            'mp_processes', 'use_multiprocessing', 'climate_qc_months',
@@ -616,7 +617,8 @@ def initialize_minimal(file=None, logging_level='INFO', params=None,
            'tidewater_type', 'store_model_geometry', 'use_winter_prcp_factor',
            'store_diagnostic_variables', 'store_fl_diagnostic_variables',
            'geodetic_mb_period', 'store_fl_diagnostics', 'winter_prcp_factor_ab',
-           'winter_prcp_factor_range', 'prcp_scaling_factor']
+           'winter_prcp_factor_range', 'prcp_scaling_factor',
+           'downstream_line_shape']
     for k in ltr:
         cp.pop(k, None)
 

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -2787,14 +2787,26 @@ def init_present_time_glacier(gdir, filesuffix=''):
         lambdas[bed_shape == 0] = def_lambda
 
         if not gdir.is_tidewater and inv['is_last']:
-            # for valley glaciers, simply add the downstream line
+            # for valley glaciers, simply add the downstream line, depending on
+            # selected shape parabola or trapezoidal
             dic_ds = gdir.read_pickle('downstream_line')
-            bed_shape = np.append(bed_shape, dic_ds['bedshapes'])
-            lambdas = np.append(lambdas, dic_ds['bedshapes'] * np.NaN)
+            if cfg.PARAMS['downstream_line_shape'] == 'parabola':
+                bed_shape = np.append(bed_shape, dic_ds['bedshapes'])
+                lambdas = np.append(lambdas, dic_ds['bedshapes'] * np.NaN)
+                widths_m = np.append(widths_m, dic_ds['bedshapes'] * 0.)
+            elif cfg.PARAMS['downstream_line_shape'] == 'trapezoidal':
+                bed_shape = np.append(bed_shape, dic_ds['bedshapes'] * np.NaN)
+                lambdas = np.append(lambdas, np.ones(len(dic_ds['w0s'])) *
+                                    def_lambda)
+                widths_m = np.append(widths_m, dic_ds['w0s'])
+            else:
+                raise InvalidParamsError(
+                    f"Unknown cfg.PARAMS['downstream_line_shape'] = "
+                    f"{cfg.PARAMS['downstream_line_shape']} (options are "
+                    f"'parabola' and 'trapezoidal').")
             section = np.append(section, dic_ds['bedshapes'] * 0.)
             surface_h = np.append(surface_h, dic_ds['surface_h'])
             bed_h = np.append(bed_h, dic_ds['surface_h'])
-            widths_m = np.append(widths_m, dic_ds['bedshapes'] * 0.)
             line = dic_ds['full_line']
 
         if gdir.is_tidewater and inv['is_last']:

--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -164,6 +164,14 @@ base_binsize = 50.
 # 1 means default (i.e. kernel size 9).
 smooth_widths_window_size = 1
 
+### DOWNSTREAM LINE
+# define which bed shape should be used for the ice free downstream line, the
+# options are 'parabola' or 'trapezoidal'
+downstream_line_shape = 'parabola'
+# defines the minimum bottom width of a potential trapezoidal downstream line
+# in meters
+trapezoid_min_bottom_width = 50.
+
 ### CLIMATE params
 
 # Baseline climate is the reference climate data to use for this workflow.


### PR DESCRIPTION
In this PR I add an option to define a trapezoidal downstream line instead of a parabol one. The shape can be selected with `cfg.PARAMS['downstream_line_shape']` with options `'parabola'` or `'trapezoidal'` before calling `init_present_time_glacier(gdir)`. The trapezoidal shape is defined in a way that the valley cross section area is the same between the parabola and the trapezoidal when looking at the terrain height (which is defined by the DEM).

- [x] Tests added/passed
- [ ] Fully documented
- [x] Entry in `whats-new.rst` 
