### PR TITLE
add option to plot flowline velocity on map

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -59,6 +59,9 @@ Enhancements
   ``cfg.PARAMS['downstream_line_shape']``, with the options ``'parabol'`` (default)
   or ``'trapezoidal'`` before calling ``init_present_time_glacier(gdir)``.
   By `Patrick Schmitt <https://github.com/pat-schmitt>`_
+- Added option to plot flowline velocities in ``graphics.plot_modeloutput_map()``
+  (:pull:`1496`)
+  By `Patrick Schmitt <https://github.com/pat-schmitt>`_
 
 Bug fixes
 ~~~~~~~~~


### PR DESCRIPTION
In this PR I added an option to `graphics.plot_modeloutput_map` to be able to plot the flowline velocities onto a 2D map. This is not a real distributed 2D velocity field! It is just a nice representation of the flowline velocities we get from the model (similar to what is done for the thickness in (e) and (f) in this figure https://docs.oggm.org/en/latest/_images/ex_workflow.png).

Should I add a test figure for this new option, or is the already implemented test for the thickness plot sufficient? If I should add a test for the velocity this could probably be done by returning one plot with two subplots for the thickness and the velocity in the test https://github.com/OGGM/oggm/blob/master/oggm/tests/test_graphics.py#L437.

- [ ] Tests added/passed
- [ ] Fully documented
- [x] Entry in `whats-new.rst` 
