### PR TITLE
Updated define_glacier_region to handle a list of DEM sources

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -69,6 +69,9 @@ Bug fixes
 - corrected a but in ``apparent_mb_from_any_mb``, where only two years of MB
   would be used instead of a range of years (:pull:`1426`).
   By `Bowen <https://github.com/bowenbelongstonature>`_
+- Corrected ``source`` argument in ``tasks.define_glacier_region`` to handle a
+  list of DEM sources. (:pull:`1503`).
+  By `Daniel Otto <https://github.com/d-otto>`_
 
 Migrating guide
 ~~~~~~~~~~~~~~~

--- a/oggm/core/gis.py
+++ b/oggm/core/gis.py
@@ -333,7 +333,16 @@ def define_glacier_region(gdir, entity=None, source=None):
 
     # Open DEM
     # We test DEM availability for glacier only (maps can grow big)
-    if not is_dem_source_available(source, *gdir.extent_ll):
+    if isinstance(source, list):  # when multiple sources are provided, try them sequentially
+        for i, src in enumerate(source):
+            source_exists = is_dem_source_available(src, *gdir.extent_ll)
+            if source_exists:
+                source = source[i]  # pick the first source which exists
+                break
+    else:
+        source_exists = is_dem_source_available(source, *gdir.extent_ll)
+        
+    if source_exists is False:
         raise InvalidWorkflowError(f'Source: {source} is not available for '
                                    f'glacier {gdir.rgi_id} with border '
                                    f"{cfg.PARAMS['border']}")


### PR DESCRIPTION
Still a bit new to PR's, apologies if I missed something.

The docs for `tasks.define_glacier_region` say `source` accepts a string or list of strings, but it was not implemented. Passing a list to `source` now tries listed DEM sources until a valid one is found. 

For example, I can now prefer Alaska DEM where it is available :)

