### PR TITLE
plot multiple glaciers in same plot

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -60,7 +60,12 @@ Enhancements
   or ``'trapezoidal'`` before calling ``init_present_time_glacier(gdir)``.
   By `Patrick Schmitt <https://github.com/pat-schmitt>`_
 - Added option to plot flowline velocities in ``graphics.plot_modeloutput_map()``
-  (:pull:`1496`)
+  (:pull:`1496`).
+  By `Patrick Schmitt <https://github.com/pat-schmitt>`_
+- Added option to extend the plot limits when plotting multiple gdirs. Could be
+  used with ``extend_plot_limits=True``, e.g.
+  ``graphics.plot_modeloutput_map(gdirs, extend_plot_limits=True)``
+  (:pull:`1508`).
   By `Patrick Schmitt <https://github.com/pat-schmitt>`_
 
 Bug fixes

--- a/oggm/graphics.py
+++ b/oggm/graphics.py
@@ -129,8 +129,8 @@ def combine_grids(gdirs):
         dy = gdir.grid.dy
         if dx_use is None or dx_use > dx:
             dx_use = dx
-        # dy is negative
-        if dy_use is None or dy_use < dy:
+        # dy could be negative
+        if dy_use is None or abs(dy_use) > abs(dy):
             dy_use = dy
 
     # calculate nx and ny, the final extend could be one grid point larger or
@@ -139,7 +139,10 @@ def combine_grids(gdirs):
     ny_use = round((top_use - bottom_use) / abs(dy_use))
 
     # finally define the last values of the new grid
-    new_grid['x0y0'] = (left_use, top_use)
+    if np.sign(dy_use) < 0:
+        new_grid['x0y0'] = (left_use, top_use)
+    else:
+        new_grid['x0y0'] = (left_use, bottom_use)
     new_grid['nxny'] = (nx_use, ny_use)
     new_grid['dxdy'] = (dx_use, dy_use)
 

--- a/oggm/graphics.py
+++ b/oggm/graphics.py
@@ -76,6 +76,76 @@ def surf_to_nan(surf_h, thick):
     return surf_h
 
 
+def combine_grids(gdirs):
+    """ Combines individual grids of different glacier directories to show
+        multiple glaciers in the same plot. The resulting grid extent includes
+        all individual grids completely.
+
+    Parameters
+    ----------
+    gdirs : [], required
+        A list of GlacierDirectories.
+
+    Returns
+    -------
+    salem.gis.Grid
+    """
+
+    new_grid = {
+        'proj': None,
+        'nxny': None,
+        'dxdy': None,
+        'x0y0': None,
+        'pixel_ref': None
+    }
+
+    left_use = None
+    right_use = None
+    bottom_use = None
+    top_use = None
+    dx_use = None
+    dy_use = None
+
+    for gdir in gdirs:
+        # use the first gdir to define some values
+        if new_grid['proj'] is None:
+            new_grid['proj'] = gdir.grid.proj
+        if new_grid['pixel_ref'] is None:
+            new_grid['pixel_ref'] = gdir.grid.pixel_ref
+
+        # find largest extend including all grids completely
+        (left, right, bottom, top) = gdir.grid.extent_in_crs(new_grid['proj'])
+        if (left_use is None) or (left_use > left):
+            left_use = left
+        if right_use is None or right_use < right:
+            right_use = right
+        if bottom_use is None or bottom_use > bottom:
+            bottom_use = bottom
+        if top_use is None or top_use < top:
+            top_use = top
+
+        # find smallest dx and dy for the estimation of nx and ny
+        dx = gdir.grid.dx
+        dy = gdir.grid.dy
+        if dx_use is None or dx_use > dx:
+            dx_use = dx
+        # dy is negative
+        if dy_use is None or dy_use < dy:
+            dy_use = dy
+
+    # calculate nx and ny, the final extend could be one grid point larger or
+    # smaller due to round()
+    nx_use = round((right_use - left_use) / dx_use)
+    ny_use = round((top_use - bottom_use) / abs(dy_use))
+
+    # finally define the last values of the new grid
+    new_grid['x0y0'] = (left_use, top_use)
+    new_grid['nxny'] = (nx_use, ny_use)
+    new_grid['dxdy'] = (dx_use, dy_use)
+
+    return salem.gis.Grid.from_dict(new_grid)
+
+
 def _plot_map(plotfunc):
     """
     Decorator for common salem.Map plotting logic
@@ -114,6 +184,8 @@ def _plot_map(plotfunc):
         save the figure to a file instead of displaying it
     savefig_kwargs : dict, optional
         the kwargs to plt.savefig
+    extend_plot_limit : bool, optional
+        set to True to extend the plotting limits for all provided gdirs grids
     """
 
     # Build on the original docstring
@@ -124,7 +196,7 @@ def _plot_map(plotfunc):
                     title_comment=None, horizontal_colorbar=False,
                     lonlat_contours_kwargs=None, cbar_ax=None, autosave=False,
                     add_scalebar=True, figsize=None, savefig=None,
-                    savefig_kwargs=None,
+                    savefig_kwargs=None, extend_plot_limit=False,
                     **kwargs):
 
         dofig = False
@@ -137,8 +209,13 @@ def _plot_map(plotfunc):
         gdirs = utils.tolist(gdirs)
 
         if smap is None:
-            mp = salem.Map(gdirs[0].grid, countries=False,
-                           nx=gdirs[0].grid.nx)
+            if extend_plot_limit:
+                grid_combined = combine_grids(gdirs)
+                mp = salem.Map(grid_combined, countries=False,
+                               nx=grid_combined.nx)
+            else:
+                mp = salem.Map(gdirs[0].grid, countries=False,
+                               nx=gdirs[0].grid.nx)
         else:
             mp = smap
 

--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -424,8 +424,12 @@ def test_plot_region_inversion():
     sm.set_topography(get_demo_file('srtm_oetztal.tif'))
 
     # Give this to the plot function
-    fig, ax = plt.subplots()
-    graphics.plot_inversion(gdirs, smap=sm, ax=ax, linewidth=1.5, vmax=250)
+    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(15, 5))
+    graphics.plot_inversion(gdirs, smap=sm, ax=ax1, linewidth=1.5, vmax=250)
+
+    # test automatic definition of larger plotting grid with extend_plot_limit
+    graphics.plot_inversion(gdirs, ax=ax2, linewidth=1.5, vmax=250,
+                            extend_plot_limit=True)
 
     fig.tight_layout()
     return fig

--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -451,10 +451,15 @@ def test_plot_region_model():
     sm.set_topography(get_demo_file('srtm_oetztal.tif'))
 
     # Give this to the plot function
-    fig, ax = plt.subplots()
-    graphics.plot_modeloutput_map(gdirs, smap=sm, ax=ax,
+    fig, (ax1, ax2) = plt.subplots(1, 2)
+    graphics.plot_modeloutput_map(gdirs, smap=sm, ax=ax1,
                                   filesuffix='_plot', vmax=250,
                                   modelyr=10, linewidth=1.5)
+    # test automatic definition of larger plotting grid with extend_plot_limit
+    graphics.plot_modeloutput_map(gdirs, ax=ax2,
+                                  filesuffix='_plot', vmax=250,
+                                  modelyr=10, linewidth=1.5,
+                                  extend_plot_limit=True)
 
     fig.tight_layout()
     return fig

--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -451,7 +451,7 @@ def test_plot_region_model():
     sm.set_topography(get_demo_file('srtm_oetztal.tif'))
 
     # Give this to the plot function
-    fig, (ax1, ax2) = plt.subplots(1, 2)
+    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(15, 5))
     graphics.plot_modeloutput_map(gdirs, smap=sm, ax=ax1,
                                   filesuffix='_plot', vmax=250,
                                   modelyr=10, linewidth=1.5)

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -69,7 +69,7 @@ logger = logging.getLogger('.'.join(__name__.split('.')[:-1]))
 # The given commit will be downloaded from github and used as source for
 # all sample data
 SAMPLE_DATA_GH_REPO = 'OGGM/oggm-sample-data'
-SAMPLE_DATA_COMMIT = 'dbd57434df8fade8d8df9206839b9bf26a1ef8e6'
+SAMPLE_DATA_COMMIT = 'd9f01846960a141690bab9d38a85524d89a0d9ae'
 
 CHECKSUM_URL = 'https://cluster.klima.uni-bremen.de/data/downloads.sha256.hdf'
 CHECKSUM_VALIDATION_URL = CHECKSUM_URL + '.sha256'


### PR DESCRIPTION
In this PR I add the functionality to plot multiple glaciers in the same plot.

For this, a new grid is defined which contains all local gdir.grid completely. This new functionality can be used with the kwarg `extend_plot_limit` (e.g. `plot_inversion(gdirs, extend_plot_limit=True)`). If this is used there will be no topographic shading!

Closes https://github.com/OGGM/oggm/issues/1007

(I have not added tests as it is only a plotting function)

- [ ] Fully documented
- [x] Entry in `whats-new.rst` 
