### PR TITLE
code line in _downloads.py is now also compatible with the RGI7 shapefile names

### DIFF
--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -1916,7 +1916,7 @@ def get_rgi_region_file(region, version=None, reset=False):
     """
 
     rgi_dir = get_rgi_dir(version=version, reset=reset)
-    f = list(glob.glob(rgi_dir + "/*/{}_*.shp".format(region)))
+    f = list(glob.glob(rgi_dir + "/*/*{}_*.shp".format(region)))
     assert len(f) == 1
     return f[0]
 


### PR DESCRIPTION
@fmaussion 
Changed this line, as RGI7 shapefiles do not start with the Region number('01, '02', ..., '19') right away, but have the 'RGI2000-v7.0-G-' as a prefix. 

Thoughts on this:
The expected two-digit region numbers (01 to 19) are not contained in the prefix, so they will work fine.
If the one-digit region numbers '2' or '7' would arrive at this part of the code [the assert in the following line](https://github.com/afisc/oggm/commit/2fbe5309b81c8e1f1ad8e42b43656b423c99bc4f#diff-44eab47742df0dfb4ccda9c29e5c2ffd94286c9f9e438e297f03df5e5776ba2eL1920) of the changed code line would be triggered.



- [ ] Tests added/passed => general tests for RGI7 will be added soon.
