### PR TITLE
Small dynamic spinup adaption

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -62,6 +62,10 @@ Enhancements
 - Added option to plot flowline velocities in ``graphics.plot_modeloutput_map()``
   (:pull:`1496`)
   By `Patrick Schmitt <https://github.com/pat-schmitt>`_
+- Added new argument ``add_fixed_geometry_spinup`` to extend the model run of
+  ``run_dynamic_spinup`` with a fixed-geometry-spinup if the spinup period is
+  shortened(:pull:`1514`)
+  By `Patrick Schmitt <https://github.com/pat-schmitt>`_
 
 Bug fixes
 ~~~~~~~~~

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -3739,7 +3739,7 @@ class TestHEF:
             prepro_base_url='https://cluster.klima.uni-bremen.de/~oggm/gdirs/'
                             'oggm_v1.4/L3-L5_files/ERA5/elev_bands/qc3/pcp1.6/'
                             'match_geod_pergla/')[0]
-        yr_rgi = gdir.rgi_date
+        yr_rgi = gdir.rgi_date + 1  # + 1 for hydro year
         run_dynamic_spinup(
             gdir,
             spinup_start_yr=1979,
@@ -3770,7 +3770,7 @@ class TestHEF:
 
         # test that fixed_geometry_spinup is added correctly if spinup period
         # is shorten, with spinup period
-        spinup_period = 20
+        spinup_period = yr_rgi - 1979
         run_dynamic_spinup(
             gdir,
             spinup_period=spinup_period,

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -3731,6 +3731,74 @@ class TestHEF:
                 minimise_for=minimise_for)
         cfg.PARAMS['use_kcalving_for_run'] = False
 
+        # test that fixed_geometry_spinup is added correctly if spinup period
+        # is shorten, with fixed year (spinup_start_yr)
+        gdir = workflow.init_glacier_directories(
+            ['RGI60-11.00033'],
+            from_prepro_level=3, prepro_border=160,
+            prepro_base_url='https://cluster.klima.uni-bremen.de/~oggm/gdirs/'
+                            'oggm_v1.4/L3-L5_files/ERA5/elev_bands/qc3/pcp1.6/'
+                            'match_geod_pergla/')[0]
+        yr_rgi = gdir.rgi_date
+        run_dynamic_spinup(
+            gdir,
+            spinup_start_yr=1979,
+            precision_percent=2,
+            minimise_for=minimise_for,
+            output_filesuffix='_without_fixed_spinup',
+            init_model_yr=yr_rgi,
+            add_fixed_geometry_spinup=False)
+        fp = gdir.get_filepath('model_diagnostics',
+                               filesuffix='_without_fixed_spinup')
+        with xr.open_dataset(fp) as ds:
+            run_without_fixed_spinup = ds.load()
+        run_dynamic_spinup(
+            gdir,
+            spinup_start_yr=1979,
+            precision_percent=2,
+            minimise_for=minimise_for,
+            output_filesuffix='_with_fixed_spinup',
+            init_model_yr=yr_rgi,
+            add_fixed_geometry_spinup=True)
+        fp = gdir.get_filepath('model_diagnostics',
+                               filesuffix='_with_fixed_spinup')
+        with xr.open_dataset(fp) as ds:
+            run_with_fixed_spinup = ds.load()
+        assert (run_without_fixed_spinup.time.values[0] >
+                run_with_fixed_spinup.time.values[0])
+        assert run_with_fixed_spinup.time.values[0] == 1979
+
+        # test that fixed_geometry_spinup is added correctly if spinup period
+        # is shorten, with spinup period
+        spinup_period = 20
+        run_dynamic_spinup(
+            gdir,
+            spinup_period=spinup_period,
+            precision_percent=2,
+            minimise_for=minimise_for,
+            output_filesuffix='_without_fixed_spinup',
+            init_model_yr=yr_rgi,
+            add_fixed_geometry_spinup=False)
+        fp = gdir.get_filepath('model_diagnostics',
+                               filesuffix='_without_fixed_spinup')
+        with xr.open_dataset(fp) as ds:
+            run_without_fixed_spinup = ds.load()
+        run_dynamic_spinup(
+            gdir,
+            spinup_period=spinup_period,
+            precision_percent=2,
+            minimise_for=minimise_for,
+            output_filesuffix='_with_fixed_spinup',
+            init_model_yr=yr_rgi,
+            add_fixed_geometry_spinup=True)
+        fp = gdir.get_filepath('model_diagnostics',
+                               filesuffix='_with_fixed_spinup')
+        with xr.open_dataset(fp) as ds:
+            run_with_fixed_spinup = ds.load()
+        assert (run_without_fixed_spinup.time.values[0] >
+                run_with_fixed_spinup.time.values[0])
+        assert run_with_fixed_spinup.time.values[0] == yr_rgi - spinup_period
+
         # change settings back to default
         cfg.PARAMS['use_inversion_params_for_run'] = True
         cfg.PARAMS['prcp_scaling_factor'] = 2.5
@@ -4153,12 +4221,14 @@ class TestHEF:
             kwargs_run_function={'minimise_for': minimise_for,
                                  'precision_percent': precision_percent,
                                  'precision_absolute': precision_absolute,
-                                 'do_inversion': do_inversion},
+                                 'do_inversion': do_inversion,
+                                 'add_fixed_geometry_spinup': False},
             fallback_function=dynamic_mu_star_run_with_dynamic_spinup_fallback,
             kwargs_fallback_function={'minimise_for': minimise_for,
                                       'precision_percent': precision_percent,
                                       'precision_absolute': precision_absolute,
-                                      'do_inversion': do_inversion},
+                                      'do_inversion': do_inversion,
+                                      'add_fixed_geometry_spinup': False},
             output_filesuffix='_dyn_mu_calib_spinup_reduce_period_no_limit',
             ys=1979, ye=ye)
         # run with max limit
@@ -4170,29 +4240,71 @@ class TestHEF:
             run_function=dynamic_mu_star_run_with_dynamic_spinup,
             kwargs_run_function={'minimise_for': minimise_for,
                                  'spinup_start_yr_max': 1979,
+                                 'add_fixed_geometry_spinup': False,
                                  'precision_percent': precision_percent,
                                  'precision_absolute': precision_absolute,
                                  'do_inversion': do_inversion},
             fallback_function=dynamic_mu_star_run_with_dynamic_spinup_fallback,
             kwargs_fallback_function={'minimise_for': minimise_for,
                                       'spinup_start_yr_max': 1979,
+                                      'add_fixed_geometry_spinup': False,
                                       'precision_percent': precision_percent,
                                       'precision_absolute': precision_absolute,
                                       'do_inversion': do_inversion},
             output_filesuffix='_dyn_mu_calib_spinup_reduce_period',
             ys=1979, ye=ye)
 
-        run_no_limit = xr.open_dataset(
+        with xr.open_dataset(
             gdir.get_filepath(
                 'model_diagnostics',
-                filesuffix='_dyn_mu_calib_spinup_reduce_period_no_limit'))
-        run_with_limit = xr.open_dataset(
+                filesuffix='_dyn_mu_calib_spinup_reduce_period_'
+                           'no_limit')) as ds:
+            run_no_limit = ds.load()
+        with xr.open_dataset(
             gdir.get_filepath(
                 'model_diagnostics',
-                filesuffix='_dyn_mu_calib_spinup_reduce_period'))
+                filesuffix='_dyn_mu_calib_spinup_reduce_period')) as ds:
+            run_with_limit = ds.load()
 
         assert run_no_limit.time.values[0] > run_with_limit.time.values[0]
         assert run_with_limit.time.values[0] == 1979
+
+        # test if add_fixed_geomtry_spinup of dynamic spinup works here as well
+        # run with add_fixed_geometry_spinup
+        run_dynamic_mu_star_calibration(
+            gdir, max_mu_star=1000.,
+            ref_dmdtda=ref_dmdtda + delta_ref_dmdtda,
+            err_ref_dmdtda=err_ref_dmdtda + delta_err_ref_dmdtda,
+            ignore_errors=True,
+            run_function=dynamic_mu_star_run_with_dynamic_spinup,
+            kwargs_run_function={'minimise_for': minimise_for,
+                                 'add_fixed_geometry_spinup': True,
+                                 'precision_percent': precision_percent,
+                                 'precision_absolute': precision_absolute,
+                                 'do_inversion': do_inversion},
+            fallback_function=dynamic_mu_star_run_with_dynamic_spinup_fallback,
+            kwargs_fallback_function={'minimise_for': minimise_for,
+                                      'add_fixed_geometry_spinup': True,
+                                      'precision_percent': precision_percent,
+                                      'precision_absolute': precision_absolute,
+                                      'do_inversion': do_inversion},
+            output_filesuffix='_dyn_mu_calib_add_fixed_spinup',
+            ys=1979, ye=ye)
+        with xr.open_dataset(
+            gdir.get_filepath(
+                'model_diagnostics',
+                filesuffix='_dyn_mu_calib_add_fixed_spinup')) as ds:
+            run_with_fixed_spinup = ds.load()
+
+        assert (run_no_limit.time.values[0] >
+                run_with_fixed_spinup.time.values[0])
+        assert run_with_fixed_spinup.time.values[0] == 1979
+        # also compare the difference of spinup_start_yr_max and
+        # add_fixed_geometry_spinup
+        assert (run_with_limit.time.values[0] ==
+                run_with_fixed_spinup.time.values[0])
+        assert (run_with_fixed_spinup.is_fixed_geometry_spinup.sum() <
+                run_with_limit.is_fixed_geometry_spinup.sum())
 
         # change settings back to default
         cfg.PARAMS['prcp_scaling_factor'] = 2.5

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -4125,6 +4125,75 @@ class TestHEF:
                 minimise_for=minimise_for
             )
 
+        # check if spinup_start_year_max works as expected, for this use a
+        # glacier where the period is shorten
+        gdir = workflow.init_glacier_directories(
+            ['RGI60-11.00033'],
+            from_prepro_level=3, prepro_border=160,
+            prepro_base_url='https://cluster.klima.uni-bremen.de/~oggm/gdirs/'
+                            'oggm_v1.4/L3-L5_files/ERA5/elev_bands/qc3/pcp1.6/'
+                            'match_geod_pergla/')[0]
+        df_ref_dmdtda = utils.get_geodetic_mb_dataframe().loc[gdir.rgi_id]
+        ref_dmdtda = float(
+            df_ref_dmdtda.loc[df_ref_dmdtda['period'] == ref_period]['dmdtda'])
+        ref_dmdtda *= 1000  # kg m-2 yr-1
+        err_ref_dmdtda = float(df_ref_dmdtda.loc[df_ref_dmdtda['period'] ==
+                                                 ref_period]['err_dmdtda'])
+        err_ref_dmdtda *= 1000  # kg m-2 yr-1
+        precision_percent = 10
+        precision_absolute = 0.1
+        ye = gdir.get_climate_info()['baseline_hydro_yr_1'] + 1
+
+        # run without max limit
+        run_dynamic_mu_star_calibration(
+            gdir, max_mu_star=1000.,
+            ref_dmdtda=ref_dmdtda + delta_ref_dmdtda,
+            err_ref_dmdtda=err_ref_dmdtda + delta_err_ref_dmdtda,
+            run_function=dynamic_mu_star_run_with_dynamic_spinup,
+            kwargs_run_function={'minimise_for': minimise_for,
+                                 'precision_percent': precision_percent,
+                                 'precision_absolute': precision_absolute,
+                                 'do_inversion': do_inversion},
+            fallback_function=dynamic_mu_star_run_with_dynamic_spinup_fallback,
+            kwargs_fallback_function={'minimise_for': minimise_for,
+                                      'precision_percent': precision_percent,
+                                      'precision_absolute': precision_absolute,
+                                      'do_inversion': do_inversion},
+            output_filesuffix='_dyn_mu_calib_spinup_reduce_period_no_limit',
+            ys=1979, ye=ye)
+        # run with max limit
+        run_dynamic_mu_star_calibration(
+            gdir, max_mu_star=1000.,
+            ref_dmdtda=ref_dmdtda + delta_ref_dmdtda,
+            err_ref_dmdtda=err_ref_dmdtda + delta_err_ref_dmdtda,
+            ignore_errors=True,
+            run_function=dynamic_mu_star_run_with_dynamic_spinup,
+            kwargs_run_function={'minimise_for': minimise_for,
+                                 'spinup_start_yr_max': 1979,
+                                 'precision_percent': precision_percent,
+                                 'precision_absolute': precision_absolute,
+                                 'do_inversion': do_inversion},
+            fallback_function=dynamic_mu_star_run_with_dynamic_spinup_fallback,
+            kwargs_fallback_function={'minimise_for': minimise_for,
+                                      'spinup_start_yr_max': 1979,
+                                      'precision_percent': precision_percent,
+                                      'precision_absolute': precision_absolute,
+                                      'do_inversion': do_inversion},
+            output_filesuffix='_dyn_mu_calib_spinup_reduce_period',
+            ys=1979, ye=ye)
+
+        run_no_limit = xr.open_dataset(
+            gdir.get_filepath(
+                'model_diagnostics',
+                filesuffix='_dyn_mu_calib_spinup_reduce_period_no_limit'))
+        run_with_limit = xr.open_dataset(
+            gdir.get_filepath(
+                'model_diagnostics',
+                filesuffix='_dyn_mu_calib_spinup_reduce_period'))
+
+        assert run_no_limit.time.values[0] > run_with_limit.time.values[0]
+        assert run_with_limit.time.values[0] == 1979
+
         # change settings back to default
         cfg.PARAMS['prcp_scaling_factor'] = 2.5
         cfg.PARAMS['hydro_month_nh'] = 10


### PR DESCRIPTION
I realized that after `run_dynamic_mu_star_calibration` the resulting model run is not always starting from the given start year. The reason for this is that the dynamic spinup tries out shorter spinup periods (= later start years) if the glacier is becoming ice-free or growing out of the boundary (e.g. the idea is if the spinup period is shorter the glacier has less time to grow out of the boundary). But for analysis, it would be nice to have a time series of all glaciers which start at the same defined year.

Therefore I introduce here a new option to deal with this in `run_dynamic_spinup`, which is the new default in `run_dynamic_mu_star_calibration`: If the period must be shortened we extend the time series with a shorter fixed-geometry-spinup.

- [x] Tests added/passed
- [ ] Fully documented (in Tutorial)
- [x] Entry in `whats-new.rst` 
