### PR TITLE
rearanged use of area_min_h

### DIFF
--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -341,8 +341,8 @@ use_inversion_params_for_run = True
 ### Dynamic spinup params
 # Defines the minimum ice thickness which is used during the dynamic spinup to
 # match area or volume. Only grid points with a larger thickness are considered
-# to the total area or volume. This is needed especially for the area to filter
-# out area changes due to climate variability around the rgi year.
+# to the total area. This is needed to filter out area changes due to climate
+# variability around the rgi year (spikes).
 dynamic_spinup_min_ice_thick = 10.
 
 ### Tidewater glaciers options

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -4616,6 +4616,10 @@ class TestHydro:
         # Needed for this to run
         cfg.PARAMS['store_model_geometry'] = True
 
+        # need to add area min h if I want to merge two runs for compatibility
+        ovars = cfg.PARAMS['store_diagnostic_variables']
+        ovars += ['area_min_h']
+
         init_present_time_glacier(gdir)
         tasks.run_with_hydro(gdir, run_task=tasks.run_dynamic_spinup,
                              store_monthly_hydro=True,


### PR DESCRIPTION
Here I adapt the usage of the minimum ice thickness for the dynamic spinup. Now the filter is only applied to area (not volume) and the variable `area_m2_min_h` is only saved during the dynamic spinup run or if a user adds it explicitly to `cfg.PARAMS['store_diagnostic_variables']`.

Thanks, @lilianschuster for bringing this up.

Closes https://github.com/OGGM/oggm/issues/1540

- [ ] Tests added/passed
- [ ] Fully documented
- [ ] Entry in `whats-new.rst` 
