### PR TITLE
add more flexibility to compile_run_output

### DIFF
--- a/oggm/core/dynamic_spinup.py
+++ b/oggm/core/dynamic_spinup.py
@@ -41,7 +41,7 @@ def run_dynamic_spinup(gdir, init_model_filesuffix=None, init_model_yr=None,
                        store_model_geometry=True, store_fl_diagnostics=None,
                        store_model_evolution=True, ignore_errors=False,
                        return_t_bias_best=False, ye=None,
-                       model_flowline_filesuffix='', make_compatible=False,
+                       model_flowline_filesuffix='',
                        add_fixed_geometry_spinup=False, **kwargs):
     """Dynamically spinup the glacier to match area or volume at the RGI date.
 
@@ -180,14 +180,6 @@ def run_dynamic_spinup(gdir, init_model_filesuffix=None, init_model_yr=None,
         suffix to the model_flowlines filename to use (if no other flowlines
         are provided with init_model_filesuffix or init_model_fls).
         Default is ''
-    make_compatible : bool
-        if set to true this will add all variables to the resulting dataset
-        so it could be combined with any other one. This is necessary if
-        different spinup methods are used. For example if using the dynamic
-        spinup and setting fixed geometry spinup as fallback, the variable
-        'is_fixed_geometry_spinup' must be added to the dynamic spinup so
-        it is possible to compile both glaciers together.
-        Default is False
     add_fixed_geometry_spinup : bool
         If True and the original spinup_period must be shortened (due to
         ice-free or out-of-boundary error) a fixed geometry spinup is added at
@@ -326,8 +318,7 @@ def run_dynamic_spinup(gdir, init_model_filesuffix=None, init_model_yr=None,
                 yr_run,
                 geom_path=geom_path,
                 diag_path=diag_path,
-                fl_diag_path=fl_diag_path,
-                make_compatible=make_compatible)
+                fl_diag_path=fl_diag_path)
 
         return model_dynamic_spinup_end
 
@@ -425,8 +416,7 @@ def run_dynamic_spinup(gdir, init_model_filesuffix=None, init_model_yr=None,
                 diag_path=diag_path,
                 fl_diag_path=fl_diag_path,
                 dynamic_spinup_min_ice_thick=min_ice_thickness,
-                fixed_geometry_spinup_yr=fixed_geometry_spinup_yr,
-                make_compatible=make_compatible)
+                fixed_geometry_spinup_yr=fixed_geometry_spinup_yr)
 
             # now we delete the min_h variable again if it was not
             # included before (inplace)
@@ -1186,7 +1176,6 @@ def dynamic_melt_f_run_with_dynamic_spinup(
             store_model_geometry=store_model_geometry,
             store_fl_diagnostics=store_fl_diagnostics,
             model_flowline_filesuffix=model_flowline_filesuffix,
-            make_compatible=True,
             add_fixed_geometry_spinup=add_fixed_geometry_spinup,
             **kwargs)
         # save the temperature bias which was successful in the last iteration
@@ -1412,7 +1401,6 @@ def dynamic_melt_f_run_with_dynamic_spinup_fallback(
             store_fl_diagnostics=store_fl_diagnostics,
             ignore_errors=False,
             ye=ye,
-            make_compatible=True,
             add_fixed_geometry_spinup=add_fixed_geometry_spinup,
             **kwargs)
 

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -933,7 +933,6 @@ class FlowlineModel(object):
                             stop_criterion=None,
                             fixed_geometry_spinup_yr=None,
                             dynamic_spinup_min_ice_thick=None,
-                            make_compatible=False
                             ):
         """Runs the model and returns intermediate steps in xarray datasets.
 
@@ -992,13 +991,6 @@ class FlowlineModel(object):
             area or the total volume. This is useful to smooth out yearly
             fluctuations when matching to observations. The names of this new
             variables include the suffix _min_h (e.g. 'area_m2_min_h')
-        make_compatible : bool
-            if set to true this will add all variables to the resulting dataset
-            so it could be combined with any other one. This is necessary if
-            different spinup methods are used. For example if using the dynamic
-            spinup and setting fixed geometry spinup as fallback, the variable
-            'is_fixed_geometry_spinup' must be added to the dynamic spinup so
-            it is possible to compile both glaciers together.
         Returns
         -------
         geom_ds : xarray.Dataset or None
@@ -1157,12 +1149,6 @@ class FlowlineModel(object):
 
         if do_fixed_spinup:
             is_spinup_time = monthly_time < self.yr
-            diag_ds['is_fixed_geometry_spinup'] = ('time', is_spinup_time)
-            desc = 'Part of the series which are spinup'
-            diag_ds['is_fixed_geometry_spinup'].attrs['description'] = desc
-            diag_ds['is_fixed_geometry_spinup'].attrs['unit'] = '-'
-        elif make_compatible:
-            is_spinup_time = np.full(len(monthly_time), False, dtype=bool)
             diag_ds['is_fixed_geometry_spinup'] = ('time', is_spinup_time)
             desc = 'Part of the series which are spinup'
             diag_ds['is_fixed_geometry_spinup'].attrs['description'] = desc

--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -401,8 +401,8 @@ store_model_geometry = False
 
 # What variables would you like to store in the diagnostics files
 # Currently available in standard files:
-#   volume, volume_bsl, volume_bwl, area, length, calving, calving_rate,
-#   terminus_thick_i (with i in 0..9).
+#   volume, volume_bsl, volume_bwl, area, area_min_h, length, calving,
+#   calving_rate, terminus_thick_i (with i in 0..9).
 # And with additional hydro output:
 #   off_area, on_area,
 #   melt_off_glacier, melt_on_glacier,
@@ -410,7 +410,7 @@ store_model_geometry = False
 # Probably useful for debugging only
 #   melt_residual_off_glacier, melt_residual_on_glacier
 #   model_mb, residual_mb, snow_bucket,
-# You need to kee all variables in one line unfortunately
+# You need to keep all variables in one line unfortunately
 store_diagnostic_variables =  volume, volume_bsl, volume_bwl, area, length, calving, calving_rate, off_area, on_area, melt_off_glacier, melt_on_glacier, liq_prcp_off_glacier, liq_prcp_on_glacier, snowfall_off_glacier, snowfall_on_glacier
 
 # Whether to store the model flowline diagnostic files during operational runs
@@ -419,5 +419,5 @@ store_diagnostic_variables =  volume, volume_bsl, volume_bwl, area, length, calv
 store_fl_diagnostics = False
 # What variables would you like to store in the flowline diagnostics files
 # Note: area and volume are mandatory
-# You need to kee all variables in one line unfortunately
+# You need to keep all variables in one line unfortunately
 store_fl_diagnostic_variables =  area, thickness, volume, volume_bsl, volume_bwl, calving_bucket, ice_velocity

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -486,7 +486,20 @@ class TestWorkflowUtils:
         filesuffix = '_compile_run_output_test'
         cfg.PARAMS['store_model_geometry'] = True
 
-        # we run the first gdir without the variables 'area_min_h' (2d) and
+        # all allowed data variables, for testing in compile_run_output
+        allowed_data_vars = ['volume', 'volume_bsl', 'volume_bwl', 'area',
+                             'area_min_h', 'length', 'calving', 'calving_rate',
+                             'off_area', 'on_area',
+                             'melt_off_glacier', 'melt_on_glacier',
+                             'liq_prcp_off_glacier', 'liq_prcp_on_glacier',
+                             'snowfall_off_glacier', 'snowfall_on_glacier',
+                             'melt_residual_off_glacier',
+                             'melt_residual_on_glacier', 'model_mb',
+                             'residual_mb', 'snow_bucket']
+        for gi in range(10):
+            allowed_data_vars += [f'terminus_thick_{gi}']
+
+        # we run the first gdir excluding the variables 'area_min_h' (2d) and
         # 'melt_on_glacier' (3d, with store_monthly_hydro=True)
         def remove_diag_var(variable):
             try:
@@ -504,10 +517,8 @@ class TestWorkflowUtils:
                                 y0=1980, halfsize=1, nyears=2,
                                 output_filesuffix=filesuffix)
 
-        # the second gdir run includes the variables 'area_min_h' (2d) and
-        # 'melt_on_glacier' (3d, with store_monthly_hydro=True)
-        cfg.PARAMS['store_diagnostic_variables'].append('area_min_h')
-        cfg.PARAMS['store_diagnostic_variables'].append('melt_on_glacier')
+        # the second gdir run includes all allowed data variables
+        cfg.PARAMS['store_diagnostic_variables'] = allowed_data_vars
         flowline.run_with_hydro(gdirs[1],
                                 run_task=flowline.run_constant_climate,
                                 store_monthly_hydro=True,

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -27,6 +27,7 @@ from oggm.utils import shape_factor_adhikari
 from oggm.exceptions import (InvalidParamsError, InvalidDEMError,
                              InvalidWorkflowError,
                              DownloadVerificationFailedException)
+from oggm.core import flowline
 
 
 pytestmark = pytest.mark.test_env("utils")
@@ -475,6 +476,68 @@ class TestWorkflowTools(unittest.TestCase):
         assert file_path in cfg.DATA
         import multiprocessing
         assert type(cfg.DATA) is multiprocessing.managers.DictProxy
+
+
+class TestWorkflowUtils:
+    def test_compile_run_output(self, hef_gdir, hef_copy_gdir):
+
+        # Here I test if compile_run_output works with different data variables
+        gdirs = [hef_gdir, hef_copy_gdir]
+        filesuffix = '_compile_run_output_test'
+        cfg.PARAMS['store_model_geometry'] = True
+
+        # we run the first gdir without the variables 'area_min_h' (2d) and
+        # 'melt_on_glacier' (3d, with store_monthly_hydro=True)
+        def remove_diag_var(variable):
+            try:
+                cfg.PARAMS['store_diagnostic_variables'].remove(variable)
+            except ValueError as err:
+                if str(err) == 'list.remove(x): x not in list':
+                    pass
+                else:
+                    raise
+        remove_diag_var('area_min_h')
+        remove_diag_var('melt_on_glacier')
+        flowline.run_with_hydro(gdirs[0],
+                                run_task=flowline.run_constant_climate,
+                                store_monthly_hydro=True,
+                                y0=1980, halfsize=1, nyears=2,
+                                output_filesuffix=filesuffix)
+
+        # the second gdir run includes the variables 'area_min_h' (2d) and
+        # 'melt_on_glacier' (3d, with store_monthly_hydro=True)
+        cfg.PARAMS['store_diagnostic_variables'].append('area_min_h')
+        cfg.PARAMS['store_diagnostic_variables'].append('melt_on_glacier')
+        flowline.run_with_hydro(gdirs[1],
+                                run_task=flowline.run_constant_climate,
+                                store_monthly_hydro=True,
+                                y0=1980, halfsize=1, nyears=2,
+                                output_filesuffix=filesuffix)
+
+        # We need to test two things:
+        # First: If their is a variable in the first diagnostics file which is
+        # not present in the second one no KeyError should be raised.
+        ds_1 = utils.compile_run_output([gdirs[0], gdirs[1]],
+                                        input_filesuffix=filesuffix)
+
+        def check_result(ds):
+            assert 'area_m2_min_h' in ds.data_vars
+            assert 'melt_on_glacier' in ds.data_vars
+            assert 'melt_on_glacier_monthly' in ds.data_vars
+            assert np.all(np.isnan(
+                ds.loc[{'rgi_id': gdirs[0].rgi_id}]['area_m2_min_h'].values))
+            assert np.all(np.isnan(
+                ds.loc[{'rgi_id': gdirs[0].rgi_id}]['melt_on_glacier'].values))
+            assert np.all(np.isnan(
+                ds.loc[{'rgi_id': gdirs[0].rgi_id}]['melt_on_glacier_monthly'].values))
+
+        check_result(ds_1)
+
+        # Second: If a variable in the second diagnostics file which is not
+        # present in the first one it should still be included in the result.
+        ds_2 = utils.compile_run_output([gdirs[1], gdirs[0]],
+                                        input_filesuffix=filesuffix)
+        check_result(ds_2)
 
 
 class TestStartFromTar(unittest.TestCase):

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -1156,7 +1156,8 @@ def compile_run_output(gdirs, path=True, input_filesuffix='',
                             data_vars[vn]['dims'] = ds.variables[vn].dimensions
                             data_vars[vn]['attrs'] = dict()
                             for attr in ds.variables[vn].ncattrs():
-                                if attr not in ['_FillValue', 'coordinates']:
+                                if attr not in ['_FillValue', 'coordinates',
+                                                'dtype']:
                                     data_vars[vn]['attrs'][attr] = getattr(
                                         ds.variables[vn], attr)
 


### PR DESCRIPTION
In this PR I added more flexibility to `compile_run_output`. Now it is possible to compile outputs with different data variables. This is mainly needed for the new minimum thickness strategy during the dynamic melt_f calibration. But maybe could be useful in the future.

I have adapted for 2d and 3d variables (for monthly or daily hydro output) and added a test for both cases.

Closes https://github.com/OGGM/oggm/issues/1561

- [x] Tests added/passed
- [ ] Fully documented
- [ ] Entry in `whats-new.rst` 
