### PR TITLE
faster process_cmip_data: allow flattened cmip and selected time series

### DIFF
--- a/oggm/shop/gcm_climate.py
+++ b/oggm/shop/gcm_climate.py
@@ -394,8 +394,6 @@ def process_cesm_data(gdir, filesuffix='', fpath_temp=None, fpath_precc=None,
                      time_unit=time_unit, calendar=calendar, **kwargs)
 
 
-# normally from oggm.shop.gcm_climate import process_cmip_data
-
 @entity_task(log, writes=['gcm_data'])
 def process_cmip_data(gdir, filesuffix='', fpath_temp=None,
                       fpath_precip=None, **kwargs):

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -2791,10 +2791,18 @@ class TestGCMClimate(unittest.TestCase):
                                       fpath_temp=fpath_temp,
                                       fpath_precip=fpath_precip,
                                       filesuffix='_CCSM4')
+        gcm_climate.process_cmip_data(gdir,
+                                      fpath_temp=fpath_temp,
+                                      fpath_precip=fpath_precip,
+                                      filesuffix='_CCSM4_y0_y1', y0=1960,
+                                      y1=2095)
 
         fh = gdir.get_filepath('climate_historical')
         fcmip = gdir.get_filepath('gcm_data', filesuffix='_CCSM4')
-        with xr.open_dataset(fh) as cru, xr.open_dataset(fcmip) as cmip:
+        fcmip_y0_y1 = gdir.get_filepath('gcm_data', filesuffix='_CCSM4_y0_y1')
+        with xr.open_dataset(fh) as cru,\
+              xr.open_dataset(fcmip) as cmip,\
+              xr.open_dataset(fcmip_y0_y1) as cmip_y0_y1:
 
             # Let's do some basic checks
             scru = cru.sel(time=slice('1961', '1990'))
@@ -2807,6 +2815,10 @@ class TestGCMClimate(unittest.TestCase):
             np.testing.assert_allclose(scru.prcp.mean(),
                                        scesm.prcp.mean(),
                                        rtol=1e-3)
+            # just check if the right time period is chosen
+            scesm_y0_y1 = cmip_y0_y1.load()
+            assert scesm_y0_y1['time.year'].min() == 1960
+            assert scesm_y0_y1['time.year'].max() == 2095
 
             # Here also std dev! But its not perfect because std_dev
             # is preserved over 31 years


### PR DESCRIPTION
Allows to use flattened CMIP data in `process_cmip_data`. The option is at the moment only used for the flattened overshoot and stabilisation options of gfdl-esm4 that go until 2500. This method is probably faster than always processing the unflattened files. 
