### PR TITLE
update the link to the leclerq dataset in the get_ref_length_data fun…

### DIFF
--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -422,7 +422,7 @@ class TestWorkflowTools(unittest.TestCase):
 
     def test_leclercq_data(self):
 
-        hef_file = utils.get_demo_file('Hintereisferner_RGI5.shp')
+        hef_file = utils.get_demo_file('Hintereisferner_RGI6.shp')
         entity = gpd.read_file(hef_file).iloc[0]
         cfg.PARAMS['use_intersects'] = False
         gdir = oggm.GlacierDirectory(entity, base_dir=self.testdir)

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -3570,7 +3570,7 @@ class GlacierDirectory(object):
          For some glaciers only!
          """
 
-        df = pd.read_csv(get_demo_file('rgi_leclercq_links_2012_RGIV5.csv'))
+        df = pd.read_csv(get_demo_file('rgi_leclercq_links_2014_RGIV6.csv'))
         df = df.loc[df.RGI_ID == self.rgi_id]
         if len(df) == 0:
             raise RuntimeError('No length data found for this glacier!')


### PR DESCRIPTION
The  `.get_ref_length_data` function is not working for RGI6. Therefore I would suggest updating it. This PR is just a quick fix. If it would be better to still be compatible with RGI5, just let me know, than I will update the PR. 

@juliaeis, thanks for helping me finding this function and solving the issue! 