### PR TITLE
move negative melt_on_glacier to snowfall

### DIFF
--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -4308,6 +4308,9 @@ class TestHydro:
                            odf['liq_prcp_on_glacier'] +
                            odf['snowfall_off_glacier'] +
                            odf['snowfall_on_glacier'])
+        # this test fails because snowfall_on_glacier changes, as the
+        # formerly negative melt_on_glacier was added to snowfall_on_glacier
+        # is this a strict test??? (the remaining part of the test does not fail)
         assert_allclose(odf['tot_prcp'], odf['tot_prcp'].iloc[0])
 
         # So is domain area
@@ -4337,9 +4340,15 @@ class TestHydro:
         # At the very first timesep there is no glacier so the
         # melt_on_glacier var is negative - this is a numerical artifact
         # from the residual
-        assert_allclose(odf['melt_on_glacier'].iloc[0],
-                        - odf['residual_mb'].iloc[0])
-
+        # assert_allclose(odf['melt_on_glacier'].iloc[0],
+        #                - odf['residual_mb'].iloc[0])
+        # we changed, that, if negative, the absolute value should go to snowfall_on_glacier
+        # let's check that (this happens also at other times than the first step,
+        # but only in the first step it always happens)
+        assert_allclose(odf['snowfall_on_glacier'].iloc[0],
+                        odf['residual_mb'].iloc[0])
+        # check if melt on glacier is always above or equal zero
+        assert np.all(odf['melt_on_glacier'] >= 0)
         # Now with zero ref area
         tasks.run_with_hydro(gdir, run_task=tasks.run_constant_climate,
                              store_monthly_hydro=store_monthly_hydro,
@@ -4388,8 +4397,16 @@ class TestHydro:
         # At the very first timesep there is no glacier so the
         # melt_on_glacier var is negative - this is a numerical artifact
         # from the residual
-        assert_allclose(odf['melt_on_glacier'].iloc[0],
-                        - odf['residual_mb'].iloc[0])
+        # assert_allclose(odf['melt_on_glacier'].iloc[0],
+        #                - odf['residual_mb'].iloc[0])
+        # we changed, that, if negative, the absolute value should go to snowfall_on_glacier
+        # let's check that (this happens also at other times than the first step,
+        # but only in the first step it always happens)
+        assert_allclose(odf['snowfall_on_glacier'].iloc[0],
+                        odf['residual_mb'].iloc[0])
+
+        # check if melt on glacier is always above or equal zero
+        assert np.all(odf['melt_on_glacier'] >= 0)
 
     @pytest.mark.slow
     @pytest.mark.parametrize('store_monthly_hydro', [False, True], ids=['annual', 'monthly'])
@@ -4419,7 +4436,10 @@ class TestHydro:
                            odf['liq_prcp_on_glacier'] +
                            odf['snowfall_off_glacier'] +
                            odf['snowfall_on_glacier'])
+        # this test failed in test above, is it just a coincidence
+        # that it works here???
         assert_allclose(odf['tot_prcp'], odf['tot_prcp'].iloc[0])
+
 
         # Glacier area is the same (remove on_area?)
         assert_allclose(odf['on_area'], odf['area_m2'])
@@ -4453,6 +4473,9 @@ class TestHydro:
         # Residual MB should not be crazy large
         frac = odf['residual_mb'] / odf['melt_on_glacier']
         assert_allclose(frac, 0, atol=0.025)
+
+        # check if melt on glacier is always above or equal zero
+        assert np.all(odf['melt_on_glacier'] >= 0)
 
     @pytest.mark.slow
     @pytest.mark.parametrize('store_monthly_hydro', [True, False], ids=['monthly', 'annual'])
@@ -4558,6 +4581,8 @@ class TestHydro:
             # Runoff peak should follow a temperature curve
             assert_allclose(odf_ma['melt_on_glacier'].idxmax(), 8)
 
+        # check if melt on glacier is always above or equal zero
+        assert np.all(odf['melt_on_glacier'] >= 0)
     @pytest.mark.slow
     def test_hydro_ref_area(self, hef_gdir, inversion_params):
 
@@ -4678,6 +4703,9 @@ class TestHydro:
         # Residual MB should not be crazy large
         frac = odf['residual_mb'] / odf['melt_on_glacier']
         assert_allclose(frac, 0, atol=0.05)
+
+        # check if melt on glacier is always above or equal zero
+        assert np.all(odf['melt_on_glacier'] >= 0)
 
     @pytest.mark.parametrize('do_inversion', [True, False])
     @pytest.mark.slow
@@ -4874,7 +4902,9 @@ class TestHydro:
         frac = odf['residual_mb'] / odf['melt_on_glacier']
         assert_allclose(frac, 0, atol=0.044)  # annual can be large (prob)
 
-    @pytest.mark.slow
+        # check if melt on glacier is always above or equal zero
+        assert np.all(odf['melt_on_glacier'] >= 0)
+    #@pytest.mark.slow
     @pytest.mark.parametrize('mb_type', ['random', 'const', 'hist'])
     @pytest.mark.parametrize('mb_bias', [500, -500, 0])
     def test_hydro_monhly_vs_annual(self, hef_gdir, inversion_params,


### PR DESCRIPTION
In hydrological projections, negative melt_on_glacier values occurred in the past. Although the absolute values were mostly relatively small, negative melt_on_glacier (and consequently negative glacier runoff) does not makes sense. 

With this pull request, no negative `melt_on_glacier` values should exist anymore. The previously negative values are now clipped to zero, and the negative values are added as absolute values to the `snowfall_on_glacier` (for mass-conservation issues). 

- [ ] There is one line in a test that still fails: https://github.com/OGGM/oggm/blob/6952200852e43ee69ba43563fdb4a8de9a3ea165/oggm/tests/test_models.py#L4311. This is because the total precipitation changes even in a constant climate (because of adding the negative values as absolute values to the `snowfall_on_glacier` variable). I am not sure if this needs to stay constant. @fmaussion, what do you think?  
 
- [ ] I could have a quick check if this makes a difference in the run_with_hydro output (by doing projections for one basin). And test again if the `melt_on_glacier` is now everywhere non-negative. 

This PR is part of the ToDo-List of  https://github.com/OGGM/oggm/issues/1582 

- [x] Tests added/passed (except for one line)

