### PR TITLE
added volume_m3_min_h to compile_run_output

### DIFF
--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -1108,6 +1108,8 @@ def compile_run_output(gdirs, path=True, input_filesuffix='',
     time_info = {}
     time_keys = ['hydro_year', 'hydro_month', 'calendar_year', 'calendar_month']
     allowed_data_vars = ['volume_m3', 'volume_bsl_m3', 'volume_bwl_m3',
+                         'volume_m3_min_h',  # only here for back compatibility
+                         # as it is a variable in gdirs v1.6 2023.1
                          'area_m2', 'area_m2_min_h', 'length_m', 'calving_m3',
                          'calving_rate_myr', 'off_area',
                          'on_area', 'model_mb', 'is_fixed_geometry_spinup']


### PR DESCRIPTION
This solves a bug in the tutorials reported on slack.

The problem was that the first v1.6 gdirs (2023.1) included the variable `volume_m3_min_h`, potentially used by the dynamic calibration functions. However, we decided to use min_h only for area now and therefore there is no `volume_m3_min_h` in the newest oggm version.

But for back compatibility when starting from gdirs 2023.1 I included now `volume_m3_min_h` as an allowed variable in `compile_run_output`.

- [x] Tests added/passed
