### PR TITLE
adding dhdt flowline diagnostics

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -15,6 +15,15 @@ Bug fixes
   special data variables (e.g. ``is_fixed_geometry_spinup``) (:pull:`1563`).
   By `Patrick Schmitt <https://github.com/pat-schmitt>`_
 
+Enhancements
+~~~~~~~~~~~~
+
+- Added three new flowline diagnostic variables: thickness change in one year
+  (``dhdt``), forcing climatic mass balance (``climatic_mb``) and flux divergence
+  (``flux_divergence``). All variables are in units meter of ice per year
+  (:pull:`1595`).
+  By `Patrick Schmitt <https://github.com/pat-schmitt>`_
+
 
 v1.6.0 (March 10, 2023)
 -----------------------

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -1224,6 +1224,44 @@ class FlowlineModel(object):
                     desc = 'Part of the series which are spinup'
                     ds['is_fixed_geometry_spinup'].attrs['description'] = desc
                     ds['is_fixed_geometry_spinup'].attrs['unit'] = '-'
+                if 'flux_divergence' in ovars_fl:
+                    # We need dhdt and climatic_mb to calculate divergence
+                    if 'dhdt' not in ovars_fl:
+                        ovars_fl.append('dhdt')
+                    if 'climatic_mb' not in ovars_fl:
+                        ovars_fl.append('climatic_mb')
+
+                    ds['flux_divergence_myr'] = (('time', 'dis_along_flowline'),
+                                                 width * np.NaN)
+                    desc = 'Ice-flux divergence'
+                    ds['flux_divergence_myr'].attrs['description'] = desc
+                    ds['flux_divergence_myr'].attrs['unit'] = 'm yr-1'
+                if 'climatic_mb' in ovars_fl:
+                    # We need dhdt to define where to calculate climatic_mb
+                    if 'dhdt' not in ovars_fl:
+                        ovars_fl.append('dhdt')
+
+                    ds['climatic_mb_myr'] = (('time', 'dis_along_flowline'),
+                                             width * np.NaN)
+                    desc = 'Climatic mass balance forcing'
+                    ds['climatic_mb_myr'].attrs['description'] = desc
+                    ds['climatic_mb_myr'].attrs['unit'] = 'm yr-1'
+
+                    # needed for the calculation of mb at start of period
+                    surface_h_previous = {}
+                    for fl_id, fl in enumerate(self.fls):
+                        surface_h_previous[fl_id] = fl.surface_h
+                if 'dhdt' in ovars_fl:
+                    ds['dhdt_myr'] = (('time', 'dis_along_flowline'),
+                                      width * np.NaN)
+                    desc = 'Thickness change'
+                    ds['dhdt_myr'].attrs['description'] = desc
+                    ds['dhdt_myr'].attrs['unit'] = 'm yr-1'
+
+                    # needed for the calculation of dhdt
+                    thickness_previous_dhdt = {}
+                    for fl_id, fl in enumerate(self.fls):
+                        thickness_previous_dhdt[fl_id] = fl.thick
 
         # First deal with spinup (we compute volume change only)
         if do_fixed_spinup:
@@ -1279,6 +1317,47 @@ class FlowlineModel(object):
                             var = self.u_stag[fl_id]
                             val = (var[1:fl.nx + 1] + var[:fl.nx]) / 2 * self._surf_vel_fac
                             ds['ice_velocity_myr'].data[j, :] = val * cfg.SEC_IN_YEAR
+                        if 'dhdt' in ovars_fl and (yr > self.y0):
+                            # dhdt can only be computed after one year
+                            val = fl.thick - thickness_previous_dhdt[fl_id]
+                            ds['dhdt_myr'].data[j, :] = val
+                            thickness_previous_dhdt[fl_id] = fl.thick
+                        if 'climatic_mb' in ovars_fl and (yr > self.y0):
+                            # yr - 1 to use the mb which lead to the current
+                            # state, also using previous surface height
+                            val = self.get_mb(surface_h_previous[fl_id],
+                                              self.yr - 1,
+                                              fl_id=fl_id)
+                            # only save climatic mb where dhdt is non zero,
+                            # isclose for avoiding numeric represention artefacts
+                            dhdt_zero = np.isclose(ds['dhdt_myr'].data[j, :],
+                                                   0.)
+                            ds['climatic_mb_myr'].data[j, :] = np.where(
+                                dhdt_zero,
+                                0.,
+                                val * cfg.SEC_IN_YEAR)
+                            surface_h_previous[fl_id] = fl.surface_h
+                        if 'flux_divergence' in ovars_fl and (yr > self.y0):
+                            # calculated after the formula dhdt = mb + flux_div
+                            val = ds['dhdt_myr'].data[j, :] -\
+                                  ds['climatic_mb_myr'].data[j, :]
+                            # special treatment for retreating: If the glacier
+                            # terminus is getting ice free it means the
+                            # climatic mass balance is more negative than the
+                            # available ice to melt. In this case we can not
+                            # calculate the flux divergence with this method
+                            # exactly, we just can say it was smaller to
+                            # compensate the very negative climatic mb.
+                            # To avoid large spikes at the terminus in the
+                            # calculated flux divergence we smooth this values
+                            # with an (arbitrary) factor of 0.1.
+                            has_become_ice_free = np.logical_and(
+                                np.isclose(fl.thick, 0.),
+                                ds['dhdt_myr'].data[j, :] < 0.
+                            )
+                            fac = np.where(has_become_ice_free, 0.1, 1.)
+                            ds['flux_divergence_myr'].data[j, :] = val * fac
+
                 # j is the yearly index in case we have monthly output
                 # we have to count it ourselves
                 j += 1

--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -420,4 +420,4 @@ store_fl_diagnostics = False
 # What variables would you like to store in the flowline diagnostics files
 # Note: area and volume are mandatory
 # You need to keep all variables in one line unfortunately
-store_fl_diagnostic_variables =  area, thickness, volume, volume_bsl, volume_bwl, calving_bucket, ice_velocity
+store_fl_diagnostic_variables =  area, thickness, volume, volume_bsl, volume_bwl, calving_bucket, ice_velocity, dhdt, climatic_mb, flux_divergence


### PR DESCRIPTION
Here is the first version for adding new flowline diagnostics dhdt, climatic mb and flux-divergence.

I decided to calculate dhdt after each year directly along the flowlines and also read out the forcing mass balance (in m yr-1). The flux-divergence (in m yr-1) is calculated using the formula `dhdt = mb + flux_divergence`. I decided to use this equation to make the interpretation of terms more straightforward (e.g. positive calculated flux-divergence means the in-flux is larger then the out-flux), as the original equation includes a minus sign (see e.g. https://docs.oggm.org/en/latest/ice-dynamics.html#ice-flow).

The advantage of this method is that it works for all bed shapes and all numeric solvers. Regarding testing, I am not sure if my very simple test is enough...

Special case retreating glaciers:
However, with this method, we can not calculate the flux-divergence exactly if a grid point at the terminus is getting ice-free. At such points, the 'very' negative climatic mass balance is not compensated by the flux-divergence and we only can calculate a value which tells us the flux-divergence at this point was smaller. To avoid unreasonable spikes in the calculated flux-divergence at such points I decided to smooth these values with a factor of 0.1.

Here are two plots of the resulting terms for a retreating and an advancing glacier, forced by a random mb:

Retreating:

![retreating](https://github.com/OGGM/oggm/assets/50843444/7c466d71-85bc-42c6-82cf-4ad0cbc9520b)

Advancing:

![advancing](https://github.com/OGGM/oggm/assets/50843444/90c1b6af-77be-4ca0-a420-5ad73ead77c3)

(Sidenote: In year 1 you can observe an initial shock if starting from a surface not dynamically initialised).

- [x] Tests added/passed
- [ ] Fully documented
- [x] Entry in `whats-new.rst` 
