### PR TITLE
fixed shapely > v0.2.0 in multipolygon_to_polygon

### DIFF
--- a/oggm/utils/_funcs.py
+++ b/oggm/utils/_funcs.py
@@ -538,7 +538,13 @@ def multipolygon_to_polygon(geometry, gdir=None):
     rid = gdir.rgi_id + ': ' if gdir is not None else ''
 
     if 'Multi' in geometry.geom_type:
-        parts = np.array(geometry)
+        # needed for shapely version > 0.2.0
+        # previous code was: parts = np.array(geometry)
+        parts = []
+        for p in geometry.geoms:
+            parts.append(p)
+        parts = np.array(parts)
+
         for p in parts:
             assert p.geom_type == 'Polygon'
         areas = np.array([p.area for p in parts])


### PR DESCRIPTION
I found a small bug when using shapely versions > 0.2.0. Their `np.array(MultiPolygon)` is not supported anymore. I updated it in `multipolygon_to_polygon`. Not sure if there are other locations which need updates.

- [ ] Tests added/passed
