### PR TITLE
Bug when some bin_variables for elevation bands are NaN

### DIFF
--- a/oggm/core/centerlines.py
+++ b/oggm/core/centerlines.py
@@ -2305,8 +2305,12 @@ def elevation_band_flowline(gdir, bin_variables=None, preserve_totals=True):
     df['dx'] = bsize / np.tan(df['slope'])
     df['width'] = df['area'] / df['dx']
 
-    # Remove possible NaNs from above, only remove if all bin_variables are NaN
-    df = df.dropna(how='all', subset=bin_variables)
+    # Remove possible NaNs from above
+    if not bin_variables:
+        df = df.dropna()
+    else:
+        # only remove if all bin_variables are NaN
+        df = df.dropna(how='all', subset=bin_variables)
 
     # Check for binned vars
     for var, data, in_total, do_p in zip(bin_variables, out_vars, out_totals,

--- a/oggm/core/centerlines.py
+++ b/oggm/core/centerlines.py
@@ -2305,8 +2305,8 @@ def elevation_band_flowline(gdir, bin_variables=None, preserve_totals=True):
     df['dx'] = bsize / np.tan(df['slope'])
     df['width'] = df['area'] / df['dx']
 
-    # Remove possible NaNs from above
-    df = df.dropna()
+    # Remove possible NaNs from above, only remove if all bin_variables are NaN
+    df = df.dropna(how='all', subset=bin_variables)
 
     # Check for binned vars
     for var, data, in_total, do_p in zip(bin_variables, out_vars, out_totals,


### PR DESCRIPTION
This is the first fix attempt for a bug reported on Slack.

You can reproduce the bug when running the 'inngest_gridded_data_on_flowlines' tutorial with `rgi_id = ['RGI60-14.04945']` (https://oggm.org/tutorials/master/notebooks/advanced/ingest_gridded_data_on_flowlines.html).

The problem is that when we include the Milan velocity as `bin_variables` in `fixed_dx_elevation_band_flowline`, there are some elevation bands with no valid velocity and they get kicked out in this line https://github.com/OGGM/oggm/blob/master/oggm/core/centerlines.py#L2309. Therefore the number of elevation bands (grid points) changes and this causes an error in the tutorial when we recalculate the OGGM bed (because the grid points in `inversion_flowlines` stay the same).

My proposed fix is to only drop elevation bands if all `bin_variables` are NaN.

I do not know if this has wider consequences (let's see what the tests are doing), but at least the tutorial is running without an error.


- [ ] Tests added/passed
