### PR TITLE
Add possibility of using MultiPolygon Outlines for Elevation Band Flowline

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -40,6 +40,11 @@ Enhancements
   (``flux_divergence``). All variables are in units meter of ice per year
   (:pull:`1595`).
   By `Patrick Schmitt <https://github.com/pat-schmitt>`_
+- Added possibility to use MultiPolygon outlines together with elevation bands.
+  That can be useful when working with local glacier inventories with multiple
+  outlines (e.g. older outline single polygon but newer outline multi polygon for
+  the same glacier) (:pull:`1604`).
+  By `Patrick Schmitt <https://github.com/pat-schmitt>`_
 
 
 v1.6.0 (March 10, 2023)

--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -506,6 +506,7 @@ def initialize_minimal(file=None, logging_level='INFO', params=None,
     PARAMS['use_rgi_area'] = cp.as_bool('use_rgi_area')
     PARAMS['compress_climate_netcdf'] = cp.as_bool('compress_climate_netcdf')
     PARAMS['use_tar_shapefiles'] = cp.as_bool('use_tar_shapefiles')
+    PARAMS['keep_multipolygon_outlines'] = cp.as_bool('keep_multipolygon_outlines')
     PARAMS['clip_tidewater_border'] = cp.as_bool('clip_tidewater_border')
     PARAMS['dl_verify'] = cp.as_bool('dl_verify')
     PARAMS['use_kcalving_for_inversion'] = cp.as_bool('use_kcalving_for_inversion')
@@ -576,7 +577,7 @@ def initialize_minimal(file=None, logging_level='INFO', params=None,
            'tidewater_type', 'store_model_geometry', 'use_winter_prcp_fac',
            'store_diagnostic_variables', 'store_fl_diagnostic_variables',
            'geodetic_mb_period', 'store_fl_diagnostics', 'winter_prcp_fac_ab',
-           'prcp_fac', 'downstream_line_shape']
+           'prcp_fac', 'downstream_line_shape', 'keep_multipolygon_outlines']
     for k in ltr:
         cp.pop(k, None)
 

--- a/oggm/core/gis.py
+++ b/oggm/core/gis.py
@@ -236,7 +236,23 @@ def glacier_grid_params(gdir):
     utm_proj = salem.check_crs(gdf.crs)
 
     # Get glacier extent
-    xx, yy = gdf.iloc[0]['geometry'].exterior.xy
+    try:
+        xx, yy = gdf.iloc[0]['geometry'].exterior.xy
+    # special treatment for Multipolygons
+    except AttributeError:
+        if not cfg.PARAMS['keep_multipolygon_outlines']:
+            raise
+        parts = []
+        for p in gdf.iloc[0]['geometry'].geoms:
+            parts.append(p)
+        parts = np.array(parts)
+
+        xx = []
+        yy = []
+        for part in parts:
+            xx_tmp, yy_tmp = part.exterior.xy
+            xx = np.append(xx, xx_tmp)
+            yy = np.append(yy, yy_tmp)
 
     # Define glacier area to use
     area = gdir.rgi_area_km2
@@ -857,8 +873,22 @@ def simple_glacier_masks(gdir, write_hypsometry=False):
         with memfile.open(**profile) as dataset:
             dataset.write(data.astype(np.int16)[np.newaxis, ...])
         dem_data = rasterio.open(memfile.name)
-        poly = shpg.mapping(shpg.Polygon(geometry.exterior))
-        masked_dem, _ = riomask(dem_data, [poly],
+        try:
+            poly = [shpg.mapping(shpg.Polygon(geometry.exterior))]
+        except AttributeError:
+            if not cfg.PARAMS['keep_multipolygon_outlines']:
+                raise
+            # special treatment for MultiPolygons
+            parts = []
+            for p in geometry.geoms:
+                parts.append(p)
+            parts = np.array(parts)
+
+            poly = []
+            for part in parts:
+                poly.append(shpg.mapping(shpg.Polygon(part.exterior)))
+
+        masked_dem, _ = riomask(dem_data, poly,
                                 filled=False)
     glacier_mask_nonuna = ~masked_dem[0, ...].mask
 

--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -51,6 +51,10 @@ use_compression = True
 # files format? If use_compression is True, use tar.gz instead.
 use_tar_shapefiles = True
 
+# If we should keep MultiPolygon Outlines or just use the larges part,
+# MultiPolygon Outlines are only supported for elevation band flowlines
+keep_multipolygon_outlines = False
+
 # MPI recv buffer size
 # If you receive "Message truncated" errors from MPI, increase this
 mpi_recv_buf_size = 131072

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -2814,7 +2814,8 @@ class GlacierDirectory(object):
         # transform geometry to map
         project = partial(transform_proj, proj_in, proj_out)
         geometry = shp_trafo(project, entity['geometry'])
-        geometry = multipolygon_to_polygon(geometry, gdir=self)
+        if not cfg.PARAMS['keep_multipolygon_outlines']:
+            geometry = multipolygon_to_polygon(geometry, gdir=self)
 
         # Save transformed geometry to disk
         entity = entity.copy()


### PR DESCRIPTION
Here I added the possibility of using MultiPolygon Outlines within Elevation Band Flowlines. For this, I added a new `cfg.PARAMS` variable, which must be turned on. The default behaviour of OGGM is unchanged.

This is useful for example if you are working with regional glacier inventories, where you have multiple outlines for a glacier and one glacier splits into multiple parts.

Not sure if we want to add this into OGGM. But I needed it so maybe it is also useful for others in the future...

- [ ] Tests added/passed
- [ ] Fully documented
- [x] Entry in `whats-new.rst` 
