### PR TITLE
Adapt 2d redistribution

### DIFF
--- a/oggm/sandbox/distribute_2d.py
+++ b/oggm/sandbox/distribute_2d.py
@@ -314,7 +314,6 @@ def distribute_thickness_from_simulation(gdir, input_filesuffix='',
 
         dgy = dg.sel(time=yr)
 
-        residual_pix = 0
         area_cov = 0
         new_thick = out_thick[i, :]
         for band_id, npix in zip(band_ids.astype(int), counts):
@@ -322,10 +321,9 @@ def distribute_thickness_from_simulation(gdir, input_filesuffix='',
             band_volume = dgy.volume_m3.values[band_id]
             if band_area != 0:
                 # We have some ice left
-                pix_cov = (band_area / dx2) + residual_pix
+                pix_cov = band_area / dx2
                 mask = (band_index_mask == band_id) & \
                        (rank_per_band >= (npix - pix_cov))
-                residual_pix = pix_cov - mask.sum()
                 vol_orig = np.where(mask, orig_distrib_thick, 0).sum() * dx2
                 area_dis = mask.sum() * dx2
                 thick_cor = (vol_orig - band_volume) / area_dis

--- a/oggm/sandbox/distribute_2d.py
+++ b/oggm/sandbox/distribute_2d.py
@@ -339,7 +339,7 @@ def distribute_thickness_from_simulation(gdir, input_filesuffix='',
         for band_id, npix in zip(band_ids.astype(int), counts):
             band_area = dgy.area_m2.values[band_id]
             band_volume = dgy.volume_m3.values[band_id]
-            if band_area != 0:
+            if ~np.isclose(band_area, 0):
                 # We have some ice left
                 pix_cov = band_area / dx2
                 mask = (band_index_mask == band_id) & \

--- a/oggm/sandbox/distribute_2d.py
+++ b/oggm/sandbox/distribute_2d.py
@@ -143,6 +143,17 @@ def assign_points_to_band(gdir, topo_variable='glacier_topo_smoothed',
     npix_per_band = fl.bin_area_m2 / (gdir.grid.dx ** 2)
     nnpix_per_band_cumsum = np.around(npix_per_band[::-1].cumsum()[::-1])
 
+    # check if their is a differenze between the flowline area and gridded area
+    pix_diff = int(nnpix_per_band_cumsum[0] - len(topo_data_flat))
+    if pix_diff > 0:
+        # we have more fl pixels, for this we can adapt a little
+        # search for the largest differences between elevation bands and reduce
+        # area for one pixel
+        sorted_indices = np.argsort(np.abs(np.diff(nnpix_per_band_cumsum)))
+        npix_per_band[sorted_indices[-pix_diff:]] = \
+            npix_per_band[sorted_indices[-pix_diff:]] - 1
+        nnpix_per_band_cumsum = np.around(npix_per_band[::-1].cumsum()[::-1])
+
     rank_elev = mstats.rankdata(topo_data_flat)
     bins = nnpix_per_band_cumsum[nnpix_per_band_cumsum > 0].copy()
     bins[0] = len(topo_data_flat) + 1


### PR DESCRIPTION
Here I add some changes to the redistribution function, made by @afisc.

This includes:

- thickness threshold for filtering out spikes in the area
- rolling mean smoothing the area to avoid steps (due to the trapezoidal bed shape of the flowline)
- monthly interpolation for a higher temporal resolution

Something to discuss is if we should use the monthly interpolation as the default. Currently, there are two different time coordinates used in `gridded_data` (`time` and `time_monthly`) depending on if we use monthly interpolation. This maybe could be simplified if we say we always want to use monthly time steps in the redistribution.

Additionally, I added an option for an area evolution plot (`show_area_plot`) for finding the best smoothing parameters for your glacier. Here are some small examples:

No smoothing:
![image](https://github.com/OGGM/oggm/assets/50843444/f55b952c-8c4d-4d4e-a0d6-552a4b8041d7)

With thickness threshold of 1:
![image](https://github.com/OGGM/oggm/assets/50843444/b0a4f116-a53f-444d-b738-7ce863bd5ae7)

With thickness threshold of 1 and rolling mean smoothing with window size 4:
![image](https://github.com/OGGM/oggm/assets/50843444/46feb796-a85b-48cd-8c0a-021cff61df92)


These changes should also be added to the tutorials (https://oggm.org/tutorials/master/notebooks/beginner/distribute_flowline.html).

- [ ] Tests added/passed
- [ ] Fully documented
- [ ] Entry in `whats-new.rst` 
