### PR TITLE
Tiny edit on index page regarding youtube

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,6 +40,7 @@ presentation from April 2020:
     <iframe width="672" height="378" src="https://www.youtube.com/embed/ttJMxcwXUjw?start=1270" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 *Slides available* `here <https://oggm.org/framework_talk>`_
+Disclaimer: If you don't have access to youtube from your location, you won't be able to see this.
 
 Overview
 ^^^^^^^^

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,8 +39,9 @@ presentation from April 2020:
 
     <iframe width="672" height="378" src="https://www.youtube.com/embed/ttJMxcwXUjw?start=1270" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
+Disclaimer: If you don't have access to youtube from your location, you won't be able to see this video.
 *Slides available* `here <https://oggm.org/framework_talk>`_
-Disclaimer: If you don't have access to youtube from your location, you won't be able to see this.
+
 
 Overview
 ^^^^^^^^


### PR DESCRIPTION
When your location doesn't allow you to access youtube, the text around the video on the index page can be very confusing. From the layout you can't see the video has been removed. To avoid future confusion, this PR adds a short message to those who can't see the video.
