### PR TITLE
Bug in filter_inversion_output

### DIFF
--- a/oggm/core/inversion.py
+++ b/oggm/core/inversion.py
@@ -543,6 +543,18 @@ def filter_inversion_output(gdir, n_smoothing=5, min_ice_thick=1.,
     cls = gdir.read_pickle('inversion_output')
     cl = cls[-1]
 
+    # check that their are enough grid points for smoothing
+    nr_grid_points = len(cl['thick'])
+    if (nr_grid_points <= n_smoothing) and (nr_grid_points > 2):
+        if nr_grid_points > 2:
+            n_smoothing = nr_grid_points - 1
+        else:
+            log.warning(f'({gdir.rgi_id}) filter_inversion_output: flowline '
+                        f'has not enough grid points for applying the filter '
+                        f'(only {nr_grid_points} grid points)!')
+            # Return volume for convenience
+            return np.sum([np.sum(cl['volume']) for cl in cls])
+
     # convert to negative number for indexing
     n_smoothing = -abs(n_smoothing)
 

--- a/oggm/core/inversion.py
+++ b/oggm/core/inversion.py
@@ -545,8 +545,8 @@ def filter_inversion_output(gdir, n_smoothing=5, min_ice_thick=1.,
 
     # check that their are enough grid points for smoothing
     nr_grid_points = len(cl['thick'])
-    if (nr_grid_points <= n_smoothing) and (nr_grid_points > 2):
-        if nr_grid_points > 2:
+    if nr_grid_points <= n_smoothing:
+        if nr_grid_points >= 3:
             n_smoothing = nr_grid_points - 1
         else:
             log.warning(f'({gdir.rgi_id}) filter_inversion_output: flowline '


### PR DESCRIPTION
filter_inversion_output through an error if the number of grid points is smaller than the number of grid points that should be used for filtering (`n_smoothing = 5` by default), reported in https://github.com/OGGM/oggm/issues/1632. I included a check for this.

- If the number of grid points is smaller `n_smoothing` and at least 3: `n_smoothing = nr_of_grid_points - 1`
- If the number of grid points is smaller 3: log a warning and do not apply the filter

We also could raise an error for flowlines with one or two grid points only...

Closes https://github.com/OGGM/oggm/issues/1632

- [ ] Tests added/passed
- [ ] Fully documented
- [ ] Entry in `whats-new.rst` 
