### PR TITLE
Vectorize floatyear_to_date

### DIFF
--- a/oggm/utils/_funcs.py
+++ b/oggm/utils/_funcs.py
@@ -610,6 +610,11 @@ def floatyear_to_date(yr):
 
     out_y = np.floor(yr).astype(int)
     out_m = np.minimum(12, np.round(((yr - out_y) * 12 + 1)).astype(int))
+
+    if len(yr) == 1:
+        out_y = out_y.item()
+        out_m = out_m.item()
+
     return out_y, out_m
 
 

--- a/oggm/utils/_funcs.py
+++ b/oggm/utils/_funcs.py
@@ -668,25 +668,16 @@ def hydrodate_to_calendardate(y, m, start_month=None):
                                  'callers of this function to specify the '
                                  'hydrological convention they are using.')
 
+    # nothing to do if start_month is 1
+    if start_month == 1:
+        return y, m
+
+    y = np.array(y)
+    m = np.array(m)
+
     e = 13 - start_month
-    try:
-        if m <= e:
-            if start_month == 1:
-                out_y = y
-            else:
-                out_y = y - 1
-            out_m = m + start_month - 1
-        else:
-            out_y = y
-            out_m = m - e
-    except (TypeError, ValueError):
-        # TODO: inefficient but no time right now
-        out_y = np.zeros(len(y), np.int64)
-        out_m = np.zeros(len(y), np.int64)
-        for i, (_y, _m) in enumerate(zip(y, m)):
-            _y, _m = hydrodate_to_calendardate(_y, _m, start_month=start_month)
-            out_y[i] = _y
-            out_m[i] = _m
+    out_m = m + np.where(m <= e, start_month - 1, -e)
+    out_y = y - np.where(m <= e, 1, 0)
     return out_y, out_m
 
 
@@ -708,24 +699,15 @@ def calendardate_to_hydrodate(y, m, start_month=None):
                                  'callers of this function to specify the '
                                  'hydrological convention they are using.')
 
-    try:
-        if m >= start_month:
-            if start_month == 1:
-                out_y = y
-            else:
-                out_y = y + 1
-            out_m = m - start_month + 1
-        else:
-            out_y = y
-            out_m = m + 13 - start_month
-    except (TypeError, ValueError):
-        # TODO: inefficient but no time right now
-        out_y = np.zeros(len(y), np.int64)
-        out_m = np.zeros(len(y), np.int64)
-        for i, (_y, _m) in enumerate(zip(y, m)):
-            _y, _m = calendardate_to_hydrodate(_y, _m, start_month=start_month)
-            out_y[i] = _y
-            out_m[i] = _m
+    # nothing to do if start_month is 1
+    if start_month == 1:
+        return y, m
+
+    y = np.array(y)
+    m = np.array(m)
+
+    out_m = m - start_month + np.where(m >= start_month, 1, 13)
+    out_y = y + np.where(m >= start_month, 1, 0)
     return out_y, out_m
 
 

--- a/oggm/utils/_funcs.py
+++ b/oggm/utils/_funcs.py
@@ -614,6 +614,9 @@ def floatyear_to_date(yr):
     if isinstance(yr, float):
         out_y = out_y.item()
         out_m = out_m.item()
+    elif (isinstance(yr, list) or isinstance(yr, np.ndarray)) and len(yr) == 1:
+        out_y = out_y.item()
+        out_m = out_m.item()
 
     return out_y, out_m
 

--- a/oggm/utils/_funcs.py
+++ b/oggm/utils/_funcs.py
@@ -618,7 +618,8 @@ def floatyear_to_date(yr):
         out_y = out_y.item()
         out_m = out_m.item()
 
-    return out_y, out_m
+    # np.array to be sure to return the correct type, if yr is xr.Dataset
+    return np.array(out_y), np.array(out_m)
 
 
 def date_to_floatyear(y, m):

--- a/oggm/utils/_funcs.py
+++ b/oggm/utils/_funcs.py
@@ -604,32 +604,12 @@ def floatyear_to_date(yr):
 
     Parameters
     ----------
-    yr : float
+    yr : float or list of float
         The floating year
     """
 
-    try:
-        try:
-            if len(yr) == 1:
-                yr = yr[0]
-        except TypeError:
-            pass
-        sec, out_y = math.modf(yr)
-        out_y = int(out_y)
-        sec = round(sec * SEC_IN_YEAR)
-        if sec == SEC_IN_YEAR:
-            # Floating errors
-            out_y += 1
-            sec = 0
-        out_m = int(sec / SEC_IN_MONTH) + 1
-    except TypeError:
-        # TODO: inefficient but no time right now
-        out_y = np.zeros(len(yr), np.int64)
-        out_m = np.zeros(len(yr), np.int64)
-        for i, y in enumerate(yr):
-            y, m = floatyear_to_date(y)
-            out_y[i] = y
-            out_m[i] = m
+    out_y = np.floor(yr).astype(int)
+    out_m = np.minimum(12, np.round(((yr - out_y) * 12 + 1)).astype(int))
     return out_y, out_m
 
 

--- a/oggm/utils/_funcs.py
+++ b/oggm/utils/_funcs.py
@@ -619,10 +619,7 @@ def floatyear_to_date(yr):
                                 np.round(month_exact),
                                 np.floor(month_exact)).astype(int))
 
-    if isinstance(yr, float):
-        out_y = out_y.item()
-        out_m = out_m.item()
-    elif (isinstance(yr, list) or isinstance(yr, np.ndarray)) and len(yr) == 1:
+    if (isinstance(yr, list) or isinstance(yr, np.ndarray)) and len(yr) == 1:
         out_y = out_y.item()
         out_m = out_m.item()
     elif isinstance(yr, xr.DataArray):

--- a/oggm/utils/_funcs.py
+++ b/oggm/utils/_funcs.py
@@ -611,7 +611,7 @@ def floatyear_to_date(yr):
     out_y = np.floor(yr).astype(int)
     out_m = np.minimum(12, np.round(((yr - out_y) * 12 + 1)).astype(int))
 
-    if len(yr) == 1:
+    if isinstance(yr, float):
         out_y = out_y.item()
         out_m = out_m.item()
 

--- a/oggm/utils/_funcs.py
+++ b/oggm/utils/_funcs.py
@@ -13,6 +13,7 @@ from packaging.version import Version
 # External libs
 import pandas as pd
 import numpy as np
+import xarray as xr
 from scipy.ndimage import convolve1d
 try:
     from scipy.signal.windows import gaussian
@@ -617,9 +618,11 @@ def floatyear_to_date(yr):
     elif (isinstance(yr, list) or isinstance(yr, np.ndarray)) and len(yr) == 1:
         out_y = out_y.item()
         out_m = out_m.item()
+    elif isinstance(yr, xr.DataArray):
+        out_y = np.array(out_y)
+        out_m = np.array(out_m)
 
-    # np.array to be sure to return the correct type, if yr is xr.Dataset
-    return np.array(out_y), np.array(out_m)
+    return out_y, out_m
 
 
 def date_to_floatyear(y, m):

--- a/oggm/utils/_funcs.py
+++ b/oggm/utils/_funcs.py
@@ -609,8 +609,15 @@ def floatyear_to_date(yr):
         The floating year
     """
 
-    out_y = np.floor(yr).astype(int)
-    out_m = np.minimum(12, np.round(((yr - out_y) * 12 + 1)).astype(int))
+    out_y, remainder = np.divmod(yr, 1)
+    out_y = out_y.astype(int)
+
+    month_exact = (remainder * 12 + 1)
+    # np.where to deal with floating point precision
+    out_m = np.minimum(12,
+                       np.where(np.isclose(month_exact, np.round(month_exact)),
+                                np.round(month_exact),
+                                np.floor(month_exact)).astype(int))
 
     if isinstance(yr, float):
         out_y = out_y.item()


### PR DESCRIPTION
Here is a suggestion for a vectorized form of `floatyear_to_date`.

A quick performance check with the following code, for around 12 million values to convert:
```python
def test_time(yrs):
    start_time = time.time()
    year_orig, month_orig = utils.floatyear_to_date(yrs)
    time_orig = time.time() - start_time
    
    start_time = time.time()
    year_new, month_new = new_floatyear_to_date(yrs)
    time_new = time.time() - start_time
    
    assert np.allclose(year_orig, year_new)
    assert np.allclose(month_orig, month_new)
    
    print(f'orig time {time_orig:.2f} s')
    print(f'new time {time_new:.2f} s')

monthly_time = utils.monthly_timeseries(0, 1000000)
test_time(monthly_time)
```
`orig time 8.34 s`
`new time 0.16 s`


Closes https://github.com/OGGM/oggm/issues/1631

- [ ] Tests added/passed
- [ ] Fully documented
- [ ] Entry in `whats-new.rst` 
