### PR TITLE
bug when using extend_plot_limit in plot_distributed_thickness

### DIFF
--- a/oggm/graphics.py
+++ b/oggm/graphics.py
@@ -666,7 +666,10 @@ def plot_distributed_thickness(gdirs, ax=None, smap=None, varname_suffix=''):
     with utils.ncDataset(gdir.get_filepath('gridded_data')) as nc:
         topo = nc.variables['topo'][:]
 
-    smap.set_topography(topo)
+    try:
+        smap.set_topography(topo)
+    except ValueError:
+        pass
 
     for gdir in gdirs:
         grids_file = gdir.get_filepath('gridded_data')


### PR DESCRIPTION
If you tried to use `extend_plot_limit` in `plot_distributed_thickness` an error occurred because we have no topographic information for the combined grid. I therefore included a try/except statement (as it is done in other plotting functions).

Thanks to @suther11LBU for finding this!

- [ ] Tests added/passed
- [ ] Fully documented
- [ ] Entry in `whats-new.rst` 
