### PR TITLE
add glacier mask for preserving totals when binning variables

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -3,6 +3,16 @@
 Version history
 ===============
 
+v1.6.2 (unreleased)
+-------------------
+
+Bug fixes
+~~~~~~~~~
+- The binned variables in the elevation band flowlines did not used the
+  glacier mask when preserving the total values (:pull:`1661`).
+  By `Patrick Schmitt <https://github.com/pat-schmitt>`_
+
+
 v1.6.1 (August 27, 2023)
 ------------------------
 

--- a/oggm/core/centerlines.py
+++ b/oggm/core/centerlines.py
@@ -2224,7 +2224,14 @@ def elevation_band_flowline(gdir, bin_variables=None, preserve_totals=True):
         bin_variables = keep
         for var in bin_variables:
             data = nc.variables[var][:]
-            out_totals.append(np.nansum(data) * gdir.grid.dx ** 2)
+            if var == 'consensus_ice_thickness':
+                # individual handling for consensus thickness as they use a
+                # different glacier mask than oggm (which was already applied)
+                data_sum = np.nansum(data)
+            else:
+                # use oggm glacier mask for all other data
+                data_sum = np.nansum(data[glacier_mask])
+            out_totals.append(data_sum * gdir.grid.dx ** 2)
             out_vars.append(data[glacier_mask])
 
     preserve_totals = utils.tolist(preserve_totals, length=len(bin_variables))

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -69,7 +69,7 @@ logger = logging.getLogger('.'.join(__name__.split('.')[:-1]))
 # The given commit will be downloaded from github and used as source for
 # all sample data
 SAMPLE_DATA_GH_REPO = 'OGGM/oggm-sample-data'
-SAMPLE_DATA_COMMIT = '2ad86c93f9235e40edea506f13f6f489adeee805'
+SAMPLE_DATA_COMMIT = '56aa8f23e3b450e6f56a8d4e8a5cdb58e03c9cc1'
 
 CHECKSUM_URL = 'https://cluster.klima.uni-bremen.de/data/downloads.sha256.hdf'
 CHECKSUM_VALIDATION_URL = CHECKSUM_URL + '.sha256'


### PR DESCRIPTION
Here I add the use of the glacier mask for preserving totals when binning variables to the elevation bins. The consensus thickness is treated differently.

Closes https://github.com/OGGM/oggm/issues/1660

- [ ] Tests added/passed
- [ ] Fully documented
- [ ] Entry in `whats-new.rst` 
