### PR TITLE
Dem gridded_data shifted coordinates

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -24,6 +24,10 @@ Bug fixes
   glacier mask when preserving the total values. This is a bad
   bug that is now fixed (:pull:`1661`).
   By `Patrick Schmitt <https://github.com/pat-schmitt>`_
+- When converting a variable of gridded_data to an tiff-file using
+  ``tasks.gridded_data_var_to_geotiff`` the resulting coordinates where
+  shifted half a pixel, this is now fixed (:pull:`1682`).
+  By `Patrick Schmitt <https://github.com/pat-schmitt>`_
 
 
 v1.6.1 (August 27, 2023)

--- a/oggm/core/gis.py
+++ b/oggm/core/gis.py
@@ -1678,7 +1678,7 @@ def gridded_data_var_to_geotiff(gdir, varname, fname=None):
         # Prepare the profile dict
         crs = ds.pyproj_srs
         var = ds[varname]
-        grid = ds.salem.grid
+        grid = ds.salem.grid.corner_grid
         data = var.data
         data_type = data.dtype.name
         height, width = var.data.shape

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -9,6 +9,7 @@ import shapely.geometry as shpg
 import numpy as np
 import pandas as pd
 import xarray as xr
+import rioxarray as rioxr
 
 salem = pytest.importorskip('salem')
 rasterio = pytest.importorskip('rasterio')
@@ -514,20 +515,17 @@ class TestGIS(unittest.TestCase):
 
         with xr.open_dataset(gdir.get_filepath('gridded_data')) as ds:
             gridded_topo = ds[target_var]
-            gtiff_ds = salem.open_xr_dataset(gtiff_path)
-            # this line is uncommented due to a bug in salem, maybe also change
-            # it to check coordinates like below (floating point issues)
-            # assert ds.salem.grid == gtiff_ds.salem.grid
+            gtiff_ds = rioxr.open_rasterio(gtiff_path)
+            np.allclose(ds.salem.grid.x_coord, gtiff_ds.x)
+            np.allclose(ds.salem.grid.y_coord, gtiff_ds.y)
             assert np.allclose(gridded_topo.data, gtiff_ds.data)
 
         # compare coordinates of topo.tif with dem.tif
-        demtiff_ds = salem.open_xr_dataset(gdir.get_filepath('dem'))
-        gtiff_ds = salem.open_xr_dataset(gtiff_path)
-        assert np.allclose(demtiff_ds.data, gtiff_ds.data.values)
-        assert np.allclose(demtiff_ds.salem.grid.x_coord,
-                           gtiff_ds.salem.grid.x_coord)
-        assert np.allclose(demtiff_ds.salem.grid.y_coord,
-                           gtiff_ds.salem.grid.y_coord)
+        demtiff_ds = rioxr.open_rasterio(gdir.get_filepath('dem'))
+        gtiff_ds = rioxr.open_rasterio(gtiff_path)
+        assert np.allclose(demtiff_ds.data, gtiff_ds.data)
+        assert np.allclose(demtiff_ds.x, gtiff_ds.x)
+        assert np.allclose(demtiff_ds.y, gtiff_ds.y)
 
 
 class TestCenterlines(unittest.TestCase):

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -518,6 +518,12 @@ class TestGIS(unittest.TestCase):
             assert ds.salem.grid == gtiff_ds.salem.grid
             assert np.allclose(gridded_topo.data, gtiff_ds.data)
 
+        # compare coordinates of topo.tif with dem.tif
+        demtiff_ds = salem.open_xr_dataset(gdir.get_filepath('dem'))
+        gtiff_ds = salem.open_xr_dataset(gtiff_path)
+        assert np.allclose(demtiff_ds.data, gtiff_ds.data.values)
+        assert demtiff_ds.salem.grid.__eq__(gtiff_ds.salem.grid)
+
 
 class TestCenterlines(unittest.TestCase):
 

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -515,14 +515,19 @@ class TestGIS(unittest.TestCase):
         with xr.open_dataset(gdir.get_filepath('gridded_data')) as ds:
             gridded_topo = ds[target_var]
             gtiff_ds = salem.open_xr_dataset(gtiff_path)
-            assert ds.salem.grid == gtiff_ds.salem.grid
+            # this line is uncommented due to a bug in salem, maybe also change
+            # it to check coordinates like below (floating point issues)
+            # assert ds.salem.grid == gtiff_ds.salem.grid
             assert np.allclose(gridded_topo.data, gtiff_ds.data)
 
         # compare coordinates of topo.tif with dem.tif
         demtiff_ds = salem.open_xr_dataset(gdir.get_filepath('dem'))
         gtiff_ds = salem.open_xr_dataset(gtiff_path)
         assert np.allclose(demtiff_ds.data, gtiff_ds.data.values)
-        assert demtiff_ds.salem.grid.__eq__(gtiff_ds.salem.grid)
+        assert np.allclose(demtiff_ds.salem.grid.x_coord,
+                           gtiff_ds.salem.grid.x_coord)
+        assert np.allclose(demtiff_ds.salem.grid.y_coord,
+                           gtiff_ds.salem.grid.y_coord)
 
 
 class TestCenterlines(unittest.TestCase):

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -9,11 +9,11 @@ import shapely.geometry as shpg
 import numpy as np
 import pandas as pd
 import xarray as xr
-import rioxarray as rioxr
 
 salem = pytest.importorskip('salem')
 rasterio = pytest.importorskip('rasterio')
 gpd = pytest.importorskip('geopandas')
+rioxr = pytest.importorskip('rioxarray')
 
 # Local imports
 import oggm


### PR DESCRIPTION
This fixes a coordinate shift between `dem.tif` and the `gridded_data.nc`.

However, there seems to be a bug in salem when opening a .tif-file using `ds = salem.open_xr_dataset(tiff_path)` and calling `ds.salem.grid` afterwards. I will open a PR for salem and link it here.

Due to this bug, one test is currently not working and I commented it out. After salem is fixed the test can be uncommented again (and maybe adapted due to floating point problems...).

Closes https://github.com/OGGM/oggm/issues/1679

- [ ] Tests added/passed
- [ ] Fully documented
- [ ] Entry in `whats-new.rst` 
