### PR TITLE
make sure that melt_f limits are not exceeded in dynamic calibration

### DIFF
--- a/oggm/core/dynamic_spinup.py
+++ b/oggm/core/dynamic_spinup.py
@@ -1978,8 +1978,10 @@ def run_dynamic_melt_f_calibration(
     def minimise_with_spline_fit(fct_to_minimise, melt_f_guess, mismatch):
         # defines limits of melt_f in accordance to maximal allowed change
         # between iterations
-        melt_f_limits = [melt_f_initial - melt_f_max_step_length,
-                         melt_f_initial + melt_f_max_step_length]
+        melt_f_limits = [max(melt_f_initial - melt_f_max_step_length,
+                             melt_f_min),
+                         min(melt_f_initial + melt_f_max_step_length,
+                             melt_f_max)]
 
         # this two variables indicate that the limits were already adapted to
         # avoid an error


### PR DESCRIPTION
@fmaussion discovered that the dynamic calibration exceeds the defined bounds for the melt factor in a few cases. This PR now makes sure that this is not happening.

To get the same performance as before this change we could adapt the bounds a little bit...

- [ ] Tests added/passed
- [ ] Fully documented
- [ ] Entry in `whats-new.rst` 
