### PR TITLE
distribute2d: introduce only_allow_retreating flag

### DIFF
--- a/oggm/sandbox/distribute_2d.py
+++ b/oggm/sandbox/distribute_2d.py
@@ -350,7 +350,7 @@ def distribute_thickness_from_simulation(gdir,
                               mask],
                              dim='time')
             if mask.any():
-                # for each increasing time-step use the future time-step
+                # for each increasing time-step use the past time-step
                 dg = xr.where(mask, dg.shift(time=1), dg)
             else:
                 # if nothing is increasing we are done

--- a/oggm/sandbox/distribute_2d.py
+++ b/oggm/sandbox/distribute_2d.py
@@ -282,9 +282,11 @@ def distribute_thickness_from_simulation(gdir,
         smoothed using a rolling mean over time. The window size is defined
         with this number. We recommend 3, 5, or more (in extreme cases).
     only_allow_retreating : bool
-        If True, the algorithm will adapt the flowline diagnostics data in the way that each bin can only shrink
-        over time. If the simulated flowline's bin would actually gain mass/volume in a timestep, it stays unchanged
-        when "only_allow_retreating" is set to True. This can prevent flickering in distributed animations.
+        If True, the algorithm will adapt the flowline diagnostics data in the way
+        that each bin can only shrink over time. If the simulated flowline's bin would
+        actually gain mass/volume in a timestep, it stays unchanged when
+        "only_allow_retreating" is set to True.
+        This can prevent flickering in distributed animations.
     debug_area_timeseries : bool
         If True, the algorithm will return a dataframe additionally to the
         gridded dataset. The dataframe contains two columns: the original area

--- a/oggm/sandbox/distribute_2d.py
+++ b/oggm/sandbox/distribute_2d.py
@@ -338,14 +338,9 @@ def distribute_thickness_from_simulation(gdir,
     # applying the thickness threshold
     dg = xr.where(dg['thickness_m'] < fl_thickness_threshold, 0, dg)
 
-    # applying the rolling mean smoothing
-    if rolling_mean_smoothing:
-        dg[['area_m2', 'volume_m3']] = dg[['area_m2', 'volume_m3']].rolling(
-            min_periods=1, time=rolling_mean_smoothing, center=True).mean()
-
     # applying the only retreating algorithm
     if only_allow_retreating:
-        # stay in the loop as long as their is a glacier growing
+        # stay in the loop as long as there is a glacier growing
         for _ in range(len(dg['time'])):
             # get time_steps where thickness is increasing
             mask = dg.thickness_m.diff(dim='time') > 0
@@ -361,6 +356,10 @@ def distribute_thickness_from_simulation(gdir,
                 # if nothing is increasing we are done
                 break
 
+    # applying the rolling mean smoothing
+    if rolling_mean_smoothing:
+        dg[['area_m2', 'volume_m3']] = dg[['area_m2', 'volume_m3']].rolling(
+            min_periods=1, time=rolling_mean_smoothing, center=True).mean()
 
     # monthly interpolation for higher temporal resolution
     if add_monthly:

--- a/oggm/sandbox/distribute_2d.py
+++ b/oggm/sandbox/distribute_2d.py
@@ -343,22 +343,22 @@ def distribute_thickness_from_simulation(gdir,
 
     # applying the only retreating algorithm
     if only_allow_retreating:
-        increasing = True
-        while increasing:
-            thick_diff = dg.thickness_m.diff(dim='time')
-            nr_of_diff_timesteps = 0
-            for t in range(1, len(dg.coords['time'])):
-                # Find where the thickness difference is greater than 0
-                mask = thick_diff.isel(time=t - 1) > 0
+        # stay in the loop as long as their is a glacier growing
+        for _ in range(len(dg['time'])):
+            # get time_steps where thickness is increasing
+            mask = dg.thickness_m.diff(dim='time') > 0
+            # add False for the first time step to keep the same dimensions
+            mask = xr.concat([xr.full_like(dg.thickness_m.isel(time=0),
+                                           False),
+                              mask],
+                             dim='time')
+            if mask.any():
+                # for each increasing time-step use the future time-step
+                dg = xr.where(mask, dg.shift(time=1), dg)
+            else:
+                # if nothing is increasing we are done
+                break
 
-                if mask.any():
-                    nr_of_diff_timesteps += 1
-                    dg['thickness_m'][t, :] = xr.where(mask, dg['thickness_m'][t - 1, :], dg['thickness_m'][t, :])
-                    dg['area_m2'][t, :] = xr.where(mask, dg['area_m2'][t - 1, :], dg['area_m2'][t, :])
-                    dg['volume_m3'][t, :] = xr.where(mask, dg['volume_m3'][t - 1, :], dg['volume_m3'][t, :])
-            if nr_of_diff_timesteps == 0:
-                # when no timestep requires further modification, the while loop can end.
-                increasing = False
 
     # monthly interpolation for higher temporal resolution
     if add_monthly:


### PR DESCRIPTION
Small addition of an option to not allow sudden glacier (re-)growth in the `distribute_thickness_from_simulation` workflow.  This allows for smoother animations, but keep in mind that this can change the area/thickness evolution of the glacier.


- [ ] Tests added/passed
- [x] Fully documented
- [ ] Entry in `whats-new.rst` 
