### PR TITLE
Add missing PR's to whats-new

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -115,9 +115,12 @@ the majority of OGGM's tasks). They are parallelizable.
     tasks.glacier_masks
     tasks.simple_glacier_masks
     tasks.rasterio_glacier_mask
+    tasks.rasterio_glacier_exterior_mask
+    tasks.compute_hypsometry_attributes
     tasks.gridded_attributes
     tasks.gridded_mb_attributes
     tasks.gridded_data_var_to_geotiff
+    tasks.rgi7g_to_complex
     tasks.compute_centerlines
     tasks.compute_downstream_line
     tasks.compute_downstream_bedshape
@@ -131,25 +134,31 @@ the majority of OGGM's tasks). They are parallelizable.
     tasks.fixed_dx_elevation_band_flowline
     tasks.process_climate_data
     tasks.process_custom_climate_data
+    tasks.historical_delta_method
     tasks.mb_calibration_from_scalar_mb
     tasks.mb_calibration_from_geodetic_mb
     tasks.mb_calibration_from_wgms_mb
     tasks.apparent_mb_from_linear_mb
     tasks.apparent_mb_from_any_mb
+    tasks.perturbate_mb_params
     tasks.fixed_geometry_mass_balance
     tasks.compute_ela
+    tasks.process_w5e5_data
     tasks.process_cru_data
     tasks.process_dummy_cru_file
     tasks.process_histalp_data
     tasks.process_ecmwf_data
     tasks.process_gcm_data
     tasks.process_cesm_data
+    tasks.process_monthly_isimip_data
     tasks.process_cmip_data
-    tasks.historical_delta_method
+    tasks.process_lmr_data
+    tasks.process_modera_data
     tasks.prepare_for_inversion
     tasks.mass_conservation_inversion
     tasks.filter_inversion_output
     tasks.get_inversion_volume
+    tasks.compute_velocities
     tasks.compute_inversion_velocities
     tasks.distribute_thickness_per_altitude
     tasks.distribute_thickness_interp
@@ -159,11 +168,12 @@ the majority of OGGM's tasks). They are parallelizable.
     tasks.run_random_climate
     tasks.run_from_climate_data
     tasks.run_constant_climate
-    tasks.merge_consecutive_run_outputs
+    tasks.run_with_hydro
     tasks.run_dynamic_spinup
     tasks.run_dynamic_melt_f_calibration
     tasks.copy_to_basedir
     tasks.gdir_to_tar
+    tasks.merge_consecutive_run_outputs
 
 .. _apiglobaltasks:
 

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -21,7 +21,8 @@ Enhancements
   for merging distributed data from multiple glacier directories, including
   the possibility of adding topography to the merged grid. The latter function
   acts as a wrapper for the first one, specifically designed for merging
-  distributed thickness data from a dynamic model run (:pull:`1674`, :pull:`1691`, :pull:`1697` and :pull:`1719`).
+  distributed thickness data from a dynamic model run (:pull:`1674`,
+  :pull:`1691`, :pull:`1697` and :pull:`1719`).
   By `Alex Fischer <https://github.com/afisc>`_ and
   `Patrick Schmitt <https://github.com/pat-schmitt>`_
 - Added a new calving module to the sandbox. The module is based on
@@ -43,10 +44,29 @@ Enhancements
   By `Alex Fischer <https://github.com/afisc>`_
 - Added Cook et al 2023 Alps thickness data to the shop (:pull:`1724`).
   By `Fabien Maussion <https://github.com/fmaussion>`_
+- Added support for RGI7 (:pull:`1657`, :pull:`1702` and :pull:`1720`).
+  By `Fabien Maussion <https://github.com/fmaussion>`_
+- Added GlaThiDa data to the shop (:pull:`1663`).
+  By `Fabien Maussion <https://github.com/fmaussion>`_
+- Added an installation guide for Windows users (:pull:`1666` and :pull:`1683`).
+  By `Anouk Vlug <https://github.com/fmaussion>`_,
+  `Rebekka Neugebauer <https://github.com/rebneugebauer>`_ and
+  `Fabien Maussion <https://github.com/fmaussion>`_
 
 Bug fixes
 ~~~~~~~~~
 
+- Fixed a bug in ``inversion.filter_inversion_output`` that caused an error
+  for small glaciers with fewer than five grid points containing ice
+  (:pull:`1635`).
+  By `Patrick Schmitt <https://github.com/pat-schmitt>`_
+- Changed variable name from ``t_bias`` to ``t_spinup`` in
+  ``dynamic_spinup.run_dynamic_spinup``, to avoid confusions with
+  variable names of the massbalance models (:pull:`1671`).
+  By `Patrick Schmitt <https://github.com/pat-schmitt>`_
+- Fixed a bug in ``dynamic_spinup.run_dynamic_melt_f_calibration`` that allowed
+  the melt_f value to slightly exceed the defined limits (:pull:`1685`).
+  By `Patrick Schmitt <https://github.com/pat-schmitt>`_
 - The binned variables in the elevation band flowlines did not use the
   glacier mask when preserving the total values. This is a bad
   bug that is now fixed (:pull:`1661`).

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -21,7 +21,7 @@ Enhancements
   for merging distributed data from multiple glacier directories, including
   the possibility of adding topography to the merged grid. The latter function
   acts as a wrapper for the first one, specifically designed for merging
-  distributed thickness data from a dynamic model run.
+  distributed thickness data from a dynamic model run (:pull:`1674`, :pull:`1691`, :pull:`1697` and :pull:`1719`).
   By `Alex Fischer <https://github.com/afisc>`_ and
   `Patrick Schmitt <https://github.com/pat-schmitt>`_
 - Added a new calving module to the sandbox. The module is based on

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -52,6 +52,20 @@ Enhancements
   By `Anouk Vlug <https://github.com/fmaussion>`_,
   `Rebekka Neugebauer <https://github.com/rebneugebauer>`_ and
   `Fabien Maussion <https://github.com/fmaussion>`_
+- Made it easier to run parameter perturbation experiments by
+  allowing more than one mb_calib.json file in the
+  working directory (:pull:`1678`) and by adding a new
+  `perturbate_mb_params` task (:pull:`1669`).
+  By `Fabien Maussion <https://github.com/fmaussion>`_
+- Preprocessed directories can now have categorical resolution
+  classes like GloGEM does (did it for IGM), where users can choose
+  bins where a given dx is used (:pull:`1664`). It looks nicer
+  to the eye but I still think the continue dx approach is better.
+  By `Fabien Maussion <https://github.com/fmaussion>`_
+- The mass-balance model can now be calibrated on regional averages
+  instead of glacier-per-glacier values. This is useful to trick
+  RGI7 into being calibrated or other things (:pull:`1692`).
+  By `Fabien Maussion <https://github.com/fmaussion>`_
 
 Bug fixes
 ~~~~~~~~~

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -1504,7 +1504,7 @@ def mb_calibration_from_geodetic_mb(gdir, *,
         same parameters as MonthlyTIModel (the default): melt_f,
         temp_bias, prcp_fac.
     filesuffix: str
-        add a filesuffix to mb_params.json. This could be useful for sensitivity
+        add a filesuffix to mb_calib.json. This could be useful for sensitivity
         analyses with MB models, if they need to fetch other sets of params for
         example.
 
@@ -1729,7 +1729,7 @@ def mb_calibration_from_scalar_mb(gdir, *,
         the maximum accepted value for the temperature bias during optimisation.
         Defaults to cfg.PARAMS['temp_bias_max'].
     filesuffix: str
-        add a filesuffix to mb_params.json. This could be useful for sensitivity
+        add a filesuffix to mb_calib.json. This could be useful for sensitivity
         analyses with MB models, if they need to fetch other sets of params for
         example.
     """

--- a/oggm/global_tasks.py
+++ b/oggm/global_tasks.py
@@ -9,7 +9,6 @@ from oggm.workflow import climate_tasks
 from oggm.workflow import inversion_tasks
 from oggm.workflow import calibrate_inversion_from_consensus
 from oggm.workflow import merge_glacier_tasks
-
 from oggm.utils import get_ref_mb_glaciers
 from oggm.utils import write_centerlines_to_shape
 from oggm.utils import compile_run_output


### PR DESCRIPTION
Here is a list of commits not included in whats-new. I highlighted the ones that I think should be included in bold.

- [ ] Bump actions or docker: 2beb564c2f1857723f06d7869d84ef6501c61f8f, 75ba2d5afef6f80c908b6ce0a054b9bf982dd85a, e7d4118321d42bdfd73a9444284008b6ca27e9de, 7897b5c31daa91152ca0cfc7c62128a30ae1ddfd, 76757e825010ffc4ae99dd2c3644f3f7da8dcb69, d8378217543463e02d1223f7b7bb843ac237ba1e, fca4449d826c817a5aca3e366922701c023c9d46, 682eda71c8691b99268bec4cdc0d06c45ac34250
- [ ] Allow existance of created directories: 71c13bd45e00eac5039a8d15f103921e58aeabd4
- PRs:
  - [ ] 1634: fix typos db634e591110e46d4d8e3c27914934e075313af1
  - [x] **1635: Bug in filter_inversion_output 29543597582befe5367847212678ab97b21044b1**
  - [ ] 1636: Vectorize floatyear_to_date 53a6a1f005ee511fe1538443a0490fe566f11dfa
  - [ ] 1659: fix small bug when using extend_plot_limit in plot_distributed_thickness 90aef5e57dfb3a14c104597c50b65893408f3ec5
  - [x] **1657: RGI7 support (officially this time) 6ba2794597a51814d919761c6f59d8fff9ea8ecd**
  - [ ] 1656: fix typos d37540c822ae3144301905ff9a42b82e569ff7c6
  - [x] **1663: Add GlaThiDa to shop a703e5e7d94bf038d9c3c615f61a2597e0014419**
  - [ ] 1665: fix broken link 263ba169d53c307d694d92c4c367a4b4af226f0e
  - [x] **1664: More options for prepro directories 009be393ebe87f86b9a4f1b39cf1340e2db55bd4**
  - [x] **1666: Installing OGGM on Windows 2162dcbec9a3fcfcfcb8a3c770b88e483edcd5aa**
  - [x] **1671: Small dynamic spinup adaptations 390f6568828775726270b0a231f023677d60a114**
  - [x] **1678: Add filesuffix to mb calibration 6e0fb56d92f02aa525e71daeee9be4848c81b5e5**
  - [x] **1669: Add mb params perturbation utility func f899432874bee48bc76b46d6dc4c0f29fd7bf14e**
  - [x] **1685: make sure that melt_f limits are not exceeded in dynamic calbration 5313d54d35d61892335209e7b3d2ba36430bdf81**
  - [ ] 1686: Fix various small bugs 7a065702f63ed97341d9a86cfd205b70c83acc0b
  - [x] **1674: merge gridded data f7ed63acf7b69f736e47a340d47e52a4338900a4**
  - [x] **1692: Add possibility to calibrate from regional values 38880e142f527671a1ad5082e63fdc9de90a7677**
  - [x] **1691: Small adaptations for merge_gridded_data c45194be38c90ef725906172c8ddacf27b0cb2c8**
  - [x] **1702: Add utilities for glacier entities in complexes 9faee85f6b8f7c16c20f1037735f73d05d61080f**
  - [x] **1683: Add link to doc on OGGM installation with WSL fc233f44b92c55e3d94413528c801ae7ed4cc60e**
  - [x] **1697: Bugfix in merged_gridded_data 7489be15c644b54c5f20501c38e654a47c63c53c**
  - [ ] 1717: Use full environment name in artifact name 1121efdf736bd92c60f35eeb0f609fb082e23b11
  - [ ] 1718: try to fix things 3354bee1a74331a4536b10840f1ec50bec21689b
  - [x] **1720: Fix silly overflow issue in RGI7 rgi7g_to_complex task 54548d15381269e91c0ba3b3311f26fd66934c88**
  - [x] **1719: distribute2d: introduce only_allow_retreating flag fb3e42b94f7def7b6e311af730c5c616942d5d2c**
  - [ ] 1725: first doc build 1b2b36d1483a0ab498073cf65bad5f1bf520a8a1
