### PR TITLE
Update flowline.py

### DIFF
--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -2415,7 +2415,7 @@ class SemiImplicitModel(FlowlineModel):
         b_corr = - d_stag * self.dbed_h_exp_dx
 
         # prepare rhs
-        smb = self.get_mb(surface_h, self.yr, fl_id=0)
+        smb = self.get_mb(surface_h, self.yr, fl_id=0, fls=self.fls)
         rhs = thick + smb * dt + dt / width * (b_corr[:-1] - b_corr[1:]) / dx
 
         # solve matrix and update flowline thickness


### PR DESCRIPTION
add the flowline object as a kwarg that can be used by get_annual_mb()

Currently, FluxBasedModel.step() in its call to get_mb() passes fls=self.fls as a kwarg. This change is simply to bring SemiImplicitModel up to parity, so the flowline object can be used by certain types of mass balance classes.

No issue was raised.
