### PR TITLE
Updating to NumPy > 2.0

### DIFF
--- a/oggm/core/dynamic_spinup.py
+++ b/oggm/core/dynamic_spinup.py
@@ -1548,8 +1548,8 @@ def dynamic_melt_f_run(
     with utils.DisableLogger():
         ds = utils.compile_run_output(gdir, input_filesuffix=output_filesuffix,
                                       path=False)
-    dmdtda_mdl = ((ds.volume.loc[yr1_ref_mb].values -
-                   ds.volume.loc[yr0_ref_mb].values) /
+    dmdtda_mdl = ((ds.volume.loc[yr1_ref_mb].values[0] -
+                   ds.volume.loc[yr0_ref_mb].values[0]) /
                   gdir.rgi_area_m2 /
                   (yr1_ref_mb - yr0_ref_mb) *
                   cfg.PARAMS['ice_density'])
@@ -1960,10 +1960,8 @@ def run_dynamic_melt_f_calibration(
         model_dynamic_spinup_end.append(copy.deepcopy(model_dynamic_spinup))
 
         # calculate the mismatch of dmdtda
-        try:
-            cost = float(dmdtda_mdl - ref_dmdtda)
-        except:
-            t = 1
+        cost = float(dmdtda_mdl - ref_dmdtda)
+
         return cost
 
     def init_cost_fun():

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -1262,7 +1262,7 @@ class FlowlineModel(object):
 
         # First deal with spinup (we compute volume change only)
         if do_fixed_spinup:
-            spinup_vol = monthly_time * 0
+            spinup_vol = monthly_time * 0.
             for fl_id, fl in enumerate(self.fls):
 
                 h = fl.surface_h

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -3858,9 +3858,9 @@ class TestDynamicSpinup:
 
         df_ref_dmdtda = utils.get_geodetic_mb_dataframe().loc[gdir.rgi_id]
         sel = df_ref_dmdtda.loc[df_ref_dmdtda['period'] == ref_period]
-        ref_dmdtda = float(sel['dmdtda'])
+        ref_dmdtda = float(sel['dmdtda'].iloc[0])
         ref_dmdtda *= 1000  # kg m-2 yr-1
-        err_ref_dmdtda = float(sel['err_dmdtda'])
+        err_ref_dmdtda = float(sel['err_dmdtda'].iloc[0])
         err_ref_dmdtda *= 1000  # kg m-2 yr-1
 
         melt_f_max = 1000 * 12 / 365

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -5713,8 +5713,10 @@ class TestDistribute2D:
         fl_diag = fl_diag.isel(dis_along_flowline=slice(0, band_ids.max()+1))
         for bid in band_ids:
             thick_band = thick.where(ds.band_index == bid)
-            fl_diag['volume_m3_dis'].data[:, bid] = thick_band.sum(dim=['x', 'y']) * dx2
-            fl_diag['area_m2_dis'].data[:, bid] = (thick_band > 1).sum(dim=['x', 'y']) * dx2
+            fl_diag['volume_m3_dis'].data[:, bid] = (
+                    thick_band.sum(dim=['x', 'y']).values * dx2)
+            fl_diag['area_m2_dis'].data[:, bid] = (
+                    (thick_band > 1).sum(dim=['x', 'y']).values * dx2)
 
         for yr in [2003]:
             # All the other years have larger errors but they somehow still look

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -5713,10 +5713,10 @@ class TestDistribute2D:
         fl_diag = fl_diag.isel(dis_along_flowline=slice(0, band_ids.max()+1))
         for bid in band_ids:
             thick_band = thick.where(ds.band_index == bid)
-            fl_diag['volume_m3_dis'].data[:, bid] = (
-                    thick_band.sum(dim=['x', 'y']).values * dx2)
-            fl_diag['area_m2_dis'].data[:, bid] = (
-                    (thick_band > 1).sum(dim=['x', 'y']).values * dx2)
+            fl_diag['volume_m3_dis'].data[:, bid] = thick_band.sum(dim=['x', 'y']
+                                                                   ).values * dx2
+            fl_diag['area_m2_dis'].data[:, bid] = (thick_band > 1).sum(dim=['x', 'y']
+                                                                       ).values * dx2
 
         for yr in [2003]:
             # All the other years have larger errors but they somehow still look

--- a/oggm/utils/_funcs.py
+++ b/oggm/utils/_funcs.py
@@ -687,7 +687,7 @@ def floatyear_to_date(yr):
         The floating year
     """
 
-    if isinstance(yr,  xr.DataArray):
+    if isinstance(yr, xr.DataArray):
         yr = yr.values
 
     out_y, remainder = np.divmod(yr, 1)

--- a/oggm/utils/_funcs.py
+++ b/oggm/utils/_funcs.py
@@ -687,6 +687,9 @@ def floatyear_to_date(yr):
         The floating year
     """
 
+    if isinstance(yr,  xr.DataArray):
+        yr = yr.values
+
     out_y, remainder = np.divmod(yr, 1)
     out_y = out_y.astype(int)
 
@@ -700,9 +703,6 @@ def floatyear_to_date(yr):
     if (isinstance(yr, list) or isinstance(yr, np.ndarray)) and len(yr) == 1:
         out_y = out_y.item()
         out_m = out_m.item()
-    elif isinstance(yr, xr.DataArray):
-        out_y = np.array(out_y)
-        out_m = np.array(out_m)
 
     return out_y, out_m
 
@@ -769,6 +769,11 @@ def calendardate_to_hydrodate(y, m, start_month=None):
         the first month of the hydrological year
     """
 
+    if isinstance(y, xr.DataArray):
+        y = y.values
+    if isinstance(m, xr.DataArray):
+        m = m.values
+
     if start_month is None:
         raise InvalidParamsError('In order to avoid confusion, we now force '
                                  'callers of this function to specify the '
@@ -792,6 +797,11 @@ def monthly_timeseries(y0, y1=None, ny=None, include_last_year=False):
     Parameters
     ----------
     """
+
+    if isinstance(y0, xr.DataArray):
+        y0 = y0.values
+    if isinstance(y1, xr.DataArray):
+        y1 = y1.values
 
     if y1 is not None:
         years = np.arange(np.floor(y0), np.floor(y1) + 1)

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -2313,9 +2313,9 @@ def extend_past_climate_run(past_run_file=None,
 
         # Time
         ods['hydro_year'].data[:] = years
-        ods['hydro_month'].data[:] = ods['hydro_month'][-1]
+        ods['hydro_month'].data[:] = ods['hydro_month'][-1].item()
         ods['calendar_year'].data[:] = years
-        ods['calendar_month'].data[:] = ods['calendar_month'][-1]
+        ods['calendar_month'].data[:] = ods['calendar_month'][-1].item()
         for vn in ['hydro_year', 'hydro_month', 'calendar_year', 'calendar_month']:
             ods[vn] = ods[vn].astype(int)
 
@@ -3423,6 +3423,12 @@ class GlacierDirectory(object):
             Apply a suffix to the file
         """
 
+        if isinstance(prcp, xr.DataArray):
+            prcp = prcp.values
+        if isinstance(temp, xr.DataArray):
+            temp = temp.values
+        if isinstance(temp_std, xr.DataArray):
+            temp_std = temp_std.values
         # overwrite as default
         fpath = self.get_filepath(file_name, filesuffix=filesuffix)
         if os.path.exists(fpath):

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -1068,7 +1068,7 @@ def merge_gridded_data(gdirs, output_folder=None,
                                     if slice_of_var is not None:
                                         if dim in slice_of_var:
                                             coord_val = ds_templ[coord].sel(
-                                                {dim: slice_of_var[dim]})
+                                                {dim: slice_of_var[dim]}).values
                                         else:
                                             coord_val = ds_templ[coord].values
                                     else:


### PR DESCRIPTION
In this PR, I address test failures and warnings related to NumPy > 2.0.

Two tests were failing due to a silent conversion from float to int during the [fixed geometry spinup](https://github.com/OGGM/oggm/blob/master/oggm/core/flowline.py#L1274). Here's a small example illustrating the issue:

```python
test_array = np.array([1, 2, 3])
test_nr = np.float64(1.2)
test_array[0] = test_nr
print(test_array)
```
will print `array([1, 2, 3])`, whereas

```python
test_array = np.array([1., 2., 3.])
test_nr = np.float64(1.2)
test_array[0] = test_nr
print(test_array)
```
will print `array([1.2, 2. , 3. ])`. 

This behaviour is tricky to catch and highlights the importance of being mindful of the `dtype` when working with NumPy > 2.0.

Most of the warnings I fixed are related to xarray (likely to be resolved in future updates to xarray), and there are still some warnings from pandas that need to be addressed within pandas itself.

- [ ] Tests added/passed
- [ ] Fully documented
- [ ] Entry in `whats-new.rst` 
