### PR TITLE
Add bin_area to the inversion flowlines

### DIFF
--- a/oggm/core/centerlines.py
+++ b/oggm/core/centerlines.py
@@ -247,6 +247,19 @@ class Centerline(object, metaclass=SuperclassMeta):
     def widths_m(self):
         return self.widths * self.map_dx
 
+    @property
+    def bin_area_m2(self):
+        # area of the grid point
+        return self.widths_m * self.dx_meter
+
+    @property
+    def area_m2(self):
+        return np.sum(self.bin_area_m2)
+
+    @property
+    def area_km2(self):
+        return self.area_m2 * 1e-6
+
     @widths.setter
     def widths(self, value):
         self._widths = value

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -1154,6 +1154,12 @@ class TestGeometry(unittest.TestCase):
         np.testing.assert_allclose(area * 10**-6, float(tdf['Area']),
                                    rtol=1e-4)
 
+        area_attr = 0
+        for cl in cls:
+            area_attr += cl.area_km2
+        np.testing.assert_allclose(area_attr, float(tdf['Area']),
+                                   rtol=1e-4)
+
         # Check for area distrib
         bins = np.arange(utils.nicenumber(np.min(hgt), 50, lower=True),
                          utils.nicenumber(np.max(hgt), 50)+1,


### PR DESCRIPTION
@bearecinos @dngoldberg this adds the bin_area attribute to the inversion flowlines objects. It's just a handy diagnostic, its also possible to compute it from the previous objects attribues, as is done in the code here.