### PR TITLE
Adaptations for 2D redistribution

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -9,6 +9,18 @@ v1.6.x (not released)
 Enhancements
 ~~~~~~~~~~~~
 
+- Added ``tasks.compute_fl_diagnostics_quantiles``, this task is designed to
+  calculate quantiles from multiple fl_diagnostic files. It enables users to
+  compute metrics such as the median flowline across various GCM projections
+  (:pull:`1746`).
+  By `Patrick Schmitt <https://github.com/pat-schmitt>`_
+- New ranking options for the ``distribute.assign_points_to_band`` task, which
+  determines the order in which pixels "melt away" when redistributing flowline
+  model runs into 2D for visualization purposes. It is now possible to combine
+  different variables from ``gridded_data`` (e.g. ``slope``,
+  ``dis_from_border``, ...) to define this ranking, providing greater flexibility
+  and control over how the melting sequence is visualized (:pull:`1746`).
+  By `Patrick Schmitt <https://github.com/pat-schmitt>`_
 
 Bug fixes
 ~~~~~~~~~

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -4599,7 +4599,7 @@ def compute_fl_diagnostics_quantiles(gdir,
                                      input_filesuffixes,
                                      quantiles=0.5,
                                      output_filesuffix='_median',
-                                    ):
+                                     ):
     """Compute quantile fl_diagnostics (e.g. median flowline of projections)
 
     This function takes a number of fl_diagnostic files and compute out of them
@@ -4629,7 +4629,7 @@ def compute_fl_diagnostics_quantiles(gdir,
             quantiles = quantiles[0]
 
     # get filepath of all fl_diagnostic files
-    all_fl_diag_paths= []
+    all_fl_diag_paths = []
     for filesuffix in input_filesuffixes:
         all_fl_diag_paths.append(gdir.get_filepath('fl_diagnostics',
                                                    filesuffix=filesuffix))

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -4592,3 +4592,80 @@ def clean_merged_flowlines(gdir, buffer=None):
 
     # Finally write the flowlines
     gdir.write_pickle(allfls, 'model_flowlines')
+
+
+@entity_task(log)
+def compute_fl_diagnostics_quantiles(gdir,
+                                     input_filesuffixes,
+                                     quantiles=0.5,
+                                     output_filesuffix='_median',
+                                    ):
+    """Compute quantile fl_diagnostics (e.g. median flowline of projections)
+
+    This function takes a number of fl_diagnostic files and compute out of them
+    quantiles. This could be useful for example for calculating a median
+    flowline for different gcm projections which use the same scenario
+    (e.g. ssp126).
+
+    Parameters
+    ----------
+    gdir : :py:class:`oggm.GlacierDirectory`
+        the glacier directory to process
+    input_filesuffixes : list
+        a list of fl_diagnostic filesuffixes which should be considered for
+        computing
+    quantiles : float or list
+        The quantiles to compute. Could be a float for a single quantile or a
+        list of floats for severel quantile calculations.
+        Default is 0.5 (the median).
+    output_filesuffix : str
+        The output_filesuffix of the resulting fl_diagnostics.
+        Default is '_median'.
+    """
+
+    # if quantiles is a list with one element, only use this
+    if isinstance(quantiles, list):
+        if len(quantiles) == 1:
+            quantiles = quantiles[0]
+
+    # get filepath of all fl_diagnostic files
+    all_fl_diag_paths= []
+    for filesuffix in input_filesuffixes:
+        all_fl_diag_paths.append(gdir.get_filepath('fl_diagnostics',
+                                                   filesuffix=filesuffix))
+
+    # assume all have the same number of flowlines, extract the base structure
+    # and number of fl_ids from the first file
+    with xr.open_dataset(all_fl_diag_paths[0]) as ds:
+        ds_base = ds.load()
+        fl_ids = ds.flowlines.data
+
+    # help function to open all fl_diag files as one with open_mfdataset
+    def add_filename_coord(ds):
+        filepath = ds.encoding["source"]
+        filename = os.path.basename(filepath).split(".")[0]
+        return ds.expand_dims({'filename': [filename]})
+
+    # now loop through all flowlines and save back in the same structure
+    fl_diag_dss = []
+    for fl_id in fl_ids:
+        with xr.open_mfdataset(all_fl_diag_paths,
+                               preprocess=lambda ds: add_filename_coord(ds),
+                               group=f'fl_{fl_id}') as ds_fl:
+            with warnings.catch_warnings():
+                # ignore warnings for NaNs
+                warnings.simplefilter("ignore", category=RuntimeWarning)
+                fl_diag_dss.append(ds_fl.load().quantile(quantiles,
+                                                         dim='filename'))
+
+    # for writing into the nice output structure
+    output_filepath = gdir.get_filepath('fl_diagnostics',
+                                        filesuffix=output_filesuffix)
+    encode = {}
+    for v in fl_diag_dss[0]:
+        encode[v] = {'zlib': True, 'complevel': 5}
+
+    ds_base.to_netcdf(output_filepath, 'w')
+    for fl_id, ds in zip(fl_ids, fl_diag_dss):
+        ds.to_netcdf(output_filepath, 'a', group='fl_{}'.format(fl_id),
+                     encoding=encode)

--- a/oggm/tasks.py
+++ b/oggm/tasks.py
@@ -62,6 +62,7 @@ from oggm.core.flowline import run_random_climate
 from oggm.core.flowline import run_from_climate_data
 from oggm.core.flowline import run_constant_climate
 from oggm.core.flowline import run_with_hydro
+from oggm.core.flowline import compute_fl_diagnostics_quantiles
 from oggm.core.dynamic_spinup import run_dynamic_spinup
 from oggm.core.dynamic_spinup import run_dynamic_melt_f_calibration
 from oggm.utils import copy_to_basedir


### PR DESCRIPTION
This PR is for discussing some possibilities for adapting the 2D redistribution.

It includes a new possibility for ranking the pixels in each elevation band (order in which pixels melt) and a function for calculating a median flowline (e.g. madian flowline from different gcms with the same scenario).

After some testing we can decide what we want to keep.

- [x] Tests added/passed
- [ ] Fully documented (opened issues for tutorials)
- [x] Entry in `whats-new.rst` 
