### PR TITLE
fix floating point precision in floatyear_to_date

### DIFF
--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -123,6 +123,10 @@ class TestFuncs(object):
         r = utils.floatyear_to_date(yr)
         assert r == (1998, 2)
 
+        yr = 1 + 1/12 - 1/12
+        r = utils.floatyear_to_date(yr)
+        assert r == (1, 1)
+
     def test_date_to_floatyear(self):
 
         r = utils.date_to_floatyear(0, 1)

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -123,9 +123,15 @@ class TestFuncs(object):
         r = utils.floatyear_to_date(yr)
         assert r == (1998, 2)
 
+        # tests for floating point precision
         yr = 1 + 1/12 - 1/12
         r = utils.floatyear_to_date(yr)
         assert r == (1, 1)
+
+        for i in range(12):
+            yr = 2000
+            r = utils.floatyear_to_date(yr + i / 12)
+            assert r == (yr, i + 1)
 
     def test_date_to_floatyear(self):
 

--- a/oggm/utils/_funcs.py
+++ b/oggm/utils/_funcs.py
@@ -694,13 +694,13 @@ def floatyear_to_date(yr):
         yr = np.array([yr], dtype=np.float64)
 
     # check if year is inside machine precision to next higher int
+    yr_ceil = np.ceil(yr)
     yr = np.where(np.isclose(yr,
-                             np.ceil(yr),
-                             # larger numbers have a smaller precision
-                             rtol=np.finfo(np.float64).eps * np.max(yr),
+                             yr_ceil,
+                             rtol=np.finfo(np.float64).eps,
                              atol=0
                              ),
-                  np.ceil(yr),
+                  yr_ceil,
                   yr)
 
     out_y, remainder = np.divmod(yr, 1)

--- a/oggm/utils/_funcs.py
+++ b/oggm/utils/_funcs.py
@@ -690,12 +690,8 @@ def floatyear_to_date(yr):
     if isinstance(yr, xr.DataArray):
         yr = yr.values
 
-    if isinstance(yr, (int, float)):
-        yr = np.array([yr], dtype=np.float64)
-
-    if ((isinstance(yr, np.ndarray) or
-         isinstance(yr, np.generic)) and yr.size == 1):
-        yr = np.array([yr], dtype=np.float64)
+    # Ensure yr is a np.array, even for scalar values
+    yr = np.atleast_1d(yr).astype(np.float64)
 
     # check if year is inside machine precision to next higher int
     yr_ceil = np.ceil(yr)
@@ -717,7 +713,7 @@ def floatyear_to_date(yr):
                                 np.round(month_exact),
                                 np.floor(month_exact)).astype(int))
 
-    if (isinstance(yr, list) or isinstance(yr, np.ndarray)) and len(yr) == 1:
+    if yr.size == 1:
         out_y = out_y.item()
         out_m = out_m.item()
 

--- a/oggm/utils/_funcs.py
+++ b/oggm/utils/_funcs.py
@@ -690,6 +690,19 @@ def floatyear_to_date(yr):
     if isinstance(yr, xr.DataArray):
         yr = yr.values
 
+    if isinstance(yr, (int, float)):
+        yr = np.array([yr], dtype=np.float64)
+
+    # check if year is inside machine precision to next higher int
+    yr = np.where(np.isclose(yr,
+                             np.ceil(yr),
+                             # larger numbers have a smaller precision
+                             rtol=np.finfo(np.float64).eps * np.max(yr),
+                             atol=0
+                             ),
+                  np.ceil(yr),
+                  yr)
+
     out_y, remainder = np.divmod(yr, 1)
     out_y = out_y.astype(int)
 

--- a/oggm/utils/_funcs.py
+++ b/oggm/utils/_funcs.py
@@ -693,6 +693,10 @@ def floatyear_to_date(yr):
     if isinstance(yr, (int, float)):
         yr = np.array([yr], dtype=np.float64)
 
+    if ((isinstance(yr, np.ndarray) or
+         isinstance(yr, np.generic)) and yr.size == 1):
+        yr = np.array([yr], dtype=np.float64)
+
     # check if year is inside machine precision to next higher int
     yr_ceil = np.ceil(yr)
     yr = np.where(np.isclose(yr,


### PR DESCRIPTION
In this PR I fix a bug which was brought up by @Ruitangtang.

The problem was when calling `floatyear_to_date(1+1/12-1/12)` you expect to get `(1, 1)`, but actually `(0, 12)` was returned, due to a floating point precision issue. I now included a check if the given floatyear is inside machine precision to the next higher int, and if so us the next higher int instead.

- [ ] Tests added/passed
- [ ] Fully documented
- [ ] Entry in `whats-new.rst` 
