### PR TITLE
Add new possiblities for providing paramters.

### DIFF
--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -301,6 +301,11 @@ BASENAMES['elevation_band_flowline'] = ('elevation_band_flowline.csv', _doc)
 _doc = "The outlines of this glacier complex sub-entities (for RGI7C only!)."
 BASENAMES['complex_sub_entities'] = ('complex_sub_entities.shp', _doc)
 
+_doc = ("A dict containing optional settings for a model run. Could contain "
+        "mass balance parameters, dynamic parameters or observations. If a "
+        "required parameter is not included, the default value will be used.")
+BASENAMES['run_settings'] = ('run_settings.yml', _doc)
+
 
 def set_logging_config(logging_level='INFO'):
     """Set the global logger parameters.

--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -378,11 +378,14 @@ def initialize_minimal(file=None, logging_level='INFO', params=None):
     Parameters
     ----------
     file : str
-        path to the configuration file (default: OGGM params.cfg)
+        path to a user configuration file. The parameters provided in this file
+        will override the default settings in `OGGM params.cfg`. The file does
+        not need to include all parameters.
     logging_level : str
         set a logging level. See :func:`set_logging_config` for options.
     params : dict
-        overrides for specific parameters from the config file
+        overrides for specific parameters from the config file. Overrules a
+        potential provided file.
     """
     global IS_INITIALIZED
     global PARAMS
@@ -390,16 +393,29 @@ def initialize_minimal(file=None, logging_level='INFO', params=None):
 
     set_logging_config(logging_level=logging_level)
 
-    is_default = False
-    if file is None:
-        file = os.path.join(os.path.abspath(os.path.dirname(__file__)),
-                            'params.cfg')
-        is_default = True
+    # Open default params file
+    is_default = True
+    file_default = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                                'params.cfg')
     try:
-        cp = ConfigObj(file, file_error=True)
+        cp = ConfigObj(file_default, file_error=True)
     except (ConfigObjError, IOError) as e:
-        log.critical('Config file could not be parsed (%s): %s', file, e)
+        log.critical('Config file could not be parsed (%s): %s',
+                     file_default, e)
         sys.exit()
+
+    # If provided open user params file and overwrite defaults
+    if file:
+        is_default = False
+        try:
+            cp_user = ConfigObj(file, file_error=True)
+        except (ConfigObjError, IOError) as e:
+            log.critical('Config file could not be parsed (%s): %s',
+                         file, e)
+            sys.exit()
+
+        for k, v in cp_user.items():
+            cp[k] = v
 
     if is_default:
         log.workflow('Reading default parameters from the OGGM `params.cfg` '
@@ -411,7 +427,7 @@ def initialize_minimal(file=None, logging_level='INFO', params=None):
     # Static Paths
     oggm_static_paths()
 
-    # Apply code-side manual params overrides
+    # Apply code-side manual params overrides, overrules provided params file
     if params:
         for k, v in params.items():
             cp[k] = v

--- a/oggm/core/centerlines.py
+++ b/oggm/core/centerlines.py
@@ -989,7 +989,10 @@ def compute_centerlines(gdir, heads=None, use_run_settings=False,
     if is_first_call:
         # For diagnostics of filtered centerlines
         gdir.add_to_diagnostics('n_orig_centerlines', len(cls))
-
+        if use_run_settings:
+            utils.add_setting_to_run_settings(gdir, settings={
+                'n_orig_centerlines': len(cls)
+            }, filesuffix=run_settings_filesuffix, overwrite=True)
 
 @entity_task(log, writes=['downstream_line'])
 def compute_downstream_line(gdir):
@@ -1855,9 +1858,17 @@ def initialize_flowlines(gdir, use_run_settings=False,
     # Write the data
     gdir.write_pickle(fls, 'inversion_flowlines')
     gdir.add_to_diagnostics('flowline_type', 'centerlines')
+    if use_run_settings:
+        utils.add_setting_to_run_settings(gdir, settings={
+            'flowline_type': 'centerlines'
+        }, filesuffix=run_settings_filesuffix, overwrite=True)
     if do_filter:
         out = diag_n_bad_slopes/diag_n_pix
         gdir.add_to_diagnostics('perc_invalid_flowline', out)
+        if use_run_settings:
+            utils.add_setting_to_run_settings(gdir, settings={
+                'perc_invalid_flowline': out
+            }, filesuffix=run_settings_filesuffix, overwrite=True)
 
 
 @entity_task(log, writes=['inversion_flowlines'])
@@ -2550,3 +2561,7 @@ def fixed_dx_elevation_band_flowline(gdir, bin_variables=None,
 
     gdir.write_pickle([fl], 'inversion_flowlines')
     gdir.add_to_diagnostics('flowline_type', 'elevation_band')
+    if use_run_settings:
+        utils.add_setting_to_run_settings(gdir, settings={
+            'flowline_type': 'elevation_band'
+        }, filesuffix=run_settings_filesuffix, overwrite=True)

--- a/oggm/core/centerlines.py
+++ b/oggm/core/centerlines.py
@@ -52,7 +52,7 @@ import oggm.cfg as cfg
 from oggm.cfg import GAUSSIAN_KERNEL
 from oggm import utils
 from oggm.utils import (tuple2int, line_interpol, interp_nans, lazy_property,
-                        SuperclassMeta)
+                        SuperclassMeta, get_params_use)
 from oggm import entity_task
 from oggm.exceptions import (InvalidParamsError, InvalidGeometryError,
                              GeometryError, InvalidDEMError)
@@ -897,10 +897,8 @@ def compute_centerlines(gdir, heads=None, use_run_settings=False,
     """
 
     # Params
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
+
     single_fl = not params_use('use_multiple_flowlines')
     do_filter_slope = params_use('filter_min_slope')
     min_slope = 'min_slope_ice_caps' if gdir.is_icecap else 'min_slope'
@@ -1295,10 +1293,8 @@ def compute_downstream_bedshape(gdir, use_run_settings=False,
         potential filesuffix of a run_settings file
     """
 
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    # Params
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     # For tidewater glaciers no need for all this
     if gdir.is_tidewater:
@@ -1590,10 +1586,7 @@ def catchment_area(gdir, use_run_settings=False, run_settings_filesuffix='',):
     """
 
     # Params
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     # Variables
     cls = gdir.read_pickle('centerlines')
@@ -1761,10 +1754,7 @@ def initialize_flowlines(gdir, use_run_settings=False,
     """
 
     # Params
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     # variables
     cls = gdir.read_pickle('centerlines')
@@ -1889,10 +1879,7 @@ def catchment_width_geom(gdir, use_run_settings=False,
     """
 
     # Params
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     # variables
     flowlines = gdir.read_pickle('inversion_flowlines')
@@ -2019,10 +2006,7 @@ def catchment_width_correction(gdir, use_run_settings=False,
     """
 
     # Params
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     # variables
     fls = gdir.read_pickle('inversion_flowlines')
@@ -2226,10 +2210,8 @@ def intersect_downstream_lines(gdir, candidates=None, use_run_settings=False,
         list of tributary rgi_ids
     """
 
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    # Params
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     # make sure tributaries are iterable
     candidates = utils.tolist(candidates)
@@ -2299,10 +2281,7 @@ def elevation_band_flowline(gdir, bin_variables=None, preserve_totals=True,
     """
 
     # Params
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     # Variables
     bin_variables = [] if bin_variables is None else utils.tolist(bin_variables)
@@ -2478,10 +2457,8 @@ def fixed_dx_elevation_band_flowline(gdir, bin_variables=None,
         potential filesuffix of a run_settings file
     """
 
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    # Params
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     df = pd.read_csv(gdir.get_filepath('elevation_band_flowline'), index_col=0)
 

--- a/oggm/core/centerlines.py
+++ b/oggm/core/centerlines.py
@@ -992,6 +992,7 @@ def compute_centerlines(gdir, heads=None, use_run_settings=False,
                 'n_orig_centerlines': len(cls)
             }, filesuffix=run_settings_filesuffix, overwrite=True)
 
+
 @entity_task(log, writes=['downstream_line'])
 def compute_downstream_line(gdir):
     """Computes the Flowline along the unglaciated downstream topography

--- a/oggm/core/climate.py
+++ b/oggm/core/climate.py
@@ -23,6 +23,7 @@ except ImportError:
 # Locals
 from oggm import cfg
 from oggm import utils
+from oggm.utils import get_params_use
 from oggm.core import centerlines
 from oggm import entity_task, global_task
 from oggm.exceptions import (MassBalanceCalibrationError, InvalidParamsError,
@@ -67,10 +68,7 @@ def process_custom_climate_data(gdir, y0=None, y1=None, output_filesuffix=None,
     """
 
     # Params
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     if not (('climate_file' in cfg.PATHS) and
             os.path.exists(cfg.PATHS['climate_file'])):
@@ -183,10 +181,7 @@ def process_climate_data(gdir, y0=None, y1=None, output_filesuffix=None,
     """
 
     # Params
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     # Which climate should we use?
     baseline = params_use('baseline_climate')

--- a/oggm/core/dynamic_spinup.py
+++ b/oggm/core/dynamic_spinup.py
@@ -12,6 +12,7 @@ from scipy import interpolate
 # Locals
 import oggm.cfg as cfg
 from oggm import utils
+from oggm.utils import get_params_use
 from oggm import entity_task
 from oggm.exceptions import InvalidParamsError, InvalidWorkflowError
 from oggm.core.massbalance import (MultipleFlowlineMassBalance,
@@ -211,10 +212,8 @@ def run_dynamic_spinup(gdir, init_model_filesuffix=None, init_model_yr=None,
         evolution_model.
     """
 
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    # Params
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     evolution_model = decide_evolution_model(
         evolution_model, gdir=gdir, use_run_settings=use_run_settings,
@@ -309,7 +308,7 @@ def run_dynamic_spinup(gdir, init_model_filesuffix=None, init_model_yr=None,
             # this is ugly, but needed because a first guess value of the
             # inversion parameters is present in params.cfg, if this would be
             # removed the option with using 'default' would be enough
-            run_settings = gdir.read_yml(run_settings_filename,
+            run_settings = gdir.read_yml('run_settings',
                                          filesuffix=run_settings_filesuffix)
             if 'inversion_fs' in run_settings:
                 fs = params_use('inversion_fs', default=fs)
@@ -956,8 +955,7 @@ def define_new_melt_f_in_gdir(gdir, new_melt_f, use_run_settings=False,
 
     """
     if use_run_settings:
-        run_settings_filename = 'run_settings' if use_run_settings else None
-        run_settings = gdir.read_yml(run_settings_filename,
+        run_settings = gdir.read_yml('run_settings',
                                      filesuffix=run_settings_filesuffix)
 
         if 'melt_f' not in run_settings:
@@ -1173,10 +1171,8 @@ def dynamic_melt_f_run_with_dynamic_spinup(
         # we are done with preparing the local_variables for the upcoming iterations
         return None
 
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    # Params
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     evolution_model = decide_evolution_model(
         evolution_model, gdir=gdir, use_run_settings=use_run_settings,
@@ -1677,10 +1673,8 @@ def dynamic_melt_f_run(
         # No local variables needed in this function
         return None
 
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    # Params
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     evolution_model = decide_evolution_model(
         evolution_model, gdir=gdir, use_run_settings=use_run_settings,
@@ -1961,11 +1955,9 @@ def run_dynamic_melt_f_calibration(
         The final dynamically spined-up model. Type depends on the selected
         evolution_model.
     """
-    # params
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+
+    # Params
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     # melt_f constraints
     if melt_f_min is None:
@@ -2074,7 +2066,7 @@ def run_dynamic_melt_f_calibration(
     # save original melt_f for later to be able to recreate original gdir
     # (using the fallback function) if an error occurs
     if use_run_settings:
-        melt_f_initial = gdir.read_yml(run_settings_filename,
+        melt_f_initial = gdir.read_yml('run_settings',
                                        filesuffix=run_settings_filesuffix
                                        )['melt_f']
     else:
@@ -2504,7 +2496,7 @@ def run_dynamic_melt_f_calibration(
 
     # check that new melt_f is correctly saved in gdir
     if use_run_settings:
-        melt_f_saved = gdir.read_yml(run_settings_filename,
+        melt_f_saved = gdir.read_yml('run_settings',
                                      filesuffix=run_settings_filesuffix
                                      )['melt_f']
     else:

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -1755,7 +1755,8 @@ class FluxBasedModel(FlowlineModel):
                                                     fgt,
                                                     shape=fl.shape_str[0],
                                                     glen_a=self.glen_a,
-                                                    fs=self.fs)
+                                                    fs=self.fs,
+                                                    params_use=self.params_use)
                 self.flux_gate.append(flux)
 
         # convert the floats to function calls

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -3041,7 +3041,8 @@ def calving_glacier_downstream_line(line, n_points):
 
 
 @entity_task(log, writes=['model_flowlines'])
-def init_present_time_glacier(gdir, use_run_settings=False, filesuffix='',
+def init_present_time_glacier(gdir, filesuffix='', use_run_settings=False,
+                              run_settings_filesuffix='',
                               use_binned_thickness_data=False):
     """Merges data from preprocessing tasks. First task after inversion!
 
@@ -3052,13 +3053,14 @@ def init_present_time_glacier(gdir, use_run_settings=False, filesuffix='',
     ----------
     gdir : :py:class:`oggm.GlacierDirectory`
         the glacier directory to process
-    use_run_settings : bool
-        if parameters of a run_settings file should be used
     filesuffix : str
-        potential filesuffix of a run_settings file, will also be appended as a
-        suffix to the model_flowlines filename (e.g. useful for
+        append a suffix to the model_flowlines filename (e.g. useful for
         dynamic melt_f calibration including an inversion, so the original
         model_flowlines are not changed).
+    use_run_settings : bool
+        if parameters of a run_settings file should be used
+    run_settings_filesuffix : str
+        potential filesuffix of a run_settings file
     use_binned_thickness_data : bool or str
         if you want to use thickness data, which was binned to the elevation
         band flowlines with tasks.elevation_band_flowine and
@@ -3068,7 +3070,8 @@ def init_present_time_glacier(gdir, use_run_settings=False, filesuffix='',
 
     run_settings_filename = 'run_settings' if use_run_settings else None
     params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename, filesuffix=filesuffix)
+        gdir=gdir, filename=run_settings_filename,
+        filesuffix=run_settings_filesuffix)
 
     # Some vars
     invs = gdir.read_pickle('inversion_output')

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -29,6 +29,7 @@ import pandas as pd
 from oggm import __version__
 import oggm.cfg as cfg
 from oggm import utils
+from oggm.utils import get_params_use
 from oggm import entity_task
 from oggm.exceptions import InvalidParamsError, InvalidWorkflowError
 from oggm.core.massbalance import (MultipleFlowlineMassBalance,
@@ -87,10 +88,9 @@ class Flowline(Centerline):
 
         super(Flowline, self).__init__(line, dx, surface_h)
 
-        run_settings_filename = 'run_settings' if use_run_settings else None
-        self.params_use = utils.get_params_wrapper(
-            gdir=gdir, filename=run_settings_filename,
-            filesuffix=run_settings_filesuffix)
+        # Params
+        self.params_use = get_params_use(gdir, use_run_settings,
+                                         run_settings_filesuffix)
 
         self._thick = utils.clip_min(surface_h - bed_h, 0.)
         self.map_dx = map_dx
@@ -654,10 +654,9 @@ class FlowlineModel(object):
             potential filesuffix of a run_settings file
         """
 
-        run_settings_filename = 'run_settings' if use_run_settings else None
-        self.params_use = utils.get_params_wrapper(
-            gdir=gdir, filename=run_settings_filename,
-            filesuffix=run_settings_filesuffix)
+        # Params
+        self.params_use = get_params_use(gdir, use_run_settings,
+                                         run_settings_filesuffix)
 
         self.is_tidewater = is_tidewater
         self.is_lake_terminating = is_lake_terminating
@@ -3068,10 +3067,8 @@ def init_present_time_glacier(gdir, filesuffix='', use_run_settings=False,
         data here to create a flowline for a dynamic model run
     """
 
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    # Params
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     # Some vars
     invs = gdir.read_pickle('inversion_output')
@@ -3216,10 +3213,8 @@ def decide_evolution_model(evolution_model=None, gdir=None,
     if evolution_model is not None:
         return evolution_model
 
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    # Params
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     from_cfg = params_use('evolution_model').lower()
     if from_cfg == 'SemiImplicit'.lower():
@@ -3317,10 +3312,8 @@ def flowline_model_run(gdir, output_filesuffix=None, mb_model=None,
         potential filesuffix of a run_settings file
      """
 
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    # Params
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     if init_model_filesuffix is not None:
         fp = gdir.get_filepath('model_geometry',
@@ -3354,7 +3347,7 @@ def flowline_model_run(gdir, output_filesuffix=None, mb_model=None,
             # this is ugly, but needed because a first guess value of the
             # inversion parameters is present in params.cfg, if this would be
             # removed the option with using 'default' would be enough
-            run_settings = gdir.read_yml(run_settings_filename,
+            run_settings = gdir.read_yml('run_settings',
                                          filesuffix=run_settings_filesuffix)
             if 'inversion_fs' in run_settings:
                 fs = params_use('inversion_fs', default=fs)
@@ -3925,10 +3918,8 @@ def run_with_hydro(gdir, run_task=None, store_monthly_hydro=False,
     **kwargs : all valid kwargs for ``run_task``
     """
 
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    # Params
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     # Make sure it'll return something
     kwargs['return_value'] = True
@@ -4568,10 +4559,8 @@ def clean_merged_flowlines(gdir, buffer=None, use_run_settings=False,
         potential filesuffix of a run_settings file
     """
 
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    # Params
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     # No buffer does not work
     if buffer is None:

--- a/oggm/core/gis.py
+++ b/oggm/core/gis.py
@@ -54,7 +54,8 @@ from oggm.exceptions import (InvalidParamsError, InvalidGeometryError,
                              InvalidDEMError, GeometryError,
                              InvalidWorkflowError)
 from oggm.utils import (tuple2int, get_topo_file, is_dem_source_available,
-                        nicenumber, ncDataset, tolist)
+                        nicenumber, ncDataset, tolist, get_params_use,
+                        check_for_none_params_use)
 
 
 # Module logger
@@ -225,10 +226,7 @@ def _polygon_to_pix(polygon):
 
 def glacier_grid_params(gdir, params_use=None):
     """Define the glacier grid map based on the user params."""
-    if params_use is None:
-        def cfg_params(param):
-            return cfg.PARAMS[param]
-        params_use = cfg_params
+    params_use = check_for_none_params_use(params_use)
 
     # Get the local map proj params and glacier extent
     gdf = gdir.read_shapefile('outlines')
@@ -329,6 +327,8 @@ def check_dem_source(source, extent_ll, rgi_id=None, params_use=None):
     -------
     String of the working DEM source.
     """
+
+    params_use = check_for_none_params_use(params_use)
 
     # when multiple sources are provided, try them sequentially
     if isinstance(source, list):
@@ -472,10 +472,7 @@ def get_dem_for_grid(grid, fpath, source=None, gdir=None,
     """
 
     # Params
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     minlon, maxlon, minlat, maxlat = grid.extent_in_crs(crs=salem.wgs84)
     extent_ll = [[minlon, maxlon], [minlat, maxlat]]
@@ -564,10 +561,8 @@ def define_glacier_region(gdir, entity=None, source=None,
         potential filesuffix of a run_settings file
     """
 
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    # Params
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     utm_proj, nx, ny, ulx, uly, dx = glacier_grid_params(gdir, params_use)
 
@@ -800,10 +795,8 @@ def process_dem(gdir=None, grid=None, fpath=None, output_filename=None,
         potential filesuffix of a run_settings file
     """
 
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    # Params
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     if gdir is not None:
         # open srtm tif-file:
@@ -1093,10 +1086,8 @@ def simple_glacier_masks(gdir, use_run_settings=False,
         potential filesuffix of a run_settings file
     """
 
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    # Params
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     # In case nominal, just raise
     if gdir.is_nominal:
@@ -1470,10 +1461,7 @@ def gridded_attributes(gdir, use_run_settings=False,
     """
 
     # Params
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     # Variables
     grids_file = gdir.get_filepath('gridded_data')
@@ -1621,10 +1609,8 @@ def gridded_mb_attributes(gdir, use_run_settings=False,
     from oggm.core.massbalance import LinearMassBalance, ConstantMassBalance
     from oggm.core.centerlines import line_inflows
 
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    # Params
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     # Get the input data
     with ncDataset(gdir.get_filepath('gridded_data')) as nc:
@@ -2053,10 +2039,8 @@ def reproject_gridded_data_variable_to_grid(gdir,
         target_grid.
     """
 
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    # Params
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     with xr.open_dataset(gdir.get_filepath(filename,
                                            filesuffix=filesuffix)) as ds:

--- a/oggm/core/gis.py
+++ b/oggm/core/gis.py
@@ -443,7 +443,8 @@ def reproject_dem(dem_list, dem_source, dst_grid_prop, output_path, params_use):
         dem_ds.close()
 
 
-def get_dem_for_grid(grid, fpath, source=None, gdir=None, params_use=None):
+def get_dem_for_grid(grid, fpath, source=None, gdir=None,
+                     use_run_settings=False, run_settings_filesuffix='',):
     """
     Fetch a DEM from source, reproject it to the extent defined by grid and
     saves it to disk.
@@ -460,11 +461,22 @@ def get_dem_for_grid(grid, fpath, source=None, gdir=None, params_use=None):
         check docstring of oggm.core.gis.define_glacier_region.
     gdir: py:class:`oggm.GlacierDirectory`
         If source is None, gdir is used to decide on the source
+    use_run_settings : bool
+        if parameters of a run_settings file should be used
+    run_settings_filesuffix : str
+        potential filesuffix of a run_settings file
 
     Returns
     -------
     tuple: (list with path(s) to the DEM file(s), data source str)
     """
+
+    # Params
+    run_settings_filename = 'run_settings' if use_run_settings else None
+    params_use = utils.get_params_wrapper(
+        gdir=gdir, filename=run_settings_filename,
+        filesuffix=run_settings_filesuffix)
+
     minlon, maxlon, minlat, maxlat = grid.extent_in_crs(crs=salem.wgs84)
     extent_ll = [[minlon, maxlon], [minlat, maxlat]]
     if gdir is not None:
@@ -566,7 +578,9 @@ def define_glacier_region(gdir, entity=None, source=None,
     dem_list, dem_source = get_dem_for_grid(grid=tmp_grid,
                                             fpath=gdir.get_filepath('dem'),
                                             source=source, gdir=gdir,
-                                            params_use=params_use)
+                                            use_run_settings=use_run_settings,
+                                            run_settings_filesuffix=run_settings_filesuffix,
+                                            )
 
     # Glacier grid
     x0y0 = (ulx+dx/2, uly-dx/2)  # To pixel center coordinates

--- a/oggm/core/gis.py
+++ b/oggm/core/gis.py
@@ -590,6 +590,10 @@ def define_glacier_region(gdir, entity=None, source=None,
 
     # Write DEM source info
     gdir.add_to_diagnostics('dem_source', dem_source)
+    if use_run_settings:
+        utils.add_setting_to_run_settings(gdir, settings={
+            'dem_source': dem_source
+        }, filesuffix=run_settings_filesuffix, overwrite=True)
     source_txt = DEM_SOURCE_INFO.get(dem_source, dem_source)
     with open(gdir.get_filepath('dem_source'), 'w') as fw:
         fw.write(source_txt)
@@ -845,6 +849,11 @@ def process_dem(gdir=None, grid=None, fpath=None, output_filename=None,
             gdir.add_to_diagnostics('dem_needed_interpolation', True)
             gdir.add_to_diagnostics('dem_invalid_perc',
                                     len(pnan[0]) / (nx * ny))
+            if use_run_settings:
+                utils.add_setting_to_run_settings(gdir, settings={
+                    'dem_needed_interpolation': True,
+                    'dem_invalid_perc': len(pnan[0]) / (nx * ny),
+                }, filesuffix=run_settings_filesuffix, overwrite=True)
         else:
             diagnostics_dict['dem_needed_interpolation'] = True
             diagnostics_dict['dem_invalid_perc'] = len(pnan[0]) / (nx * ny)
@@ -867,6 +876,11 @@ def process_dem(gdir=None, grid=None, fpath=None, output_filename=None,
             gdir.add_to_diagnostics('dem_needed_extrapolation', True)
             gdir.add_to_diagnostics('dem_extrapol_perc',
                                     len(pnan[0]) / (nx * ny))
+            if use_run_settings:
+                utils.add_setting_to_run_settings(gdir, settings={
+                    'dem_needed_extrapolation': True,
+                    'dem_extrapol_perc': len(pnan[0]) / (nx * ny),
+                }, filesuffix=run_settings_filesuffix, overwrite=True)
         else:
             diagnostics_dict['dem_needed_extrapolation'] = True
             diagnostics_dict['dem_extrapol_perc'] = len(pnan[0]) / (nx * ny)
@@ -1050,6 +1064,11 @@ def glacier_masks(gdir, use_run_settings=False, run_settings_filesuffix='',):
             pnan = (valid_mask == 0) & glacier_mask
             gdir.add_to_diagnostics('dem_invalid_perc_in_mask',
                                     np.sum(pnan) / np.sum(glacier_mask))
+            if use_run_settings:
+                utils.add_setting_to_run_settings(gdir, settings={
+                    'dem_invalid_perc_in_mask':
+                        np.sum(pnan) / np.sum(glacier_mask),
+                }, filesuffix=run_settings_filesuffix, overwrite=True)
 
         # add some meta stats and close
         dem_on_g = dem[np.where(glacier_mask)]
@@ -1185,6 +1204,11 @@ def simple_glacier_masks(gdir, use_run_settings=False,
             pnan = (valid_mask == 0) & glacier_mask
             gdir.add_to_diagnostics('dem_invalid_perc_in_mask',
                                     np.sum(pnan) / np.sum(glacier_mask))
+            if use_run_settings:
+                utils.add_setting_to_run_settings(gdir, settings={
+                    'dem_invalid_perc_in_mask':
+                        np.sum(pnan) / np.sum(glacier_mask),
+                }, filesuffix=run_settings_filesuffix, overwrite=True)
 
         # add some meta stats and close
         nc.max_h_dem = np.nanmax(dem)

--- a/oggm/core/inversion.py
+++ b/oggm/core/inversion.py
@@ -42,6 +42,7 @@ from oggm import utils, cfg
 from oggm import entity_task
 from oggm.core.gis import gaussian_blur
 from oggm.exceptions import InvalidParamsError, InvalidWorkflowError
+from oggm.utils import get_params_use, check_for_none_params_use
 
 # Module logger
 log = logging.getLogger(__name__)
@@ -74,11 +75,8 @@ def prepare_for_inversion(gdir,
         potential filesuffix of a run_settings file
     """
 
-    # params
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    # Params
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     # variables
     fls = gdir.read_pickle('inversion_flowlines')
@@ -227,11 +225,7 @@ def sia_thickness_via_optim(slope, width, flux, shape='rectangular',
     the ice thickness (in m)
     """
 
-    if params_use is None:
-        def cfg_params(param):
-            return cfg.PARAMS[param]
-
-        params_use = cfg_params
+    params_use = check_for_none_params_use(params_use)
 
     if len(np.atleast_1d(slope)) > 1:
         shape = utils.tolist(shape, len(slope))
@@ -306,10 +300,7 @@ def sia_thickness(slope, width, flux, shape='rectangular',
     the ice thickness (in m)
     """
 
-    if params_use is None:
-        def cfg_params(param):
-            return cfg.PARAMS[param]
-        params_use = cfg_params
+    params_use = check_for_none_params_use(params_use)
 
     if glen_a is None:
         glen_a = params_use('inversion_glen_a')
@@ -350,10 +341,7 @@ def find_sia_flux_from_thickness(slope, width, thick, glen_a=None, fs=None,
     This can be done analytically but I'm lazy and use optimisation instead.
     """
 
-    if params_use is None:
-        def cfg_params(param):
-            return cfg.PARAMS[param]
-        params_use = cfg_params
+    params_use = check_for_none_params_use(params_use)
 
     def to_minimize(x):
         h = sia_thickness(slope, width, x[0], glen_a=glen_a, fs=fs,
@@ -423,11 +411,8 @@ def mass_conservation_inversion(gdir, glen_a=None, fs=None, write=True,
         potential filesuffix of a run_settings file
     """
 
-    # params
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    # Params
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     # Defaults
     if glen_a is None:
@@ -586,10 +571,8 @@ def filter_inversion_output(gdir, n_smoothing=5, min_ice_thick=1.,
         potential filesuffix of a run_settings file
     """
 
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    # Params
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     if gdir.is_tidewater:
         # No need for filter in tidewater case
@@ -740,10 +723,8 @@ def compute_inversion_velocities(gdir, glen_a=None, fs=None, filesuffix='',
         potential filesuffix of a run_settings file
     """
 
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    # Params
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     # Defaults
     if glen_a is None:
@@ -845,10 +826,7 @@ def distribute_thickness_per_altitude(gdir, add_slope=True,
     """
 
     # Params
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     # Variables
     grids_file = gdir.get_filepath('gridded_data')
@@ -979,10 +957,7 @@ def distribute_thickness_interp(gdir, add_slope=True, smooth_radius=None,
     """
 
     # Params
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     # Variables
     grids_file = gdir.get_filepath('gridded_data')
@@ -1108,10 +1083,7 @@ def calving_flux_from_depth(gdir, k=None, water_level=None, water_depth=None,
     """
 
     # Params
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     # Defaults
     if k is None:
@@ -1187,10 +1159,8 @@ def find_inversion_calving_from_any_mb(gdir, mb_model=None, mb_years=None,
     """
     from oggm.core import massbalance
 
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    # Params
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     if not gdir.is_tidewater or not params_use('use_kcalving_for_inversion'):
         # Do nothing

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -17,7 +17,7 @@ from oggm.utils import (SuperclassMeta, get_geodetic_mb_dataframe,
                         floatyear_to_date, date_to_floatyear, get_demo_file,
                         monthly_timeseries, ncDataset, get_temp_bias_dataframe,
                         clip_min, clip_max, clip_array, clip_scalar,
-                        weighted_average_1d, lazy_property, get_params_wrapper,
+                        weighted_average_1d, lazy_property,
                         add_setting_to_run_settings, get_params_use, )
 from oggm.exceptions import (InvalidWorkflowError, InvalidParamsError,
                              MassBalanceCalibrationError)
@@ -439,8 +439,8 @@ class MonthlyTIModel(MassBalanceModel):
                 if v != self.params_use(k):
                     msg = ('You seem to use different mass balance parameters '
                            'than used for the calibration: '
-                           f"you use cfg.PARAMS['{k}']={self.params_use(k)} while "
-                           f"it was calibrated with cfg.PARAMS['{k}']={v}. "
+                           f"you use PARAMS['{k}']={self.params_use(k)} while "
+                           f"it was calibrated with PARAMS['{k}']={v}. "
                            'Set `check_calib_params=False` to ignore this '
                            'warning.')
                     raise InvalidWorkflowError(msg)

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -18,7 +18,7 @@ from oggm.utils import (SuperclassMeta, get_geodetic_mb_dataframe,
                         monthly_timeseries, ncDataset, get_temp_bias_dataframe,
                         clip_min, clip_max, clip_array, clip_scalar,
                         weighted_average_1d, lazy_property, get_params_wrapper,
-                        add_setting_to_run_settings,)
+                        add_setting_to_run_settings, get_params_use, )
 from oggm.exceptions import (InvalidWorkflowError, InvalidParamsError,
                              MassBalanceCalibrationError)
 from oggm import entity_task
@@ -55,10 +55,11 @@ class MassBalanceModel(object, metaclass=SuperclassMeta):
         self.valid_bounds = None
         self.hemisphere = None
         self.gdir = gdir
-        run_settings_filename = 'run_settings' if use_run_settings else None
-        self.params_use = get_params_wrapper(gdir=gdir,
-                                             filename=run_settings_filename,
-                                             filesuffix=run_settings_filesuffix)
+
+        # Params
+        self.params_use = get_params_use(gdir, use_run_settings,
+                                         run_settings_filesuffix)
+
         self.rho = self.params_use('ice_density')
 
     def __repr__(self):
@@ -1390,10 +1391,7 @@ def calving_mb(gdir, use_run_settings=False, run_settings_filesuffix='',):
     """
 
     # Params
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     if not gdir.is_tidewater:
         return 0.
@@ -1410,10 +1408,7 @@ def decide_winter_precip_factor(gdir,
     """Utility function to decide on a precip factor based on winter precip."""
 
     # Params
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     # We have to decide on a precip factor
     if 'W5E5' not in params_use('baseline_climate'):
@@ -1579,10 +1574,8 @@ def mb_calibration_from_geodetic_mb(gdir, *,
     the calibrated parameters as dict
     """
 
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = get_params_wrapper(gdir=gdir,
-                                    filename=run_settings_filename,
-                                    filesuffix=filesuffix)
+    # Params
+    params_use = get_params_use(gdir, use_run_settings, filesuffix)
 
     if not ref_period:
         ref_period = params_use('geodetic_mb_period')
@@ -1834,10 +1827,8 @@ def mb_calibration_from_scalar_mb(gdir, *,
                                  'mb_calib.json OR run_settings.yml. Either set '
                                  'use_mb_calib or use_run_settings to False.')
 
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = get_params_wrapper(gdir=gdir,
-                                    filename=run_settings_filename,
-                                    filesuffix=filesuffix)
+    # Params
+    params_use = get_params_use(gdir, use_run_settings, filesuffix)
 
     # Param constraints
     if melt_f_min is None:
@@ -2143,12 +2134,8 @@ def perturbate_mb_params(gdir, perturbation=None, reset_default=False, filesuffi
 
 def _check_terminus_mass_flux(gdir, fls, use_run_settings=False,
                               run_settings_filesuffix='',):
-
     # Params
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     # Check that we have done this correctly
     rho = params_use('ice_density')
@@ -2191,10 +2178,8 @@ def apparent_mb_from_linear_mb(gdir, mb_gradient=3., ela_h=None,
         potential filesuffix of a run_settings file
     """
 
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = get_params_wrapper(gdir=gdir,
-                                    filename=run_settings_filename,
-                                    filesuffix=run_settings_filesuffix)
+    # Params
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     # Do we have a calving glacier?
     cmb = calving_mb(gdir, use_run_settings=use_run_settings,
@@ -2278,10 +2263,8 @@ def apparent_mb_from_any_mb(gdir, mb_model=None,
         period by providing the name of the observation here
     """
 
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = get_params_wrapper(gdir=gdir,
-                                    filename=run_settings_filename,
-                                    filesuffix=run_settings_filesuffix)
+    # Params
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     # Do we have a calving glacier?
     cmb = calving_mb(gdir, use_run_settings=use_run_settings,

--- a/oggm/core/sia2d.py
+++ b/oggm/core/sia2d.py
@@ -21,7 +21,9 @@ class Model2D(object):
 
     def __init__(self, bed_topo, init_ice_thick=None, dx=None, dy=None,
                  mb_model=None, y0=0., glen_a=None, mb_elev_feedback='annual',
-                 ice_thick_filter=filter_ice_border, mb_filter=None):
+                 ice_thick_filter=filter_ice_border, mb_filter=None,
+                 gdir=None, use_run_settings=False, run_settings_filesuffix='',
+                 ):
         """Create a new 2D model from gridded data.
 
         Parameters
@@ -49,7 +51,17 @@ class Model2D(object):
         mb_filter : ndarray
             2d array indicating the mask where positive mb is allowed
             (useful to allow only specific glaciers to grow)
+        use_run_settings : bool
+            if parameters of a run_settings file should be used
+        run_settings_filesuffix : str
+            potential filesuffix of a run_settings file
         """
+
+        # Params
+        run_settings_filename = 'run_settings' if use_run_settings else None
+        self.params_use = utils.get_params_wrapper(
+            gdir=gdir, filename=run_settings_filename,
+            filesuffix=run_settings_filesuffix)
 
         # Mass balance
         self.mb_elev_feedback = mb_elev_feedback
@@ -58,7 +70,7 @@ class Model2D(object):
 
         # Defaults
         if glen_a is None:
-            glen_a = cfg.PARAMS['glen_a']
+            glen_a = self.params_use('glen_a')
         self.glen_a = glen_a
 
         if dy is None:
@@ -294,8 +306,8 @@ class Upstream2D(Model2D):
                                          mb_filter=mb_filter)
 
         # We introduce Gamma to shorten the equations
-        self.rho = cfg.PARAMS['ice_density']
-        self.glen_n = cfg.PARAMS['glen_n']
+        self.rho = self.params_use('ice_density')
+        self.glen_n = self.params_use('glen_n')
         self.gamma = (2. * self.glen_a * (self.rho * G) ** self.glen_n
                       / (self.glen_n + 2))
 

--- a/oggm/core/sia2d.py
+++ b/oggm/core/sia2d.py
@@ -5,6 +5,7 @@ import os
 
 from oggm import cfg, utils
 from oggm.cfg import G, SEC_IN_YEAR, SEC_IN_DAY
+from oggm.utils import get_params_use
 
 
 def filter_ice_border(ice_thick):
@@ -58,10 +59,8 @@ class Model2D(object):
         """
 
         # Params
-        run_settings_filename = 'run_settings' if use_run_settings else None
-        self.params_use = utils.get_params_wrapper(
-            gdir=gdir, filename=run_settings_filename,
-            filesuffix=run_settings_filesuffix)
+        self.params_use = get_params_use(gdir, use_run_settings,
+                                         run_settings_filesuffix)
 
         # Mass balance
         self.mb_elev_feedback = mb_elev_feedback

--- a/oggm/sandbox/calving_fabi.py
+++ b/oggm/sandbox/calving_fabi.py
@@ -182,7 +182,8 @@ class CalvingFluxBasedModelFabi(FlowlineModel):
                                                     fgt,
                                                     shape=fl.shape_str[0],
                                                     glen_a=self.glen_a,
-                                                    fs=self.fs)
+                                                    fs=self.fs,
+                                                    params_use=self.params_use)
                 self.flux_gate.append(flux)
 
         # convert the floats to function calls

--- a/oggm/sandbox/calving_jan.py
+++ b/oggm/sandbox/calving_jan.py
@@ -189,7 +189,8 @@ class CalvingFluxBasedModelJan(FlowlineModel):
                                                     fgt,
                                                     shape=fl.shape_str[0],
                                                     glen_a=self.glen_a,
-                                                    fs=self.fs)
+                                                    fs=self.fs,
+                                                    params_use=self.params_use)
                 self.flux_gate.append(flux)
 
         # convert the floats to function calls

--- a/oggm/shop/cru.py
+++ b/oggm/shop/cru.py
@@ -73,7 +73,8 @@ def get_cru_file(var=None):
 
 @entity_task(log, writes=['climate_historical'])
 def process_cru_data(gdir, tmp_file=None, pre_file=None, y0=None, y1=None,
-                     output_filesuffix=None):
+                     output_filesuffix=None, use_run_settings=False,
+                     run_settings_filesuffix='',):
     """Processes and writes the CRU baseline climate data for this glacier.
 
     Interpolates the CRU TS data to the high-resolution CL2 climatologies
@@ -100,10 +101,20 @@ def process_cru_data(gdir, tmp_file=None, pre_file=None, y0=None, y1=None,
     output_filesuffix : str
         this add a suffix to the output file (useful to avoid overwriting
         previous experiments)
+    use_run_settings : bool
+        if parameters of a run_settings file should be used
+    run_settings_filesuffix : str
+        potential filesuffix of a run_settings file
     """
 
-    if cfg.PARAMS['baseline_climate'] != 'CRU':
-        raise InvalidParamsError("cfg.PARAMS['baseline_climate'] should be "
+    # Params
+    run_settings_filename = 'run_settings' if use_run_settings else None
+    params_use = utils.get_params_wrapper(
+        gdir=gdir, filename=run_settings_filename,
+        filesuffix=run_settings_filesuffix)
+
+    if params_use('baseline_climate') != 'CRU':
+        raise InvalidParamsError("PARAMS['baseline_climate'] should be "
                                  "set to CRU")
 
     # read the climatology

--- a/oggm/shop/cru.py
+++ b/oggm/shop/cru.py
@@ -108,10 +108,7 @@ def process_cru_data(gdir, tmp_file=None, pre_file=None, y0=None, y1=None,
     """
 
     # Params
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     if params_use('baseline_climate') != 'CRU':
         raise InvalidParamsError("PARAMS['baseline_climate'] should be "

--- a/oggm/shop/cru.py
+++ b/oggm/shop/cru.py
@@ -16,6 +16,7 @@ except ImportError:
 # Locals
 from oggm import cfg
 from oggm import utils
+from oggm.utils import get_params_use
 from oggm import entity_task
 from oggm.exceptions import MassBalanceCalibrationError, InvalidParamsError
 

--- a/oggm/shop/ecmwf.py
+++ b/oggm/shop/ecmwf.py
@@ -14,6 +14,7 @@ except ImportError:
 # Locals
 from oggm import cfg
 from oggm import utils
+from oggm.utils import get_params_use
 from oggm import entity_task
 from oggm.exceptions import InvalidParamsError
 

--- a/oggm/shop/ecmwf.py
+++ b/oggm/shop/ecmwf.py
@@ -138,10 +138,7 @@ def process_ecmwf_data(gdir, dataset=None, ensemble_member=0,
     """
 
     # Params
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     if dataset is None:
         dataset = params_use('baseline_climate')

--- a/oggm/shop/ecmwf.py
+++ b/oggm/shop/ecmwf.py
@@ -105,7 +105,9 @@ def _check_ds_validity(ds):
 
 @entity_task(log, writes=['climate_historical'])
 def process_ecmwf_data(gdir, dataset=None, ensemble_member=0,
-                       y0=None, y1=None, output_filesuffix=None):
+                       y0=None, y1=None, output_filesuffix=None,
+                       use_run_settings=False, run_settings_filesuffix='',
+                       ):
     """Processes and writes the ECMWF baseline climate data for this glacier.
 
     Extracts the nearest timeseries and writes everything to a NetCDF file.
@@ -114,7 +116,7 @@ def process_ecmwf_data(gdir, dataset=None, ensemble_member=0,
     ----------
     dataset : str
         'ERA5', 'ERA5L', 'CERA', 'ERA5L-HMA', 'ERA5dr'.
-        Defaults to cfg.PARAMS['baseline_climate']
+        Defaults to PARAMS['baseline_climate']
     ensemble_member : int
         for CERA, pick an ensemble member number (0-9). We might make this
         more of a clever pick later.
@@ -129,10 +131,20 @@ def process_ecmwf_data(gdir, dataset=None, ensemble_member=0,
     output_filesuffix : str
         this add a suffix to the output file (useful to avoid overwriting
         previous experiments)
+    use_run_settings : bool
+        if parameters of a run_settings file should be used
+    run_settings_filesuffix : str
+        potential filesuffix of a run_settings file
     """
 
+    # Params
+    run_settings_filename = 'run_settings' if use_run_settings else None
+    params_use = utils.get_params_wrapper(
+        gdir=gdir, filename=run_settings_filename,
+        filesuffix=run_settings_filesuffix)
+
     if dataset is None:
-        dataset = cfg.PARAMS['baseline_climate']
+        dataset = params_use('baseline_climate')
 
     # Use xarray to read the data
     lon = gdir.cenlon + 360 if gdir.cenlon < 0 else gdir.cenlon

--- a/oggm/shop/histalp.py
+++ b/oggm/shop/histalp.py
@@ -64,7 +64,9 @@ def get_histalp_file(var=None):
 
 
 @entity_task(log, writes=['climate_historical'])
-def process_histalp_data(gdir, y0=None, y1=None, output_filesuffix=None):
+def process_histalp_data(gdir, y0=None, y1=None, output_filesuffix=None,
+                         use_run_settings=False, run_settings_filesuffix='',
+                         ):
     """Processes and writes the HISTALP baseline climate data for this glacier.
 
     Extracts the nearest timeseries and writes everything to a NetCDF file.
@@ -83,10 +85,20 @@ def process_histalp_data(gdir, y0=None, y1=None, output_filesuffix=None):
     output_filesuffix : str
         this adds a suffix to the output file (useful to avoid overwriting
         previous experiments)
+    use_run_settings : bool
+        if parameters of a run_settings file should be used
+    run_settings_filesuffix : str
+        potential filesuffix of a run_settings file
     """
 
-    if cfg.PARAMS['baseline_climate'] != 'HISTALP':
-        raise InvalidParamsError("cfg.PARAMS['baseline_climate'] should be "
+    # Params
+    run_settings_filename = 'run_settings' if use_run_settings else None
+    params_use = utils.get_params_wrapper(
+        gdir=gdir, filename=run_settings_filename,
+        filesuffix=run_settings_filesuffix)
+
+    if params_use('baseline_climate') != 'HISTALP':
+        raise InvalidParamsError("PARAMS['baseline_climate'] should be "
                                  "set to HISTALP.")
 
     # read the time out of the pure netcdf file

--- a/oggm/shop/histalp.py
+++ b/oggm/shop/histalp.py
@@ -92,10 +92,7 @@ def process_histalp_data(gdir, y0=None, y1=None, output_filesuffix=None,
     """
 
     # Params
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     if params_use('baseline_climate') != 'HISTALP':
         raise InvalidParamsError("PARAMS['baseline_climate'] should be "

--- a/oggm/shop/histalp.py
+++ b/oggm/shop/histalp.py
@@ -15,6 +15,7 @@ except ImportError:
 # Locals
 from oggm import cfg
 from oggm import utils
+from oggm.utils import get_params_use
 from oggm import entity_task
 from oggm.exceptions import InvalidParamsError
 

--- a/oggm/tests/mini_params_for_test.cfg
+++ b/oggm/tests/mini_params_for_test.cfg
@@ -1,0 +1,2 @@
+# Default number of files to be cached in the temporary directory
+lru_maxsize = 123

--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -797,10 +797,13 @@ class TestRunSettings:
 
         # test gis_prepro_tasks (tests all centerline tasks)
         inv_fl_before = gdir.read_pickle('inversion_flowlines')
+        assert gdir.get_diagnostics()['flowline_type'] == 'elevation_band'
         workflow.gis_prepro_tasks(gdirs, use_run_settings=True)
         inv_fl_after = gdir.read_pickle('inversion_flowlines')
         # before the inversion flowlines where an elevation band fl, afterwards
         # it is a centerline flowline
+        assert gdir.get_diagnostics()['flowline_type'] == 'centerlines'
+        assert gdir.read_yml('run_settings')['flowline_type'] == 'centerlines'
         assert np.all(inv_fl_before[0].is_trapezoid)
         assert inv_fl_after[0].is_trapezoid is None
 

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -2081,10 +2081,8 @@ def climate_statistics(gdir, add_climate_period=1995, halfsize=15,
     from oggm.core.massbalance import (ConstantMassBalance,
                                        MultipleFlowlineMassBalance)
 
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = get_params_wrapper(
-        gdir=gdir, filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    # Params
+    params_use = get_params_use(gdir, use_run_settings, run_settings_filesuffix)
 
     d = OrderedDict()
 
@@ -4233,6 +4231,22 @@ def get_params(setting, gdir=None, filename=None, filesuffix='', default=None):
 def get_params_wrapper(gdir=None, filename=None, filesuffix=''):
     return partial(get_params, gdir=gdir, filename=filename,
                    filesuffix=filesuffix)
+
+
+def get_params_use(gdir, use_run_settings, run_settings_filesuffix):
+    run_settings_filename = 'run_settings' if use_run_settings else None
+    return get_params_wrapper(gdir=gdir,
+                              filename=run_settings_filename,
+                              filesuffix=run_settings_filesuffix)
+
+
+def check_for_none_params_use(params_use):
+    if params_use is None:
+        def cfg_params(param):
+            return cfg.PARAMS[param]
+
+        params_use = cfg_params
+    return params_use
 
 
 @entity_task(log)

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -16,7 +16,7 @@ import oggm
 from oggm import cfg, tasks, utils
 from oggm.core import centerlines, flowline, climate, gis
 from oggm.exceptions import InvalidParamsError, InvalidWorkflowError
-from oggm.utils import global_task
+from oggm.utils import global_task, get_params_use
 
 # MPI
 try:
@@ -580,10 +580,8 @@ def inversion_tasks(gdirs, glen_a=None, fs=None, filter_inversion_output=True,
     """
 
     # Use params of first gdir, it is assumed all use the same settings
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdirs[0], filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    params_use = get_params_use(gdirs[0], use_run_settings,
+                                run_settings_filesuffix)
 
     if params_use('use_kcalving_for_inversion'):
         # Differentiate between calving and non-calving glaciers
@@ -699,10 +697,8 @@ def calibrate_inversion_from_consensus(gdirs, ignore_missing=True,
     gdirs = utils.tolist(gdirs)
 
     # take a potential run_settings file from the first gdir
-    run_settings_filename = 'run_settings' if use_run_settings else None
-    params_use = utils.get_params_wrapper(
-        gdir=gdirs[0], filename=run_settings_filename,
-        filesuffix=run_settings_filesuffix)
+    params_use = get_params_use(gdirs[0], use_run_settings,
+                                run_settings_filesuffix)
 
     if run_settings_volume:
         if volume_m3_reference:


### PR DESCRIPTION
This PR introduces two new ways to define and provide parameters for the model (in addition to the current default of using `cfg.PARAMS`):

1. Minimal `params.cfg` File: You can now pass a minimal `params.cfg` file to `cfg.initialize`. If some parameters are missing in this file, the defaults from the main `params.cfg` (available [here](https://github.com/OGGM/oggm/blob/master/oggm/params.cfg)) will be used automatically.
2. New `run_settings.yml` File, which could contain:
  -  Almost all parameters from `params.cfg`
  -  Values of observations used during calibration or initialization
  -  If any parameter is not included in `run_settings.yml`, it falls back to the current defaults.

These additions required significant changes in sensitive parts of the model, particularly for the second point. However, tests appear to be passing. I have also included some tests for `run_settings.yml`. Not every aspect is tested yet, as adding more tests would overly expand the test suite.

Points for Discussion
- Each function currently opens the `run_settings.yml` file independently, instead of opening it once at the start of a workflow and passing it around. While this approach may slightly reduce performance (dynamic runs are not effected by this), it maintains the flexibility needed for setting up custom workflows.
- The new `run_settings.yml` works similarly to the existing `mb_calib` logic but supports calibration for only a single flowline. For now, I’ve kept `mb_calib` for backward compatibility and enforce a selection between the two possibilities to avoid potential confusions. However, we could consider removing `mb_calib` in the future.
- When using `run_settings.yml`, all diagnostics are saved both to `gdir.add_diagnostics` and the `run_settings.yml` file. Maybe one or the other is enough?

- [ ] Tests added/passed
- [ ] Fully documented
- [ ] Entry in `whats-new.rst` 
