### PR TITLE
Add capability to reset the "state" of the mass balance model

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -21,15 +21,13 @@ Enhancements
   ``dis_from_border``, ...) to define this ranking, providing greater flexibility
   and control over how the melting sequence is visualized (:pull:`1746`).
   By `Patrick Schmitt <https://github.com/pat-schmitt>`_
-- Added "reset_state" functionality to ``MassBalanceModel.get_specific_mb()`` to 
-  signal any state-dependent mass balance model to "reset its state" at the start
-  of the period. This is achieved through a "reset_state" kwarg passed by 
-  ``MassBalanceModel.get_annual_mb()``. Done to address that 
-  ``apparent_mb_from_any_mb()`` calls ``get_specific_mb()``  twice, leading to nonzero
-  terminal flux (potentially) with a state-dependent mass balance model.
-  `apparent_mb_from_any_mb()` also changed accordingly. Similar change also 
-  made to ``MultipleFlowlineMassBalanceModel.get_specific_mb()``. Does not impact
-  any current functionality within oggm.
+- Added "reset_state()" function to ``MassBalanceModel`` to signal any state-dependent 
+  mass balance model to "reset its state" at the start of the period. This function
+  does nothing in the parent class and would only be implemented by a state-ful
+  mass balance model. Done mainly to address that ``apparent_mb_from_any_mb()`` calls 
+  ``get_specific_mb()``  twice, leading to nonzero terminal flux (potentially) with a 
+  state-dependent mass balance model. `apparent_mb_from_any_mb()` also changed 
+  accordingly. 
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -21,14 +21,14 @@ Enhancements
   ``dis_from_border``, ...) to define this ranking, providing greater flexibility
   and control over how the melting sequence is visualized (:pull:`1746`).
   By `Patrick Schmitt <https://github.com/pat-schmitt>`_
-- Added "reset_state" functionality to `MassBalanceModel.get_specific_mb()` to 
+- Added "reset_state" functionality to ``MassBalanceModel.get_specific_mb()`` to 
   signal any state-dependent mass balance model to "reset its state" at the start
   of the period. This is achieved through a "reset_state" kwarg passed by 
-  `MassBalanceModel.get_annual_mb()`. Done to address that 
-  `apparent_mb_from_any_mb()` calls `get_specific_mb()`  twice, leading to nonzero
+  ``MassBalanceModel.get_annual_mb()``. Done to address that 
+  ``apparent_mb_from_any_mb()`` calls ``get_specific_mb()``  twice, leading to nonzero
   terminal flux (potentially) with a state-dependent mass balance model.
   `apparent_mb_from_any_mb()` also changed accordingly. Similar change also 
-  made to `MultipleFlowlineMassBalanceModel.get_specific_mb()`. Does not impact
+  made to ``MultipleFlowlineMassBalanceModel.get_specific_mb()``. Does not impact
   any current functionality within oggm.
 
 Bug fixes

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -21,16 +21,21 @@ Enhancements
   ``dis_from_border``, ...) to define this ranking, providing greater flexibility
   and control over how the melting sequence is visualized (:pull:`1746`).
   By `Patrick Schmitt <https://github.com/pat-schmitt>`_
-- Added "reset_state()" function to ``MassBalanceModel`` to signal any state-dependent 
+- Added "reset_state()" function to ``MassBalanceModel`` to signal any state-dependent
   mass balance model to "reset its state" at the start of the period. This function
   does nothing in the parent class and would only be implemented by a state-ful
-  mass balance model. Done mainly to address that ``apparent_mb_from_any_mb()`` calls 
-  ``get_specific_mb()``  twice, leading to nonzero terminal flux (potentially) with a 
-  state-dependent mass balance model. `apparent_mb_from_any_mb()` also changed 
-  accordingly. 
+  mass balance model. There might be a use for this in the future, but for now
+  it's just a placeholder (:pull:`1757`).
+  By `Dan Goldberg <https://github.com/dngoldberg>`_ and
+  `Fabien Maussion <https://github.com/fmaussion>`_.
+
 
 Bug fixes
 ~~~~~~~~~
+
+- `apparent_mb_from_any_mb` no longer computes mass-balance twice (:pull:`1757`).
+  By `Dan Goldberg <https://github.com/dngoldberg>`_ and
+  `Fabien Maussion <https://github.com/fmaussion>`_.
 
 
 

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -21,6 +21,11 @@ Enhancements
   ``dis_from_border``, ...) to define this ranking, providing greater flexibility
   and control over how the melting sequence is visualized (:pull:`1746`).
   By `Patrick Schmitt <https://github.com/pat-schmitt>`_
+- Added "reset_state" functionality to MassBalanceModel.get_specific_mb() to 
+  signal any state-dependent mass balance model to "reset its state" at the start
+  of the period. This is because apparent_mb_from_any_mb() calls get_specific_mb()
+  twice -- apparent_mb_from_any_mb() also changed accordingly. Similar change also 
+  made to MultipleFlowlineMassBalanceModel
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -21,11 +21,15 @@ Enhancements
   ``dis_from_border``, ...) to define this ranking, providing greater flexibility
   and control over how the melting sequence is visualized (:pull:`1746`).
   By `Patrick Schmitt <https://github.com/pat-schmitt>`_
-- Added "reset_state" functionality to MassBalanceModel.get_specific_mb() to 
+- Added "reset_state" functionality to `MassBalanceModel.get_specific_mb()` to 
   signal any state-dependent mass balance model to "reset its state" at the start
-  of the period. This is because apparent_mb_from_any_mb() calls get_specific_mb()
-  twice -- apparent_mb_from_any_mb() also changed accordingly. Similar change also 
-  made to MultipleFlowlineMassBalanceModel
+  of the period. This is achieved through a "reset_state" kwarg passed by 
+  `MassBalanceModel.get_annual_mb()`. Done to address that 
+  `apparent_mb_from_any_mb()` calls `get_specific_mb()`  twice, leading to nonzero
+  terminal flux (potentially) with a state-dependent mass balance model.
+  `apparent_mb_from_any_mb()` also changed accordingly. Similar change also 
+  made to `MultipleFlowlineMassBalanceModel.get_specific_mb()`. Does not impact
+  any current functionality within oggm.
 
 Bug fixes
 ~~~~~~~~~

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -157,6 +157,9 @@ class MassBalanceModel(object, metaclass=SuperclassMeta):
                 out = [self.get_specific_mb(heights=heights, widths=widths,
                     fls=fls, year=yr) for yr in year[1:]]
                 out.insert(0,out1)
+            else:
+                out = [self.get_specific_mb(heights=heights, widths=widths,
+                    fls=fls, year=yr) for yr in year]
             return np.asarray(out)
 
         if fls is not None:
@@ -1311,7 +1314,7 @@ class MultipleFlowlineMassBalance(MassBalanceModel):
         if len(np.atleast_1d(year)) > 1:
             if (reset_state):
                 out1 = self.get_specific_mb(fls=fls, year=year[0], reset_state=True)
-                out = out.append([self.get_specific_mb(fls=fls, year=yr) for yr in year[1:]])
+                out = [self.get_specific_mb(fls=fls, year=yr) for yr in year[1:]]
                 out.insert(0,out1)
             else:
                 out = [self.get_specific_mb(fls=fls, year=yr) for yr in year]
@@ -1328,7 +1331,7 @@ class MultipleFlowlineMassBalance(MassBalanceModel):
                 pass
             widths = np.append(widths, _widths)
             mb = mb_mod.get_annual_mb(fl.surface_h, year=year, fls=fls, fl_id=i,\
-                    reset_state=reset_state, **kwargs)
+                    reset_state=reset_state)
             mbs = np.append(mbs, mb * SEC_IN_YEAR * mb_mod.rho)
 
         return weighted_average_1d(mbs, widths)

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -2142,6 +2142,7 @@ def apparent_mb_from_any_mb(gdir, mb_model=None,
         mb_years = np.arange(*mb_years, 1)
 
     # Unchanged SMB
+    rho = cfg.PARAMS['ice_density']
     mb_on_fl = []
     spec_mb = []
     area_smb = []
@@ -2156,7 +2157,7 @@ def apparent_mb_from_any_mb(gdir, mb_model=None,
         smb = 0
         for yr in mb_years:
             amb = mb_model.get_annual_mb(fl.surface_h, fls=fls, fl_id=fl_id, year=yr)
-            amb *= cfg.SEC_IN_YEAR * mb_model.rho
+            amb *= cfg.SEC_IN_YEAR * rho
             mbz += amb
             smb += weighted_average_1d(amb, widths)
         mb_on_fl.append(mbz / len(mb_years))

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -153,13 +153,13 @@ class MassBalanceModel(object, metaclass=SuperclassMeta):
         if len(np.atleast_1d(year)) > 1:
             if (reset_state):
                 out1 = self.get_specific_mb(heights=heights, widths=widths,
-                    fls=fls, year=year[0], reset_state=True)
+                                            fls=fls, year=year[0], reset_state=True)
                 out = [self.get_specific_mb(heights=heights, widths=widths,
-                    fls=fls, year=yr) for yr in year[1:]]
-                out.insert(0,out1)
+                       fls=fls, year=yr) for yr in year[1:]]
+                out.insert(0, out1)
             else:
                 out = [self.get_specific_mb(heights=heights, widths=widths,
-                    fls=fls, year=yr) for yr in year]
+                       fls=fls, year=yr) for yr in year]
             return np.asarray(out)
 
         if fls is not None:
@@ -1315,7 +1315,7 @@ class MultipleFlowlineMassBalance(MassBalanceModel):
             if (reset_state):
                 out1 = self.get_specific_mb(fls=fls, year=year[0], reset_state=True)
                 out = [self.get_specific_mb(fls=fls, year=yr) for yr in year[1:]]
-                out.insert(0,out1)
+                out.insert(0, out1)
             else:
                 out = [self.get_specific_mb(fls=fls, year=yr) for yr in year]
             return np.asarray(out)
@@ -1330,8 +1330,8 @@ class MultipleFlowlineMassBalance(MassBalanceModel):
             except AttributeError:
                 pass
             widths = np.append(widths, _widths)
-            mb = mb_mod.get_annual_mb(fl.surface_h, year=year, fls=fls, fl_id=i,\
-                    reset_state=reset_state)
+            mb = mb_mod.get_annual_mb(fl.surface_h, year=year, fls=fls, fl_id=i,
+                                      reset_state=reset_state)
             mbs = np.append(mbs, mb * SEC_IN_YEAR * mb_mod.rho)
 
         return weighted_average_1d(mbs, widths)
@@ -2147,7 +2147,7 @@ def apparent_mb_from_any_mb(gdir, mb_model=None,
 
     # Unchanged SMB
     o_smb = np.mean(mb_model.get_specific_mb(fls=fls, year=mb_years, reset_state=True))
- 
+
     def to_minimize(residual_to_opt):
         return o_smb + residual_to_opt - cmb
 
@@ -2162,13 +2162,13 @@ def apparent_mb_from_any_mb(gdir, mb_model=None,
     for fl_id, fl in enumerate(fls):
         mbz = 0
         for yr in mb_years:
-            if yr==mb_years[0]:
+            if yr == mb_years[0]:
                 mbz += mb_model.get_annual_mb(fl.surface_h, year=yr,
-                                          fls=fls, fl_id=fl_id, reset_state=True)
+                                              fls=fls, fl_id=fl_id, reset_state=True)
             else:
                 mbz += mb_model.get_annual_mb(fl.surface_h, year=yr,
                                           fls=fls, fl_id=fl_id)
-               
+
         mbz = mbz / len(mb_years)
         fl.set_apparent_mb(mbz * cfg.SEC_IN_YEAR * rho + residual,
                            is_calving=is_calving)

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -12,7 +12,6 @@ from scipy.interpolate import interp1d
 from scipy import optimize
 # Locals
 import oggm.cfg as cfg
-from IPython import embed
 from oggm.cfg import SEC_IN_YEAR, SEC_IN_MONTH
 from oggm.utils import (SuperclassMeta, get_geodetic_mb_dataframe,
                         floatyear_to_date, date_to_floatyear, get_demo_file,


### PR DESCRIPTION
Although this does not apply to any existing mass balance models, there may be mass balance models in the future that have a "state" associated. Now, for a given set of climate files for a given glacier in a given year or interval, the mass balance models return consistent values whenever `get_annual_mb` or `get_specific_mb` is called. But if an energy balance model is implemented, the mass balance will depend on properties such as snow state and glacier surface temperature, and this may not give consistent results unless there is a consistent "state". The issue arises, for instance, in `apparent_mb_from_any_mb`, **but there could be others as well**.

One possibility is to save the "state" in a given year in a glacier directory. However, this will not completely address the problem as  get_annual_mb may be called for a different year. 

Another is to give flexibility by allowing a "reset_state" kwarg. This does absolutely nothing with existing mass balance models, but allows developers of new MB models a way to address the issues above. That is what the current pull request does.

**NOTE** a far less-invasive option to address the issue in `apparent_mb_from_any_mb` might be to re-instantiate the mass balance model within the function. But this led to multiple testing errors.

Closes https://github.com/OGGM/oggm/issues/1755

- Passes All ci Tests
- [ ] Fully documented
- Entry in `whats-new.rst`: Added "reset_state" functionality to ``MassBalanceModel.get_specific_mb()`` to 
  signal any state-dependent mass balance model to "reset its state" at the start
  of the period. This is achieved through a "reset_state" kwarg passed by 
  ``MassBalanceModel.get_annual_mb()``. Done to address that 
  ``apparent_mb_from_any_mb()`` calls ``get_specific_mb()``  twice, leading to nonzero
  terminal flux (potentially) with a state-dependent mass balance model.
  `apparent_mb_from_any_mb()` also changed accordingly. Similar change also 
  made to ``MultipleFlowlineMassBalanceModel.get_specific_mb()``. Does not impact
  any current functionality within oggm.

**NOTE**: this PR is invasive, and i have decided on a less invasive change. so i am closing it.