### PR TITLE
Re-instantiate mass balance model within apparent_mb_from_any_mb

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -21,6 +21,10 @@ Enhancements
   ``dis_from_border``, ...) to define this ranking, providing greater flexibility
   and control over how the melting sequence is visualized (:pull:`1746`).
   By `Patrick Schmitt <https://github.com/pat-schmitt>`_
+- Added line in `massbalance.apparent_mb_from_any_mb()` to reinstantiate mass balance
+  model. This should have no effect for any existing mass balance model but could
+  help with future mass balance models that are state dependent
+  By `Dan Goldberg <<https://github.com/dngoldberg>`_
 
 Bug fixes
 ~~~~~~~~~

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -2141,6 +2141,10 @@ def apparent_mb_from_any_mb(gdir, mb_model=None,
 
     residual = optimize.brentq(to_minimize, -1e5, 1e5)
 
+    # re-instantiate the class, in case there is any state dependence
+    # in the mass balance model
+    mb_model = mb_model_class(gdir)
+
     # Reset flux
     for fl in fls:
         fl.reset_flux()


### PR DESCRIPTION
Although this does not apply to any existing mass balance models, there may be mass balance models in the future that have a "state" associated. In this case calls such as get_specific_mb() may give different results depending on how they are called. The issue arises, for instance, in apparent_mb_from_any_mb, **but there could be others as well**.

The simplest approach is to reinstantiate the mass balance model mid-function. This will only work if this resets the mass balance model state. 

Closes https://github.com/OGGM/oggm/issues/1755

- Tests passed: All except for TestGIS::test_gridded_data_var_to_geotiff and Test_bedtopo::test_add_consensus, which do not pass on my server with the master branch either.
- [ ] Fully documented
- Entry in `whats-new.rst`: Added line in `massbalance.apparent_mb_from_any_mb()` to reinstantiate mass balance
  model. This should have no effect for any existing mass balance model but could
  help with future mass balance models that are state dependent

