### PR TITLE
Refactor recursive functions

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -21,6 +21,9 @@ Enhancements
   ``dis_from_border``, ...) to define this ranking, providing greater flexibility
   and control over how the melting sequence is visualized (:pull:`1746`).
   By `Patrick Schmitt <https://github.com/pat-schmitt>`_
+- Refactored mass balance functions ``get_specific_mb`` and``get_ela``. These
+  are no longer recursive and have been optimised for performance.
+  By `Nicolas Gampierakis <https://github.com/gampnico>`_
 
 Bug fixes
 ~~~~~~~~~

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -17,7 +17,7 @@ from oggm.utils import (SuperclassMeta, get_geodetic_mb_dataframe,
                         floatyear_to_date, date_to_floatyear, get_demo_file,
                         monthly_timeseries, ncDataset, get_temp_bias_dataframe,
                         clip_min, clip_max, clip_array, clip_scalar,
-                        weighted_average_1d, lazy_property)
+                        weighted_average_1d, lazy_property, set_array_type)
 from oggm.exceptions import (InvalidWorkflowError, InvalidParamsError,
                              MassBalanceCalibrationError)
 from oggm import entity_task
@@ -194,8 +194,7 @@ class MassBalanceModel(object, metaclass=SuperclassMeta):
                 mbs = weighted_average_1d(mbs, widths)
             out.append(mbs)
 
-        # Convert units here to maintain backwards compatibility
-        return np.asarray(out) * SEC_IN_YEAR * self.rho
+        return set_array_type(out) * SEC_IN_YEAR * self.rho
 
     def get_ela(self, year=None, **kwargs):
         """Compute the equilibrium line altitude for a given year.
@@ -1390,7 +1389,8 @@ class MultipleFlowlineMassBalance(MassBalanceModel):
         for mb_yr in year:
             mbs = self.get_weighted_mb_from_flowlines(fls=fls, year=mb_yr)
             out.append(mbs)
-        return np.asarray(out)
+
+        return set_array_type(out)
 
     def get_ela(self, year=None, **kwargs):
 

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -2389,7 +2389,7 @@ def compute_ela(gdir, ys=None, ye=None, years=None, climate_filename='climate_hi
 
     ela = []
     for yr in years:
-        ela = np.append(ela, mbmod.get_ela(year=yr))
+        ela.append(mbmod.get_ela(year=yr))
 
     odf = pd.Series(data=ela, index=years)
     return odf

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -708,9 +708,22 @@ class TestMassBalanceModels:
         assert isinstance(smb, np.ndarray)
         assert smb.shape == (1 + (ye - ys),)
 
+        # Rough non-weighted bounds
+        ref_smb_lo = (
+            mb_mod.get_annual_mb(fls[-1].surface_h, year=ys, fls=fls, fl_id=-1)
+            * cfg.SEC_IN_YEAR
+            * cfg.PARAMS["ice_density"]
+        )
+        ref_smb_hi = (
+            mb_mod.get_annual_mb(fls[0].surface_h, year=ys, fls=fls, fl_id=0)
+            * cfg.SEC_IN_YEAR
+            * cfg.PARAMS["ice_density"]
+        )
+
         smb_single = mb_mod.get_specific_mb(year=ys)
         assert isinstance(smb_single, float)
         assert smb_single == smb[0]
+        assert ref_smb_lo.mean() < smb_single < ref_smb_hi.mean()
 
     def test_get_ela(self, hef_gdir):
 
@@ -718,7 +731,7 @@ class TestMassBalanceModels:
         init_present_time_glacier(gdir)
         ys = 1979
         ye = 2019
-        years = np.arange(ys, ye+1)
+        years = np.arange(ys, ye + 1)
 
         fls = gdir.read_pickle("inversion_flowlines")
         mb_mod = massbalance.MultipleFlowlineMassBalance(
@@ -736,6 +749,7 @@ class TestMassBalanceModels:
         ela_single = mb_mod.get_ela(year=ys)
         assert isinstance(ela_single, float)
         assert ela_single == ela[0]
+        assert fls[-1].surface_h.min() < ela_single < fls[0].surface_h.max()
 
     def test_constant_mb_model(self, hef_gdir):
 

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -650,7 +650,7 @@ class TestMassBalanceModels:
         #                 mb_gw.get_ela(year=yrs[:30]))
 
     @pytest.mark.parametrize("ref_year", [1979, 1980])
-    def test_get_mass_balance_from_flowlines(self, hef_gdir, ref_year):
+    def test_get_annual_specific_mass_balance(self, hef_gdir, ref_year):
 
         gdir = hef_gdir
         init_present_time_glacier(gdir)
@@ -660,7 +660,7 @@ class TestMassBalanceModels:
         mb_mod = massbalance.MultipleFlowlineMassBalance(
             gdir, fls=test_fls, mb_model_class=massbalance.MonthlyTIModel
         )
-        test_mbs = mb_mod.get_weighted_mb_from_flowlines(
+        test_mbs = mb_mod.get_annual_specific_mass_balance(
             fls=test_fls, year=ref_year
         )
         assert isinstance(test_mbs, np.float64)

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -704,14 +704,38 @@ class TestMassBalanceModels:
             ys=ys,
             ye=ye,
         )
-        smb_iter = mb_mod.get_specific_mb(year=years)
-        assert isinstance(smb_iter, np.ndarray)
-        assert smb_iter.shape == (1 + (ye - ys),)
+        smb = mb_mod.get_specific_mb(year=years)
+        assert isinstance(smb, np.ndarray)
+        assert smb.shape == (1 + (ye - ys),)
 
-        smb_iter_single = mb_mod.get_specific_mb(year=ys)
-        assert isinstance(smb_iter_single, float)
+        smb_single = mb_mod.get_specific_mb(year=ys)
+        assert isinstance(smb_single, float)
+        assert smb_single == smb[0]
 
-        assert smb_iter_single == smb_iter[0]
+    def test_get_ela(self, hef_gdir):
+
+        gdir = hef_gdir
+        init_present_time_glacier(gdir)
+        ys = 1979
+        ye = 2019
+        years = np.arange(ys, ye+1)
+
+        fls = gdir.read_pickle("inversion_flowlines")
+        mb_mod = massbalance.MultipleFlowlineMassBalance(
+            gdir,
+            fls=fls,
+            mb_model_class=massbalance.MonthlyTIModel,
+            repeat=True,
+            ys=ys,
+            ye=ye,
+        )
+        ela = mb_mod.get_ela(year=years)
+        assert isinstance(ela, np.ndarray)
+        assert ela.shape == (1 + (ye - ys),)
+
+        ela_single = mb_mod.get_ela(year=ys)
+        assert isinstance(ela_single, float)
+        assert ela_single == ela[0]
 
     def test_constant_mb_model(self, hef_gdir):
 

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -660,7 +660,7 @@ class TestMassBalanceModels:
         mb_mod = massbalance.MultipleFlowlineMassBalance(
             gdir, fls=test_fls, mb_model_class=massbalance.MonthlyTIModel
         )
-        test_mbs = mb_mod.get_mass_balance_from_flowlines(
+        test_mbs = mb_mod.get_weighted_mb_from_flowlines(
             fls=test_fls, year=ref_year
         )
         assert isinstance(test_mbs, np.float64)

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -202,6 +202,19 @@ class TestFuncs(object):
         with pytest.raises(ZeroDivisionError):
             utils.weighted_average_1d(d, weights=w)
 
+    @pytest.mark.parametrize(
+            "in_data,out_type",
+            [
+                (np.empty(1), float),
+                (np.empty(5,), np.ndarray),
+                ([1.0], float),
+                ([1.0, 2.0], np.ndarray),
+            ]
+        )
+    def test_set_array_type(self, in_data, out_type):
+        out_data = utils.set_array_type(in_data)
+        assert isinstance(out_data, out_type)
+
     def test_hydro_convertion(self):
 
         # October

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -3205,6 +3205,10 @@ class TestELAComputation(unittest.TestCase):
         assert ([ELA1 < ELA2])
         assert_allclose(np.mean(mb * SEC_IN_YEAR), 0, atol=1e-3)
 
+        for ela in (ELA1, ELA2):
+            assert isinstance(ela, pd.Series)
+            assert ela.shape == (1 + (ye - ys),)
+
     def test_compile(self):
         gdir = init_hef()
 

--- a/oggm/utils/_funcs.py
+++ b/oggm/utils/_funcs.py
@@ -172,6 +172,31 @@ def tolist(arg, length=None):
     return arg
 
 
+def set_array_type(array):
+    """Convert array to scalar if it contains a single value.
+
+    Converting arrays with ndim > 0 to scalar is deprecated in numpy
+    1.25+. Some OGGM functions expect arrays with a single value to be returned as scalars.
+
+    Parameters
+    ----------
+    array : ArrayLike
+        A numpy array or list.
+
+    Returns
+    -------
+    float or np.ndarray
+        Scalar if the array contains a single value, otherwise a numpy
+        array.
+    """
+    if len(array) > 1:
+        output = np.asanyarray(array)
+    else:
+        output = array[0]
+
+    return output
+
+
 def haversine(lon1, lat1, lon2, lat2):
     """Great circle distance between two (or more) points on Earth
 


### PR DESCRIPTION
This PR refactors recursive methods into iterative ones.

The refactored methods have known bounds (either a single year, or a predetermined date range), and therefore do not benefit from recursion. My main motivation here is to simplify the daily MB implementation (#1750). The iterative methods are much easier to overload and test.

**Changes**
* Recursive functions are now iterative.
* Removes ``np.append`` in favour of concatenating over lists of numpy arrays, which provides ~2x performance increase. This is especially important for #1750 where arrays are larger and ragged.
* Adds ``utils.set_array_type`` to ensure single values are returned as floats, because numpy 1.25+ no longer supports converting arrays to scalars. This maintains backwards compatibility with other parts of OGGM that expect a float.

**Points for discussion**
* I have run my own tests to ensure the recursive and iterative variants produce an identical output. However, I would like to know if (and how) these tests should be included, as the recursive variants have been removed entirely. This PR only checks if a value is within bounds for the minimum and maximum flowlines.
* ``np.append`` is used liberally in OGGM - presumably to deal with ragged arrays/setting elements with a sequence? It's usually faster to use ``np.concatenate`` or ``np.stack`` over lists of numpy arrays as the axis is always known (this is what ``append`` does internally anyway), and the elements in the lists still benefit from numpy's memory efficiency. Perhaps this could be cleaned up in a round of optimisations (#855)?

Refs: #1750,  #855

- [x] Tests added/passed
- [x] Fully documented
- [x] Entry in `whats-new.rst` 
