### PR TITLE
Allowe to use a mini params file during initialization

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -35,6 +35,11 @@ Enhancements
 - Refactored mass balance functions ``get_specific_mb`` and``get_ela``. These
   are no longer recursive and have been optimised for performance.
   By `Nicolas Gampierakis <https://github.com/gampnico>`_.
+- Added the ability to use an incomplete version of the full params.cfg file
+  to override some default parameter values. This can be done by providing the
+  file during initialization with ``cfg.initialize(file=mini_params_filepath)``
+  (:pull:`1776`).
+  By `Patrick Schmitt <https://github.com/pat-schmitt>`_
 
 Bug fixes
 ~~~~~~~~~

--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -378,11 +378,14 @@ def initialize_minimal(file=None, logging_level='INFO', params=None):
     Parameters
     ----------
     file : str
-        path to the configuration file (default: OGGM params.cfg)
+        path to a user configuration file. The parameters provided in this file
+        will override the default settings in `OGGM params.cfg`. The file does
+        not need to include all parameters.
     logging_level : str
         set a logging level. See :func:`set_logging_config` for options.
     params : dict
-        overrides for specific parameters from the config file
+        overrides for specific parameters from the config file. Overrules a
+        potential provided file.
     """
     global IS_INITIALIZED
     global PARAMS
@@ -390,16 +393,29 @@ def initialize_minimal(file=None, logging_level='INFO', params=None):
 
     set_logging_config(logging_level=logging_level)
 
-    is_default = False
-    if file is None:
-        file = os.path.join(os.path.abspath(os.path.dirname(__file__)),
-                            'params.cfg')
-        is_default = True
+    # Open default params file
+    is_default = True
+    file_default = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                                'params.cfg')
     try:
-        cp = ConfigObj(file, file_error=True)
+        cp = ConfigObj(file_default, file_error=True)
     except (ConfigObjError, IOError) as e:
-        log.critical('Config file could not be parsed (%s): %s', file, e)
+        log.critical('Config file could not be parsed (%s): %s',
+                     file_default, e)
         sys.exit()
+
+    # If provided open user params file and overwrite defaults
+    if file:
+        is_default = False
+        try:
+            cp_user = ConfigObj(file, file_error=True)
+        except (ConfigObjError, IOError) as e:
+            log.critical('Config file could not be parsed (%s): %s',
+                         file, e)
+            sys.exit()
+
+        for k, v in cp_user.items():
+            cp[k] = v
 
     if is_default:
         log.workflow('Reading default parameters from the OGGM `params.cfg` '
@@ -411,7 +427,7 @@ def initialize_minimal(file=None, logging_level='INFO', params=None):
     # Static Paths
     oggm_static_paths()
 
-    # Apply code-side manual params overrides
+    # Apply code-side manual params overrides, overrules provided params file
     if params:
         for k, v in params.items():
             cp[k] = v

--- a/oggm/tests/mini_params_for_test.cfg
+++ b/oggm/tests/mini_params_for_test.cfg
@@ -1,0 +1,2 @@
+# Default number of files to be cached in the temporary directory
+lru_maxsize = 123

--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -196,7 +196,10 @@ class TestFullRun(unittest.TestCase):
     @pytest.mark.slow
     def test_calibrate_inversion_from_consensus(self):
 
-        gdirs = up_to_inversion(params_file='mini_params_for_test.cfg')
+        # test mini params file, define path relative to file location
+        fp_mini_params = os.path.join(os.path.dirname(__file__),
+                                      'mini_params_for_test.cfg')
+        gdirs = up_to_inversion(params_file=fp_mini_params)
 
         # check if mini params file is used as expected
         assert cfg.PARAMS['lru_maxsize'] == 123

--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -35,7 +35,7 @@ def clean_dir(testdir):
     os.makedirs(testdir)
 
 
-def up_to_climate(reset=False, use_mp=None):
+def up_to_climate(reset=False, use_mp=None, params_file=None):
     """Run the tasks you want."""
 
     # test directory
@@ -49,7 +49,7 @@ def up_to_climate(reset=False, use_mp=None):
             pickle.dump('none', f)
 
     # Init
-    cfg.initialize()
+    cfg.initialize(file=params_file)
 
     # Use multiprocessing
     use_mp = False
@@ -119,10 +119,10 @@ def up_to_climate(reset=False, use_mp=None):
     return gdirs
 
 
-def up_to_inversion(reset=False):
+def up_to_inversion(reset=False, params_file=None):
     """Run the tasks you want."""
 
-    gdirs = up_to_climate(reset=reset)
+    gdirs = up_to_climate(reset=reset, params_file=params_file)
 
     with open(CLI_LOGF, 'rb') as f:
         clilog = pickle.load(f)
@@ -196,7 +196,11 @@ class TestFullRun(unittest.TestCase):
     @pytest.mark.slow
     def test_calibrate_inversion_from_consensus(self):
 
-        gdirs = up_to_inversion()
+        gdirs = up_to_inversion(params_file='mini_params_for_test.cfg')
+
+        # check if mini params file is used as expected
+        assert cfg.PARAMS['lru_maxsize'] == 123
+
         df = workflow.calibrate_inversion_from_consensus(gdirs,
                                                          ignore_missing=True)
         df = df.dropna()


### PR DESCRIPTION
Previously, modifying parameters during initialization required supplying a complete `params.cfg` file. This PR introduces support for an optional `mini_params.cfg` file, usabel as `cfg.initialize(file=mini_params_filepath)`. This file can include only the parameters you wish to override, defaults will be filled in from the base `params.cfg`.

his PR extracts a subset of changes from PR https://github.com/OGGM/oggm/pull/1756, as they are unrelated to the new parameter handling approach envisioned in that PR.

- [x] Tests added/passed
- [ ] Fully documented
- [x] Entry in `whats-new.rst` 
