### PR TITLE
deprecate dl_verify

### DIFF
--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -516,7 +516,6 @@ def initialize_minimal(file=None, logging_level='INFO', params=None):
     PARAMS['use_tar_shapefiles'] = cp.as_bool('use_tar_shapefiles')
     PARAMS['keep_multipolygon_outlines'] = cp.as_bool('keep_multipolygon_outlines')
     PARAMS['clip_tidewater_border'] = cp.as_bool('clip_tidewater_border')
-    PARAMS['dl_verify'] = cp.as_bool('dl_verify')
     PARAMS['use_kcalving_for_inversion'] = cp.as_bool('use_kcalving_for_inversion')
     PARAMS['use_kcalving_for_run'] = cp.as_bool('use_kcalving_for_run')
     PARAMS['calving_use_limiter'] = cp.as_bool('calving_use_limiter')
@@ -580,7 +579,7 @@ def initialize_minimal(file=None, logging_level='INFO', params=None):
            'hydro_month_sh', 'hydro_month_nh', 'by_bin_bins',
            'use_intersects', 'filter_min_slope', 'clip_tidewater_border',
            'auto_skip_task', 'ref_mb_valid_window',
-           'rgi_version', 'dl_verify', 'use_mp_spawn', 'calving_use_limiter',
+           'rgi_version', 'use_mp_spawn', 'calving_use_limiter',
            'use_rgi_area', 'baseline_climate',
            'calving_line_extension', 'use_kcalving_for_run', 'lru_maxsize',
            'free_board_marine_terminating', 'use_kcalving_for_inversion',
@@ -651,10 +650,6 @@ def initialize(file=None, logging_level='INFO', params=None):
                 except NameError:
                     pass
         DATA['dem_grids'] = grids
-
-    # Trigger a one time check of the hash file
-    from oggm.utils import get_dl_verify_data
-    get_dl_verify_data('dummy_section')
 
     # OK
     PARAMS.do_log = True

--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -63,9 +63,6 @@ keep_multipolygon_outlines = False
 # If you receive "Message truncated" errors from MPI, increase this
 mpi_recv_buf_size = 131072
 
-# Check for the integrity of the files OGGM downloads at run time
-dl_verify = False
-
 # Default number of files to be cached in the temporary directory
 lru_maxsize = 100
 

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -421,9 +421,6 @@ def init_glacier_directories(rgidf=None, *, reset=False, force=False,
             log.workflow('init_glacier_directories from prepro level {} on '
                          '{} glaciers.'.format(from_prepro_level,
                                                len(entities)))
-            # Read the hash dictionary before we use multiproc
-            if cfg.PARAMS['dl_verify']:
-                utils.get_dl_verify_data('cluster.klima.uni-bremen.de')
             gdirs = execute_entity_task(gdir_from_prepro, entities,
                                         from_prepro_level=from_prepro_level,
                                         prepro_border=prepro_border,


### PR DESCRIPTION
This is hard to maintain, and has not been necessary recently since we have a lot of safeguards for downloads, etc.

Closes https://github.com/OGGM/oggm/issues/1838
Closes https://github.com/OGGM/oggm/issues/1834 
