### PR TITLE
Modernize .readthedocs.yaml for latest OS and tools

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,8 +1,8 @@
 version: 2
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-lts-latest"
   tools:
-    python: "mambaforge-4.10"
+    python: "miniforge3-latest"
 conda:
   environment: docs/environment.yml
 sphinx:


### PR DESCRIPTION
Just got a mail that both or tool and os are deprecated and will be gone in a few months.
