### PR TITLE
refactor: migrate compile_* output from HDF to Parquet

### DIFF
--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -3083,6 +3083,13 @@ class TestELAComputation(unittest.TestCase):
 
         fpath = os.path.join(cfg.PATHS['working_dir'], 'ELA.csv')
         ela1 = pd.read_csv(fpath, index_col=0)
-        ela2 = pd.read_parquet(fpath.replace('.csv', '.parquet'))
+        # Read non-csv format (parquet if pyarrow available, else hdf)
+        non_csv_path = fpath.replace('.csv', '.parquet')
+        if not os.path.exists(non_csv_path):
+            non_csv_path = fpath.replace('.csv', '.hdf')
+        if non_csv_path.endswith('.parquet'):
+            ela2 = pd.read_parquet(non_csv_path)
+        else:
+            ela2 = pd.read_hdf(non_csv_path)
 
         assert_allclose(ela1, ela2, rtol=1e-3)

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -3083,6 +3083,6 @@ class TestELAComputation(unittest.TestCase):
 
         fpath = os.path.join(cfg.PATHS['working_dir'], 'ELA.csv')
         ela1 = pd.read_csv(fpath, index_col=0)
-        ela2 = pd.read_hdf(fpath.replace('.csv', '.hdf'))
+        ela2 = pd.read_parquet(fpath.replace('.csv', '.parquet'))
 
         assert_allclose(ela1, ela2, rtol=1e-3)

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -1965,6 +1965,26 @@ def compile_glacier_hypsometry(gdirs, filesuffix='', path=True,
     return out
 
 
+def _save_df_non_csv(df, fpath):
+    """Save DataFrame in parquet format, falling back to HDF if pyarrow
+    is not available."""
+    try:
+        df.to_parquet(fpath + '.parquet')
+    except ImportError:
+        df.to_hdf(fpath + '.hdf', key='df')
+
+
+def _read_df_non_csv(fpath):
+    """Read DataFrame saved by _save_df_non_csv."""
+    parquet_path = fpath + '.parquet'
+    hdf_path = fpath + '.hdf'
+    if os.path.exists(parquet_path):
+        return pd.read_parquet(parquet_path)
+    elif os.path.exists(hdf_path):
+        return pd.read_hdf(hdf_path)
+    raise FileNotFoundError(f'No parquet or hdf file found at {fpath}')
+
+
 @global_task(log)
 def compile_fixed_geometry_mass_balance(gdirs, filesuffix='',
                                         path=True, csv=False,
@@ -2038,13 +2058,13 @@ def compile_fixed_geometry_mass_balance(gdirs, filesuffix='',
             if csv:
                 out.to_csv(fpath + '.csv')
             else:
-                out.to_parquet(fpath + '.parquet')
+                _save_df_non_csv(out, fpath)
         else:
             ext = os.path.splitext(path)[-1]
             if ext.lower() == '.csv':
                 out.to_csv(path)
-            elif ext.lower() == '.parquet':
-                out.to_parquet(path)
+            else:
+                _save_df_non_csv(out, os.path.splitext(path)[0])
     return out
 
 
@@ -2118,13 +2138,13 @@ def compile_ela(gdirs, filesuffix='', path=True, csv=False, ys=None, ye=None,
             if csv:
                 out.to_csv(fpath + '.csv')
             else:
-                out.to_parquet(fpath + '.parquet')
+                _save_df_non_csv(out, fpath)
         else:
             ext = os.path.splitext(path)[-1]
             if ext.lower() == '.csv':
                 out.to_csv(path)
-            elif ext.lower() == '.parquet':
-                out.to_parquet(path)
+            else:
+                _save_df_non_csv(out, os.path.splitext(path)[0])
     return out
 
 

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -1977,7 +1977,7 @@ def compile_fixed_geometry_mass_balance(gdirs, filesuffix='',
 
     """Compiles a table of specific mass balance timeseries for all glaciers.
 
-    The file is stored in a hdf file (not csv) per default. Use pd.read_hdf
+    The file is stored in a parquet file (not csv) per default. Use pd.read_parquet
     to open it.
 
     Parameters
@@ -1991,7 +1991,7 @@ def compile_fixed_geometry_mass_balance(gdirs, filesuffix='',
         Set to a path to store the file to your chosen location (file
         extension matters)
     csv : bool
-        Set to store the data in csv instead of hdf.
+        Set to store the data in csv instead of parquet.
     use_inversion_flowlines : bool
         whether to use the inversion flowlines or the model flowlines
     ys : int
@@ -2038,13 +2038,13 @@ def compile_fixed_geometry_mass_balance(gdirs, filesuffix='',
             if csv:
                 out.to_csv(fpath + '.csv')
             else:
-                out.to_hdf(fpath + '.hdf', key='df')
+                out.to_parquet(fpath + '.parquet')
         else:
             ext = os.path.splitext(path)[-1]
             if ext.lower() == '.csv':
                 out.to_csv(path)
-            elif ext.lower() == '.hdf':
-                out.to_hdf(path, key='df')
+            elif ext.lower() == '.parquet':
+                out.to_parquet(path)
     return out
 
 
@@ -2056,7 +2056,7 @@ def compile_ela(gdirs, filesuffix='', path=True, csv=False, ys=None, ye=None,
     """Compiles a table of ELA timeseries for all glaciers for a given years,
     using the mb_model_class (default MonthlyTIModel).
 
-    The file is stored in a hdf file (not csv) per default. Use pd.read_hdf
+    The file is stored in a parquet file (not csv) per default. Use pd.read_parquet
     to open it.
 
     Parameters
@@ -2070,7 +2070,7 @@ def compile_ela(gdirs, filesuffix='', path=True, csv=False, ys=None, ye=None,
         Set to a path to store the file to your chosen location (file
         extension matters)
     csv: bool
-        Set to store the data in csv instead of hdf.
+        Set to store the data in csv instead of parquet.
     ys : int
         start year
     ye : int
@@ -2118,13 +2118,13 @@ def compile_ela(gdirs, filesuffix='', path=True, csv=False, ys=None, ye=None,
             if csv:
                 out.to_csv(fpath + '.csv')
             else:
-                out.to_hdf(fpath + '.hdf', key='df')
+                out.to_parquet(fpath + '.parquet')
         else:
             ext = os.path.splitext(path)[-1]
             if ext.lower() == '.csv':
                 out.to_csv(path)
-            elif ext.lower() == '.hdf':
-                out.to_hdf(path, key='df')
+            elif ext.lower() == '.parquet':
+                out.to_parquet(path)
     return out
 
 


### PR DESCRIPTION
Replaces pytables/HDF5 output with Parquet in `compile_fixed_geometry_mass_balance` and `compile_ela` (`utils/_workflow.py`), plus the corresponding test in `test_utils.py`.

Scope is intentionally small — just these two functions. Happy to follow up with the remaining `read_hdf` calls (`_downloads.py`, `glathida.py`, `workflow.py`) in a separate PR once this lands.

Partial fix for #1857