### PR TITLE
Replace get_lock() wrappers with @locked_func decorator

### DIFF
--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -50,11 +50,16 @@ except ImportError:
 
 # Locals
 import oggm.cfg as cfg
-from oggm.exceptions import (InvalidParamsError, NoInternetException,
-                             DownloadVerificationFailedException,
-                             DownloadCredentialsMissingException,
-                             HttpDownloadError, HttpContentTooShortError,
-                             InvalidDEMError, FTPSDownloadError)
+from oggm.exceptions import (
+    InvalidParamsError,
+    NoInternetException,
+    DownloadVerificationFailedException,
+    DownloadCredentialsMissingException,
+    HttpDownloadError,
+    HttpContentTooShortError,
+    InvalidDEMError,
+    FTPSDownloadError,
+)
 
 # Python 3.12+ gives a deprecation warning if TarFile.extraction_filter is None.
 # https://docs.python.org/3.12/library/tarfile.html#tarfile-extraction-filter
@@ -62,46 +67,62 @@ if hasattr(tarfile, "fully_trusted_filter"):
     tarfile.TarFile.extraction_filter = staticmethod(tarfile.fully_trusted_filter)  # type: ignore
 
 # Module logger
-logger = logging.getLogger('.'.join(__name__.split('.')[:-1]))
+logger = logging.getLogger(".".join(__name__.split(".")[:-1]))
 
 # Github repository and commit hash/branch name/tag name on that repository
 # The given commit will be downloaded from github and used as source for
 # all sample data
-SAMPLE_DATA_GH_REPO = 'OGGM/oggm-sample-data'
-SAMPLE_DATA_COMMIT = '8af40f89620c6bd72f3485a777a018dcacb99d94'
+SAMPLE_DATA_GH_REPO = "OGGM/oggm-sample-data"
+SAMPLE_DATA_COMMIT = "8af40f89620c6bd72f3485a777a018dcacb99d94"
 
 # Recommended url for runs
-DEFAULT_BASE_URL = ('https://cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.6/'
-                    'L3-L5_files/2025.6/elev_bands/W5E5/per_glacier_spinup/')
+DEFAULT_BASE_URL = (
+    "https://cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.6/"
+    "L3-L5_files/2025.6/elev_bands/W5E5/per_glacier_spinup/"
+)
 
 # Web mercator proj constants
 WEB_N_PIX = 256
-WEB_EARTH_RADUIS = 6378137.
+WEB_EARTH_RADUIS = 6378137.0
 
-DEM_SOURCES = ['GIMP', 'ARCTICDEM', 'RAMP', 'TANDEM', 'AW3D30', 'MAPZEN', 'DEM3',
-               'ASTER', 'SRTM', 'REMA', 'ALASKA', 'COPDEM30', 'COPDEM90', 'NASADEM']
+DEM_SOURCES = [
+    "GIMP",
+    "ARCTICDEM",
+    "RAMP",
+    "TANDEM",
+    "AW3D30",
+    "MAPZEN",
+    "DEM3",
+    "ASTER",
+    "SRTM",
+    "REMA",
+    "ALASKA",
+    "COPDEM30",
+    "COPDEM90",
+    "NASADEM",
+]
 DEM_SOURCES_PER_GLACIER = None
 
 _RGI_METADATA = dict()
 
 DEM3REG = {
-    'ISL': [-25., -13., 63., 67.],  # Iceland
-    'SVALBARD': [9., 35.99, 75., 84.],
-    'JANMAYEN': [-10., -7., 70., 72.],
-    'FJ': [36., 68., 79., 90.],  # Franz Josef Land
-    'FAR': [-8., -6., 61., 63.],  # Faroer
-    'BEAR': [18., 20., 74., 75.],  # Bear Island
-    'SHL': [-3., 0., 60., 61.],  # Shetland
+    "ISL": [-25.0, -13.0, 63.0, 67.0],  # Iceland
+    "SVALBARD": [9.0, 35.99, 75.0, 84.0],
+    "JANMAYEN": [-10.0, -7.0, 70.0, 72.0],
+    "FJ": [36.0, 68.0, 79.0, 90.0],  # Franz Josef Land
+    "FAR": [-8.0, -6.0, 61.0, 63.0],  # Faroer
+    "BEAR": [18.0, 20.0, 74.0, 75.0],  # Bear Island
+    "SHL": [-3.0, 0.0, 60.0, 61.0],  # Shetland
     # Antarctica tiles as UTM zones, large files
-    '01-15': [-180., -91., -90, -60.],
-    '16-30': [-91., -1., -90., -60.],
-    '31-45': [-1., 89., -90., -60.],
-    '46-60': [89., 189., -90., -60.],
+    "01-15": [-180.0, -91.0, -90, -60.0],
+    "16-30": [-91.0, -1.0, -90.0, -60.0],
+    "31-45": [-1.0, 89.0, -90.0, -60.0],
+    "46-60": [89.0, 189.0, -90.0, -60.0],
     # Greenland tiles
-    'GL-North': [-72., -11., 76., 84.],
-    'GL-West': [-62., -42., 64., 76.],
-    'GL-South': [-52., -40., 59., 64.],
-    'GL-East': [-42., -17., 64., 76.]
+    "GL-North": [-72.0, -11.0, 76.0, 84.0],
+    "GL-West": [-62.0, -42.0, 64.0, 76.0],
+    "GL-South": [-52.0, -40.0, 59.0, 64.0],
+    "GL-East": [-42.0, -17.0, 64.0, 76.0],
 }
 
 # Function
@@ -169,16 +190,26 @@ def get_lock():
     global lock
     if lock is None:
         # Global Lock
-        if cfg.PARAMS.get('use_mp_spawn', False):
-            lock = multiprocessing.get_context('spawn').Lock()
+        if cfg.PARAMS.get("use_mp_spawn", False):
+            lock = multiprocessing.get_context("spawn").Lock()
         else:
             lock = multiprocessing.Lock()
     return lock
 
 
+def locked_func(func):
+    """To decorate a function that needs to be locked for multiprocessing"""
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        with get_lock():
+            return func(*args, **kwargs)
+
+    return wrapper
+
+
 def _call_dl_func(dl_func, cache_path):
-    """Helper so the actual call to downloads can be overridden
-    """
+    """Helper so the actual call to downloads can be overridden"""
     return dl_func(cache_path)
 
 
@@ -188,28 +219,28 @@ def _cached_download_helper(cache_obj_name, dl_func, reset=False):
     Takes care of checking if the file is already cached.
     Only calls the actual download function when no cached version exists.
     """
-    cache_dir = cfg.PATHS['dl_cache_dir']
-    cache_ro = cfg.PARAMS['dl_cache_readonly']
+    cache_dir = cfg.PATHS["dl_cache_dir"]
+    cache_ro = cfg.PARAMS["dl_cache_readonly"]
 
     # A lot of logic below could be simplified but it's also not too important
-    wd = cfg.PATHS.get('working_dir')
+    wd = cfg.PATHS.get("working_dir")
     if wd:
         # this is for real runs
-        fb_cache_dir = os.path.join(wd, 'cache')
+        fb_cache_dir = os.path.join(wd, "cache")
         check_fb_dir = False
     else:
         # Nothing have been set up yet, this is bad - find a place to write
         # This should happen on read-only cluster only but still
-        wd = os.environ.get('OGGM_WORKDIR')
+        wd = os.environ.get("OGGM_WORKDIR")
         if wd is not None and os.path.isdir(wd):
-            fb_cache_dir = os.path.join(wd, 'cache')
+            fb_cache_dir = os.path.join(wd, "cache")
         else:
-            fb_cache_dir = os.path.join(cfg.CACHE_DIR, 'cache')
+            fb_cache_dir = os.path.join(cfg.CACHE_DIR, "cache")
         check_fb_dir = True
 
     if not cache_dir:
         # Defaults to working directory: it must be set!
-        if not cfg.PATHS['working_dir']:
+        if not cfg.PATHS["working_dir"]:
             raise InvalidParamsError("Need a valid PATHS['working_dir']!")
         cache_dir = fb_cache_dir
         cache_ro = False
@@ -225,14 +256,14 @@ def _cached_download_helper(cache_obj_name, dl_func, reset=False):
     if cache_ro:
         if check_fb_dir:
             # Add a manual check that we are caching sample data download
-            if 'oggm-sample-data' not in fb_path:
-                raise InvalidParamsError('Attempting to download something '
-                                         'with invalid global settings.')
+            if "oggm-sample-data" not in fb_path:
+                raise InvalidParamsError(
+                    "Attempting to download something with invalid global settings."
+                )
         cache_path = fb_path
 
-    if not cfg.PARAMS['has_internet']:
-        raise NoInternetException("Download required, but "
-                                  "`has_internet` is False.")
+    if not cfg.PARAMS["has_internet"]:
+        raise NoInternetException("Download required, but `has_internet` is False.")
 
     mkdir(os.path.dirname(cache_path))
 
@@ -247,8 +278,7 @@ def _cached_download_helper(cache_obj_name, dl_func, reset=False):
 
 
 def _requests_urlretrieve(url, path, reporthook, auth=None, timeout=None):
-    """Implements the required features of urlretrieve on top of requests
-    """
+    """Implements the required features of urlretrieve on top of requests"""
 
     chunk_size = 128 * 1024
     chunk_count = 0
@@ -258,13 +288,13 @@ def _requests_urlretrieve(url, path, reporthook, auth=None, timeout=None):
             raise HttpDownloadError(r.status_code, url)
         r.raise_for_status()
 
-        size = r.headers.get('content-length') or -1
+        size = r.headers.get("content-length") or -1
         size = int(size)
 
         if reporthook:
             reporthook(chunk_count, chunk_size, size)
 
-        with open(path, 'wb') as f:
+        with open(path, "wb") as f:
             for chunk in r.iter_content(chunk_size=chunk_size):
                 if not chunk:
                     continue
@@ -278,14 +308,13 @@ def _requests_urlretrieve(url, path, reporthook, auth=None, timeout=None):
 
 
 def _classic_urlretrieve(url, path, reporthook, auth=None, timeout=None):
-    """Thin wrapper around pythons urllib urlretrieve
-    """
+    """Thin wrapper around pythons urllib urlretrieve"""
 
     ourl = url
     if auth:
         u = urlparse(url)
-        if '@' not in u.netloc:
-            netloc = auth[0] + ':' + auth[1] + '@' + u.netloc
+        if "@" not in u.netloc:
+            netloc = auth[0] + ":" + auth[1] + "@" + u.netloc
             url = u._replace(netloc=netloc).geturl()
 
     old_def_timeout = socket.getdefaulttimeout()
@@ -303,10 +332,10 @@ def _classic_urlretrieve(url, path, reporthook, auth=None, timeout=None):
 
 
 class ImplicitFTPTLS(ftplib.FTP_TLS):
-    """ FTP_TLS subclass that automatically wraps sockets in SSL to support
-        implicit FTPS.
+    """FTP_TLS subclass that automatically wraps sockets in SSL to support
+    implicit FTPS.
 
-        Taken from https://stackoverflow.com/a/36049814
+    Taken from https://stackoverflow.com/a/36049814
     """
 
     def __init__(self, *args, **kwargs):
@@ -333,12 +362,12 @@ def url_exists(url):
 
 
 def _ftps_retrieve(url, path, reporthook, auth=None, timeout=None):
-    """ Wrapper around ftplib to download from FTPS server
-    """
+    """Wrapper around ftplib to download from FTPS server"""
 
     if not auth:
-        raise DownloadCredentialsMissingException('No authentication '
-                                                  'credentials given!')
+        raise DownloadCredentialsMissingException(
+            "No authentication credentials given!"
+        )
 
     upar = urlparse(url)
 
@@ -354,21 +383,21 @@ def _ftps_retrieve(url, path, reporthook, auth=None, timeout=None):
         ftps.login(user=auth[0], passwd=auth[1])
         ftps.prot_p()
 
-        logger.info('Established connection %s' % upar.hostname)
+        logger.info("Established connection %s" % upar.hostname)
 
         # meta for progress bar size
         count = 0
         total = ftps.size(upar.path)
-        bs = 12*1024
+        bs = 12 * 1024
 
         def _ftps_progress(data):
             outfile.write(data)
             nonlocal count
             count += 1
-            reporthook(count, count*bs, total)
+            reporthook(count, count * bs, total)
 
-        with open(path, 'wb') as outfile:
-            ftps.retrbinary('RETR ' + upar.path, _ftps_progress, blocksize=bs)
+        with open(path, "wb") as outfile:
+            ftps.retrbinary("RETR " + upar.path, _ftps_progress, blocksize=bs)
 
     except (ftplib.error_perm, socket.timeout, socket.gaierror) as err:
         raise FTPSDownloadError(err)
@@ -377,17 +406,16 @@ def _ftps_retrieve(url, path, reporthook, auth=None, timeout=None):
 
 
 def _get_url_cache_name(url):
-    """Returns the cache name for any given url.
-    """
+    """Returns the cache name for any given url."""
 
     res = urlparse(url)
-    return res.netloc.split(':', 1)[0] + res.path
+    return res.netloc.split(":", 1)[0] + res.path
 
 
 def _assert_url_in_allowlist(url):
     """Fail if a URL is not in the optional download allowlist."""
 
-    allowlist = cfg.PARAMS.get('download_url_allowlist')
+    allowlist = cfg.PARAMS.get("download_url_allowlist")
     if not allowlist:
         return
 
@@ -397,12 +425,14 @@ def _assert_url_in_allowlist(url):
     if any(entry in url for entry in allowlist):
         return
 
-    raise InvalidParamsError('URL is not in cfg.PARAMS["download_url_allowlist"]: '
-                             f'{url}')
+    raise InvalidParamsError(
+        f'URL is not in cfg.PARAMS["download_url_allowlist"]: {url}'
+    )
 
 
-def oggm_urlretrieve(url, cache_obj_name=None, reset=False,
-                     reporthook=None, auth=None, timeout=None):
+def oggm_urlretrieve(
+    url, cache_obj_name=None, reset=False, reporthook=None, auth=None, timeout=None
+):
     """Wrapper around urlretrieve, to implement our caching logic.
 
     Instead of accepting a destination path, it decides where to store the file
@@ -421,22 +451,21 @@ def oggm_urlretrieve(url, cache_obj_name=None, reset=False,
         try:
             _requests_urlretrieve(url, cache_path, reporthook, auth, timeout)
         except requests.exceptions.InvalidSchema:
-            if 'ftps://' in url:
+            if "ftps://" in url:
                 _ftps_retrieve(url, cache_path, reporthook, auth, timeout)
             else:
-                _classic_urlretrieve(url, cache_path, reporthook, auth,
-                                     timeout)
+                _classic_urlretrieve(url, cache_path, reporthook, auth, timeout)
         return cache_path
 
     return _cached_download_helper(cache_obj_name, _dlf, reset)
 
 
-def _progress_urlretrieve(url, cache_name=None, reset=False,
-                          auth=None, timeout=None):
+def _progress_urlretrieve(url, cache_name=None, reset=False, auth=None, timeout=None):
     """Downloads a file, returns its local path, and shows a progressbar."""
 
     try:
         from progressbar import DataTransferBar, UnknownLength
+
         pbar = None
 
         def _upd(count, size, total):
@@ -452,24 +481,28 @@ def _progress_urlretrieve(url, cache_name=None, reset=False,
                     pbar.start(UnknownLength)
             pbar.update(min(count * size, total))
             sys.stdout.flush()
-        res = oggm_urlretrieve(url, cache_obj_name=cache_name, reset=reset,
-                               reporthook=_upd, auth=auth, timeout=timeout)
+
+        res = oggm_urlretrieve(
+            url,
+            cache_obj_name=cache_name,
+            reset=reset,
+            reporthook=_upd,
+            auth=auth,
+            timeout=timeout,
+        )
         try:
             pbar.finish()
         except BaseException:
             pass
         return res
     except ImportError:
-        return oggm_urlretrieve(url, cache_obj_name=cache_name,
-                                reset=reset, auth=auth, timeout=timeout)
+        return oggm_urlretrieve(
+            url, cache_obj_name=cache_name, reset=reset, auth=auth, timeout=timeout
+        )
 
 
+@locked_func
 def aws_file_download(aws_path, cache_name=None, reset=False):
-    with get_lock():
-        return _aws_file_download_unlocked(aws_path, cache_name, reset)
-
-
-def _aws_file_download_unlocked(aws_path, cache_name=None, reset=False):
     """Download a file from the AWS drive s3://astgtmv2/
 
     **Note:** you need AWS credentials for this to work.
@@ -479,13 +512,13 @@ def _aws_file_download_unlocked(aws_path, cache_name=None, reset=False):
     aws_path: path relative to s3://astgtmv2/
     """
 
-    while aws_path.startswith('/'):
+    while aws_path.startswith("/"):
         aws_path = aws_path[1:]
 
     if cache_name is not None:
         cache_obj_name = cache_name
     else:
-        cache_obj_name = 'astgtmv2/' + aws_path
+        cache_obj_name = "astgtmv2/" + aws_path
 
     def _dlf(cache_path):
         raise NotImplementedError("Downloads from AWS are no longer supported")
@@ -493,9 +526,15 @@ def _aws_file_download_unlocked(aws_path, cache_name=None, reset=False):
     return _cached_download_helper(cache_obj_name, _dlf, reset)
 
 
-def file_downloader(www_path, retry_max=3, sleep_on_retry=5,
-                    cache_name=None, reset=False, auth=None,
-                    timeout=None):
+def file_downloader(
+    www_path,
+    retry_max=3,
+    sleep_on_retry=5,
+    cache_name=None,
+    reset=False,
+    auth=None,
+    timeout=None,
+):
     """A slightly better downloader: it tries more than once."""
 
     local_path = None
@@ -504,9 +543,9 @@ def file_downloader(www_path, retry_max=3, sleep_on_retry=5,
         # Try to download
         try:
             retry_counter += 1
-            local_path = _progress_urlretrieve(www_path, cache_name=cache_name,
-                                               reset=reset, auth=auth,
-                                               timeout=timeout)
+            local_path = _progress_urlretrieve(
+                www_path, cache_name=cache_name, reset=reset, auth=auth, timeout=timeout
+            )
             # if no error, exit
             break
         except HttpDownloadError as err:
@@ -515,24 +554,30 @@ def file_downloader(www_path, retry_max=3, sleep_on_retry=5,
                 # Ok so this *should* be an ocean tile
                 return None
             elif err.code >= 500 and err.code < 600:
-                logger.info(f"Downloading {www_path} failed with "
-                            f"HTTP error {err.code}, "
-                            f"retrying in {sleep_on_retry} seconds... "
-                            f"{retry_counter}/{retry_max}")
+                logger.info(
+                    f"Downloading {www_path} failed with "
+                    f"HTTP error {err.code}, "
+                    f"retrying in {sleep_on_retry} seconds... "
+                    f"{retry_counter}/{retry_max}"
+                )
                 time.sleep(sleep_on_retry)
                 continue
             else:
                 raise
         except HttpContentTooShortError as err:
-            logger.info("Downloading %s failed with ContentTooShortError"
-                        " error %s, retrying in %s seconds... %s/%s" %
-                        (www_path, err.code, sleep_on_retry, retry_counter, retry_max))
+            logger.info(
+                "Downloading %s failed with ContentTooShortError"
+                " error %s, retrying in %s seconds... %s/%s"
+                % (www_path, err.code, sleep_on_retry, retry_counter, retry_max)
+            )
             time.sleep(sleep_on_retry)
             continue
         except DownloadVerificationFailedException as err:
-            if (cfg.PATHS['dl_cache_dir'] and
-                  err.path.startswith(cfg.PATHS['dl_cache_dir']) and
-                  cfg.PARAMS['dl_cache_readonly']):
+            if (
+                cfg.PATHS["dl_cache_dir"]
+                and err.path.startswith(cfg.PATHS["dl_cache_dir"])
+                and cfg.PARAMS["dl_cache_readonly"]
+            ):
                 if not cache_name:
                     cache_name = _get_url_cache_name(www_path)
                 cache_name = "GLOBAL_CACHE_INVALID/" + cache_name
@@ -543,45 +588,42 @@ def file_downloader(www_path, retry_max=3, sleep_on_retry=5,
                     os.remove(err.path)
                 except FileNotFoundError:
                     pass
-                logger.info("Downloading %s failed with "
-                            "DownloadVerificationFailedException\n %s\n"
-                            "The file might have changed or is corrupted. "
-                            "File deleted. Re-downloading... %s/%s" %
-                            (www_path, err.msg, retry_counter, retry_max))
+                logger.info(
+                    "Downloading %s failed with "
+                    "DownloadVerificationFailedException\n %s\n"
+                    "The file might have changed or is corrupted. "
+                    "File deleted. Re-downloading... %s/%s"
+                    % (www_path, err.msg, retry_counter, retry_max)
+                )
             continue
         except requests.ConnectionError as err:
-            if err.args[0].__class__.__name__ == 'MaxRetryError':
+            if err.args[0].__class__.__name__ == "MaxRetryError":
                 # if request tried often enough we don't have to do this
                 # this error does happen for not existing ASTERv3 files
                 return None
             else:
                 # in other cases: try again
-                logger.info("Downloading %s failed with ConnectionError, "
-                            "retrying in %s seconds... %s/%s" %
-                            (www_path, sleep_on_retry, retry_counter, retry_max))
+                logger.info(
+                    "Downloading %s failed with ConnectionError, "
+                    "retrying in %s seconds... %s/%s"
+                    % (www_path, sleep_on_retry, retry_counter, retry_max)
+                )
                 time.sleep(sleep_on_retry)
                 continue
         except FTPSDownloadError as err:
-            logger.info("Downloading %s failed with FTPSDownloadError"
-                        " error: '%s', retrying in %s seconds... %s/%s" %
-                        (www_path, err.orgerr, sleep_on_retry, retry_counter, retry_max))
+            logger.info(
+                "Downloading %s failed with FTPSDownloadError"
+                " error: '%s', retrying in %s seconds... %s/%s"
+                % (www_path, err.orgerr, sleep_on_retry, retry_counter, retry_max)
+            )
             time.sleep(sleep_on_retry)
             continue
 
     # See if we managed (fail is allowed)
     if not local_path or not os.path.exists(local_path):
-        logger.warning('Downloading %s failed.' % www_path)
+        logger.warning("Downloading %s failed." % www_path)
 
     return local_path
-
-
-def locked_func(func):
-    """To decorate a function that needs to be locked for multiprocessing"""
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        with get_lock():
-            return func(*args, **kwargs)
-    return wrapper
 
 
 def file_extractor(file_path):
@@ -590,76 +632,76 @@ def file_extractor(file_path):
     filename, file_extension = os.path.splitext(file_path)
     # Second one for tar.gz files
     f2, ex2 = os.path.splitext(filename)
-    if ex2 == '.tar':
-        filename, file_extension = f2, '.tar.gz'
+    if ex2 == ".tar":
+        filename, file_extension = f2, ".tar.gz"
     bname = os.path.basename(file_path)
 
     # This is to give a unique name to the tmp file
-    hid = hashlib.md5(file_path.encode()).hexdigest()[:7] + '_'
+    hid = hashlib.md5(file_path.encode()).hexdigest()[:7] + "_"
 
     # extract directory
-    tmpdir = cfg.PATHS['tmp_dir']
+    tmpdir = cfg.PATHS["tmp_dir"]
     mkdir(tmpdir)
 
     # Check output extension
     def _check_ext(f):
         _, of_ext = os.path.splitext(f)
-        if of_ext not in ['.nc', '.tif']:
-            raise InvalidParamsError('Extracted file extension not recognized'
-                                     ': {}'.format(of_ext))
+        if of_ext not in [".nc", ".tif"]:
+            raise InvalidParamsError(
+                "Extracted file extension not recognized: {}".format(of_ext)
+            )
         return of_ext
 
-    if file_extension == '.zip':
+    if file_extension == ".zip":
         with zipfile.ZipFile(file_path) as zf:
             members = zf.namelist()
             if len(members) != 1:
-                raise RuntimeError('Cannot extract multiple files')
+                raise RuntimeError("Cannot extract multiple files")
             o_name = hid + members[0]
             o_path = os.path.join(tmpdir, o_name)
             of_ext = _check_ext(o_path)
             if not os.path.exists(o_path):
-                logger.info('Extracting {} to {}...'.format(bname, o_path))
-                with open(o_path, 'wb') as f:
+                logger.info("Extracting {} to {}...".format(bname, o_path))
+                with open(o_path, "wb") as f:
                     f.write(zf.read(members[0]))
-    elif file_extension == '.gz':
+    elif file_extension == ".gz":
         # Gzip files cannot be inspected. It's always only one file
         # Decide on its name
         o_name = hid + os.path.basename(filename)
         o_path = os.path.join(tmpdir, o_name)
         of_ext = _check_ext(o_path)
         if not os.path.exists(o_path):
-            logger.info('Extracting {} to {}...'.format(bname, o_path))
+            logger.info("Extracting {} to {}...".format(bname, o_path))
             with gzip.GzipFile(file_path) as zf:
-                with open(o_path, 'wb') as outfile:
+                with open(o_path, "wb") as outfile:
                     for line in zf:
                         outfile.write(line)
-    elif file_extension == '.bz2':
+    elif file_extension == ".bz2":
         # bzip2 files cannot be inspected. It's always only one file
         # Decide on its name
         o_name = hid + os.path.basename(filename)
         o_path = os.path.join(tmpdir, o_name)
         of_ext = _check_ext(o_path)
         if not os.path.exists(o_path):
-            logger.info('Extracting {} to {}...'.format(bname, o_path))
+            logger.info("Extracting {} to {}...".format(bname, o_path))
             with bz2.open(file_path) as zf:
-                with open(o_path, 'wb') as outfile:
+                with open(o_path, "wb") as outfile:
                     for line in zf:
                         outfile.write(line)
-    elif file_extension in ['.tar.gz', '.tar']:
+    elif file_extension in [".tar.gz", ".tar"]:
         with tarfile.open(file_path) as zf:
             members = zf.getmembers()
             if len(members) != 1:
-                raise RuntimeError('Cannot extract multiple files')
+                raise RuntimeError("Cannot extract multiple files")
             o_name = hid + members[0].name
             o_path = os.path.join(tmpdir, o_name)
             of_ext = _check_ext(o_path)
             if not os.path.exists(o_path):
-                logger.info('Extracting {} to {}...'.format(bname, o_path))
-                with open(o_path, 'wb') as f:
+                logger.info("Extracting {} to {}...".format(bname, o_path))
+                with open(o_path, "wb") as f:
                     f.write(zf.extractfile(members[0]).read())
     else:
-        raise InvalidParamsError('Extension not recognized: '
-                                 '{}'.format(file_extension))
+        raise InvalidParamsError("Extension not recognized: {}".format(file_extension))
 
     # Be sure we don't overfill the folder
     cfg.get_lru_handler(tmpdir, ending=of_ext).append(o_path)
@@ -668,7 +710,7 @@ def file_extractor(file_path):
 
 
 def download_with_authentication(wwwfile, key):
-    """ Uses credentials from a local .netrc file to download files
+    """Uses credentials from a local .netrc file to download files
 
     Parameters
     ----------
@@ -692,41 +734,54 @@ def download_with_authentication(wwwfile, key):
 
     # Grab auth parameters
     if not dest_file:
-        authfile = os.path.expanduser('~/.netrc')
+        authfile = os.path.expanduser("~/.netrc")
 
         if not os.path.isfile(authfile):
             raise DownloadCredentialsMissingException(
-                (authfile, ' does not exist. Add necessary credentials for ',
-                 key, ' with `oggm_netrc_credentials. You may have to ',
-                 'register at the respective service first.'))
+                (
+                    authfile,
+                    " does not exist. Add necessary credentials for ",
+                    key,
+                    " with `oggm_netrc_credentials. You may have to ",
+                    "register at the respective service first.",
+                )
+            )
 
         try:
             netrc(authfile).authenticators(key)[0]
         except TypeError:
             raise DownloadCredentialsMissingException(
-                ('Credentials for ', key, ' are not in ', authfile, '. Add ',
-                 'credentials for with `oggm_netrc_credentials`.'))
+                (
+                    "Credentials for ",
+                    key,
+                    " are not in ",
+                    authfile,
+                    ". Add ",
+                    "credentials for with `oggm_netrc_credentials`.",
+                )
+            )
 
         dest_file = file_downloader(
-            wwwfile, auth=(netrc(authfile).authenticators(key)[0],
-                           netrc(authfile).authenticators(key)[2]))
+            wwwfile,
+            auth=(
+                netrc(authfile).authenticators(key)[0],
+                netrc(authfile).authenticators(key)[2],
+            ),
+        )
 
     return dest_file
 
 
+@locked_func
 def download_oggm_files():
-    with get_lock():
-        return _download_oggm_files_unlocked()
-
-
-def _download_oggm_files_unlocked():
     """Checks if the demo data is already on the cache and downloads it."""
 
-    zip_url = 'https://github.com/%s/archive/%s.zip' % \
-              (SAMPLE_DATA_GH_REPO, SAMPLE_DATA_COMMIT)
+    zip_url = "https://github.com/%s/archive/%s.zip" % (
+        SAMPLE_DATA_GH_REPO,
+        SAMPLE_DATA_COMMIT,
+    )
     odir = os.path.join(cfg.CACHE_DIR)
-    sdir = os.path.join(cfg.CACHE_DIR,
-                        'oggm-sample-data-%s' % SAMPLE_DATA_COMMIT)
+    sdir = os.path.join(cfg.CACHE_DIR, "oggm-sample-data-%s" % SAMPLE_DATA_COMMIT)
 
     # download only if necessary
     if not os.path.exists(sdir):
@@ -751,27 +806,24 @@ def _download_oggm_files_unlocked():
     return out
 
 
+@locked_func
 def _download_srtm_file(zone):
-    with get_lock():
-        return _download_srtm_file_unlocked(zone)
-
-
-def _download_srtm_file_unlocked(zone):
-    """Checks if the srtm data is in the directory and if not, download it.
-    """
+    """Checks if the srtm data is in the directory and if not, download it."""
 
     # extract directory
-    tmpdir = cfg.PATHS['tmp_dir']
+    tmpdir = cfg.PATHS["tmp_dir"]
     mkdir(tmpdir)
-    outpath = os.path.join(tmpdir, 'srtm_' + zone + '.tif')
+    outpath = os.path.join(tmpdir, "srtm_" + zone + ".tif")
 
     # check if extracted file exists already
     if os.path.exists(outpath):
         return outpath
 
     # Did we download it yet?
-    wwwfile = ('http://srtm.csi.cgiar.org/wp-content/uploads/files/srtm_5x5/'
-               'TIFF/srtm_' + zone + '.zip')
+    wwwfile = (
+        "http://srtm.csi.cgiar.org/wp-content/uploads/files/srtm_5x5/"
+        "TIFF/srtm_" + zone + ".zip"
+    )
     dest_file = file_downloader(wwwfile)
 
     # None means we tried hard but we couldn't find it
@@ -789,21 +841,18 @@ def _download_srtm_file_unlocked(zone):
     return outpath
 
 
+@locked_func
 def _download_nasadem_file(zone):
-    with get_lock():
-        return _download_nasadem_file_unlocked(zone)
-
-
-def _download_nasadem_file_unlocked(zone):
-    """Checks if the NASADEM data is in the directory and if not, download it.
-    """
+    """Checks if the NASADEM data is in the directory and if not, download it."""
 
     # extract directory
-    tmpdir = cfg.PATHS['tmp_dir']
+    tmpdir = cfg.PATHS["tmp_dir"]
     mkdir(tmpdir)
-    wwwfile = ('https://e4ftl01.cr.usgs.gov/MEASURES/NASADEM_HGT.001/'
-               '2000.02.11/NASADEM_HGT_{}.zip'.format(zone))
-    demfile = '{}.hgt'.format(zone)
+    wwwfile = (
+        "https://e4ftl01.cr.usgs.gov/MEASURES/NASADEM_HGT.001/"
+        "2000.02.11/NASADEM_HGT_{}.zip".format(zone)
+    )
+    demfile = "{}.hgt".format(zone)
     outpath = os.path.join(tmpdir, demfile)
 
     # check if extracted file exists already
@@ -828,28 +877,22 @@ def _download_nasadem_file_unlocked(zone):
     return outpath
 
 
+@locked_func
 def _download_tandem_file(zone):
-    with get_lock():
-        return _download_tandem_file_unlocked(zone)
-
-
-def _download_tandem_file_unlocked(zone):
-    """Checks if the tandem data is in the directory and if not, download it.
-    """
+    """Checks if the tandem data is in the directory and if not, download it."""
 
     # extract directory
-    tmpdir = cfg.PATHS['tmp_dir']
+    tmpdir = cfg.PATHS["tmp_dir"]
     mkdir(tmpdir)
-    bname = zone.split('/')[-1] + '_DEM.tif'
-    wwwfile = ('https://download.geoservice.dlr.de/TDM90/files/DEM/'
-               '{}.zip'.format(zone))
+    bname = zone.split("/")[-1] + "_DEM.tif"
+    wwwfile = "https://download.geoservice.dlr.de/TDM90/files/DEM/{}.zip".format(zone)
     outpath = os.path.join(tmpdir, bname)
 
     # check if extracted file exists already
     if os.path.exists(outpath):
         return outpath
 
-    dest_file = download_with_authentication(wwwfile, 'geoservice.dlr.de')
+    dest_file = download_with_authentication(wwwfile, "geoservice.dlr.de")
 
     # That means we tried hard but we couldn't find it
     if not dest_file:
@@ -863,9 +906,9 @@ def _download_tandem_file_unlocked(zone):
     if not os.path.exists(outpath):
         with zipfile.ZipFile(dest_file) as zf:
             for fn in zf.namelist():
-                if 'DEM/' + bname in fn:
+                if "DEM/" + bname in fn:
                     break
-            with open(outpath, 'wb') as fo:
+            with open(outpath, "wb") as fo:
                 fo.write(zf.read(fn))
 
     # See if we're good, don't overfill the tmp directory
@@ -874,20 +917,15 @@ def _download_tandem_file_unlocked(zone):
     return outpath
 
 
+@locked_func
 def _download_dem3_viewpano(zone):
-    with get_lock():
-        return _download_dem3_viewpano_unlocked(zone)
-
-
-def _download_dem3_viewpano_unlocked(zone):
-    """Checks if the DEM3 data is in the directory and if not, download it.
-    """
+    """Checks if the DEM3 data is in the directory and if not, download it."""
 
     # extract directory
-    tmpdir = cfg.PATHS['tmp_dir']
+    tmpdir = cfg.PATHS["tmp_dir"]
     mkdir(tmpdir)
-    outpath = os.path.join(tmpdir, zone + '.tif')
-    extract_dir = os.path.join(tmpdir, 'tmp_' + zone)
+    outpath = os.path.join(tmpdir, zone + ".tif")
+    extract_dir = os.path.join(tmpdir, "tmp_" + zone)
     mkdir(extract_dir, reset=True)
 
     # check if extracted file exists already
@@ -896,17 +934,44 @@ def _download_dem3_viewpano_unlocked(zone):
 
     # OK, so see if downloaded already
     # some files have a newer version 'v2'
-    if zone in ['R33', 'R34', 'R35', 'R36', 'R37', 'R38', 'Q32', 'Q33', 'Q34',
-                'Q35', 'Q36', 'Q37', 'Q38', 'Q39', 'Q40', 'P31', 'P32', 'P33',
-                'P34', 'P35', 'P36', 'P37', 'P38', 'P39', 'P40']:
-        ifile = 'http://viewfinderpanoramas.org/dem3/' + zone + 'v2.zip'
+    if zone in [
+        "R33",
+        "R34",
+        "R35",
+        "R36",
+        "R37",
+        "R38",
+        "Q32",
+        "Q33",
+        "Q34",
+        "Q35",
+        "Q36",
+        "Q37",
+        "Q38",
+        "Q39",
+        "Q40",
+        "P31",
+        "P32",
+        "P33",
+        "P34",
+        "P35",
+        "P36",
+        "P37",
+        "P38",
+        "P39",
+        "P40",
+    ]:
+        ifile = "http://viewfinderpanoramas.org/dem3/" + zone + "v2.zip"
     elif zone in DEM3REG.keys():
         # We prepared these files as tif already
-        ifile = ('https://cluster.klima.uni-bremen.de/~oggm/dem/'
-                 'DEM3_MERGED/{}.tif'.format(zone))
+        ifile = (
+            "https://cluster.klima.uni-bremen.de/~oggm/dem/DEM3_MERGED/{}.tif".format(
+                zone
+            )
+        )
         return file_downloader(ifile)
     else:
-        ifile = 'http://viewfinderpanoramas.org/dem3/' + zone + '.zip'
+        ifile = "http://viewfinderpanoramas.org/dem3/" + zone + ".zip"
 
     dfile = file_downloader(ifile)
 
@@ -924,20 +989,19 @@ def _download_dem3_viewpano_unlocked(zone):
     # BUT: There are southern hemisphere files that download properly. However,
     # the unzipped folder has the file name of
     # the northern hemisphere file. Some checks if correct file exists:
-    if len(zone) == 4 and zone.startswith('S'):
+    if len(zone) == 4 and zone.startswith("S"):
         zonedir = os.path.join(extract_dir, zone[1:])
     else:
         zonedir = os.path.join(extract_dir, zone)
-    globlist = glob.glob(os.path.join(zonedir, '*.hgt'))
+    globlist = glob.glob(os.path.join(zonedir, "*.hgt"))
 
     # take care of the special file naming cases
     if zone in DEM3REG.keys():
-        globlist = glob.glob(os.path.join(extract_dir, '*', '*.hgt'))
+        globlist = glob.glob(os.path.join(extract_dir, "*", "*.hgt"))
 
     if not globlist:
         # Final resort
-        globlist = (findfiles(extract_dir, '.hgt') or
-                    findfiles(extract_dir, '.HGT'))
+        globlist = findfiles(extract_dir, ".hgt") or findfiles(extract_dir, ".HGT")
         if not globlist:
             raise RuntimeError("We should have some files here, but we don't")
 
@@ -946,13 +1010,13 @@ def _download_dem3_viewpano_unlocked(zone):
     rfiles = [rasterio.open(s) for s in globlist]
     dest, output_transform = merge_tool(rfiles)
     profile = rfiles[0].profile
-    if 'affine' in profile:
-        profile.pop('affine')
-    profile['transform'] = output_transform
-    profile['height'] = dest.shape[1]
-    profile['width'] = dest.shape[2]
-    profile['driver'] = 'GTiff'
-    with rasterio.open(outpath, 'w', **profile) as dst:
+    if "affine" in profile:
+        profile.pop("affine")
+    profile["transform"] = output_transform
+    profile["height"] = dest.shape[1]
+    profile["width"] = dest.shape[2]
+    profile["driver"] = "GTiff"
+    with rasterio.open(outpath, "w", **profile) as dst:
         dst.write(dest)
     for rf in rfiles:
         rf.close()
@@ -968,28 +1032,24 @@ def _download_dem3_viewpano_unlocked(zone):
     return outpath
 
 
+@locked_func
 def _download_aster_file(zone):
-    with get_lock():
-        return _download_aster_file_unlocked(zone)
-
-
-def _download_aster_file_unlocked(zone):
-    """Checks if the ASTER data is in the directory and if not, download it.
-    """
+    """Checks if the ASTER data is in the directory and if not, download it."""
 
     # extract directory
-    tmpdir = cfg.PATHS['tmp_dir']
+    tmpdir = cfg.PATHS["tmp_dir"]
     mkdir(tmpdir)
-    wwwfile = ('https://e4ftl01.cr.usgs.gov/ASTT/ASTGTM.003/'
-               '2000.03.01/{}.zip'.format(zone))
-    outpath = os.path.join(tmpdir, zone + '_dem.tif')
+    wwwfile = "https://e4ftl01.cr.usgs.gov/ASTT/ASTGTM.003/2000.03.01/{}.zip".format(
+        zone
+    )
+    outpath = os.path.join(tmpdir, zone + "_dem.tif")
 
     # check if extracted file exists already
     if os.path.exists(outpath):
         return outpath
 
     # download from NASA Earthdata with credentials
-    dest_file = download_with_authentication(wwwfile, 'urs.earthdata.nasa.gov')
+    dest_file = download_with_authentication(wwwfile, "urs.earthdata.nasa.gov")
 
     # That means we tried hard but we couldn't find it
     if not dest_file:
@@ -1006,27 +1066,23 @@ def _download_aster_file_unlocked(zone):
     return outpath
 
 
+@locked_func
 def _download_topo_file_from_cluster(fname):
-    with get_lock():
-        return _download_topo_file_from_cluster_unlocked(fname)
-
-
-def _download_topo_file_from_cluster_unlocked(fname):
     """Checks if the special topo data is in the directory and if not,
     download it from the cluster.
     """
 
     # extract directory
-    tmpdir = cfg.PATHS['tmp_dir']
+    tmpdir = cfg.PATHS["tmp_dir"]
     mkdir(tmpdir)
     outpath = os.path.join(tmpdir, fname)
 
-    url = 'https://cluster.klima.uni-bremen.de/data/dems/'
-    url += fname + '.zip'
+    url = "https://cluster.klima.uni-bremen.de/data/dems/"
+    url += fname + ".zip"
     dfile = file_downloader(url)
 
     if not os.path.exists(outpath):
-        logger.info('Extracting ' + fname + '.zip to ' + outpath + '...')
+        logger.info("Extracting " + fname + ".zip to " + outpath + "...")
         with zipfile.ZipFile(dfile) as zf:
             zf.extractall(tmpdir)
 
@@ -1036,14 +1092,9 @@ def _download_topo_file_from_cluster_unlocked(fname):
     return outpath
 
 
+@locked_func
 def _download_copdem_file(tileurl):
-    with get_lock():
-        return _download_copdem_file_unlocked(tileurl)
-
-
-def _download_copdem_file_unlocked(tileurl):
-    """Checks if Copernicus DEM file is in the directory, if not download it.
-    """
+    """Checks if Copernicus DEM file is in the directory, if not download it."""
     if not tileurl:
         return None
     dest_file = file_downloader(tileurl)
@@ -1053,30 +1104,28 @@ def _download_copdem_file_unlocked(tileurl):
     return dest_file
 
 
-def _download_aw3d30_file(zone):
-    with get_lock():
-        return _download_aw3d30_file_unlocked(zone)
-
-
-def _download_aw3d30_file_unlocked(fullzone):
-    """Checks if the AW3D30 data is in the directory and if not, download it.
-    """
+@locked_func
+def _download_aw3d30_file(fullzone):
+    """Checks if the AW3D30 data is in the directory and if not, download it."""
 
     # extract directory
-    tmpdir = cfg.PATHS['tmp_dir']
+    tmpdir = cfg.PATHS["tmp_dir"]
     mkdir(tmpdir)
 
     # tarfiles are extracted in directories per each tile
-    tile = fullzone.split('/')[1]
-    demfile = os.path.join(tmpdir, tile, tile + '_AVE_DSM.tif')
+    tile = fullzone.split("/")[1]
+    demfile = os.path.join(tmpdir, tile, tile + "_AVE_DSM.tif")
 
     # check if extracted file exists already
     if os.path.exists(demfile):
         return demfile
 
     # Did we download it yet?
-    ftpfile = ('ftp://ftp.eorc.jaxa.jp/pub/ALOS/ext1/AW3D30/release_v1804/'
-               + fullzone + '.tar.gz')
+    ftpfile = (
+        "ftp://ftp.eorc.jaxa.jp/pub/ALOS/ext1/AW3D30/release_v1804/"
+        + fullzone
+        + ".tar.gz"
+    )
     try:
         dest_file = file_downloader(ftpfile, timeout=180)
     except urllib.error.URLError:
@@ -1090,6 +1139,7 @@ def _download_aw3d30_file_unlocked(fullzone):
     # ok we have to extract it
     if not os.path.exists(demfile):
         from oggm.utils import robust_tar_extract
+
         dempath = os.path.dirname(demfile)
         robust_tar_extract(dest_file, dempath)
 
@@ -1101,66 +1151,62 @@ def _download_aw3d30_file_unlocked(fullzone):
     return demfile
 
 
+@locked_func
 def _download_mapzen_file(zone):
-    with get_lock():
-        return _download_mapzen_file_unlocked(zone)
-
-
-def _download_mapzen_file_unlocked(zone):
-    """Checks if the mapzen data is in the directory and if not, download it.
-    """
-    bucket = 'elevation-tiles-prod'
-    prefix = 'geotiff'
-    url = 'http://s3.amazonaws.com/%s/%s/%s' % (bucket, prefix, zone)
+    """Checks if the mapzen data is in the directory and if not, download it."""
+    bucket = "elevation-tiles-prod"
+    prefix = "geotiff"
+    url = "http://s3.amazonaws.com/%s/%s/%s" % (bucket, prefix, zone)
 
     # That's all
     return file_downloader(url, timeout=180)
 
 
-def get_prepro_gdir(rgi_version, rgi_id, border, prepro_level, base_url=None):
-    with get_lock():
-        return _get_prepro_gdir_unlocked(rgi_version, rgi_id, border,
-                                         prepro_level, base_url=base_url)
-
-
-def get_prepro_base_url(base_url=None, rgi_version=None, border=None,
-                        prepro_level=None):
+def get_prepro_base_url(
+    base_url=None, rgi_version=None, border=None, prepro_level=None
+):
     """Extended base url where to find the desired gdirs."""
 
     if base_url is None:
-        raise InvalidParamsError('Starting with v1.6, users now have to '
-                                 'explicitly indicate the url they want '
-                                 'to start from.')
+        raise InvalidParamsError(
+            "Starting with v1.6, users now have to "
+            "explicitly indicate the url they want "
+            "to start from."
+        )
 
-    if not base_url.endswith('/'):
-        base_url += '/'
+    if not base_url.endswith("/"):
+        base_url += "/"
 
     if rgi_version is None:
-        rgi_version = cfg.PARAMS['rgi_version']
+        rgi_version = cfg.PARAMS["rgi_version"]
 
     if border is None:
-        border = cfg.PARAMS['border']
+        border = cfg.PARAMS["border"]
 
     url = base_url
-    url += 'RGI{}/'.format(rgi_version)
-    url += 'b_{:03d}/'.format(int(border))
-    url += 'L{:d}/'.format(prepro_level)
+    url += "RGI{}/".format(rgi_version)
+    url += "b_{:03d}/".format(int(border))
+    url += "L{:d}/".format(prepro_level)
     return url
 
 
-def _get_prepro_gdir_unlocked(rgi_version, rgi_id, border, prepro_level,
-                              base_url=None):
+@locked_func
+def get_prepro_gdir(rgi_version, rgi_id, border, prepro_level, base_url=None):
 
-    url = get_prepro_base_url(rgi_version=rgi_version, border=border,
-                              prepro_level=prepro_level, base_url=base_url)
+    url = get_prepro_base_url(
+        rgi_version=rgi_version,
+        border=border,
+        prepro_level=prepro_level,
+        base_url=base_url,
+    )
     if len(rgi_id) == 23:
         # RGI7
-        url += '{}/{}.tar'.format(rgi_id[:17], rgi_id[:20])
+        url += "{}/{}.tar".format(rgi_id[:17], rgi_id[:20])
     else:
-        url += '{}/{}.tar'.format(rgi_id[:8], rgi_id[:11])
+        url += "{}/{}.tar".format(rgi_id[:8], rgi_id[:11])
     tar_base = file_downloader(url)
     if tar_base is None:
-        raise RuntimeError('Could not find file at ' + url)
+        raise RuntimeError("Could not find file at " + url)
 
     return tar_base
 
@@ -1187,12 +1233,12 @@ def get_geodetic_mb_dataframe(file_path=None, regional=False):
 
     # fetch the file online or read custom file
     if file_path is None:
-        base_url = 'https://cluster.klima.uni-bremen.de/~oggm/geodetic_ref_mb/'
+        base_url = "https://cluster.klima.uni-bremen.de/~oggm/geodetic_ref_mb/"
         if regional:
-            file_name = 'hugonnet_2021_regional_avg.csv'
+            file_name = "hugonnet_2021_regional_avg.csv"
             file_path = file_downloader(base_url + file_name)
         else:
-            file_name = 'hugonnet_2021_ds_rgi60_pergla_rates_10_20_worldwide_filled.hdf'
+            file_name = "hugonnet_2021_ds_rgi60_pergla_rates_10_20_worldwide_filled.hdf"
             file_path = file_downloader(base_url + file_name)
 
     # Did we open it yet?
@@ -1201,22 +1247,24 @@ def get_geodetic_mb_dataframe(file_path=None, regional=False):
 
     # If not let's go
     extension = os.path.splitext(file_path)[1]
-    if extension == '.csv':
+    if extension == ".csv":
         df = pd.read_csv(file_path)
-    elif extension == '.hdf':
+    elif extension == ".hdf":
         df = pd.read_hdf(file_path)
 
     # Check for missing data (old files)
-    if len(df.loc[df['dmdtda'].isnull()]) > 0:
-        raise InvalidParamsError('The reference file you are using has missing '
-                                 'data and is probably outdated (sorry for '
-                                 'that). Delete the file at '
-                                 f'{file_path} and start again.')
+    if len(df.loc[df["dmdtda"].isnull()]) > 0:
+        raise InvalidParamsError(
+            "The reference file you are using has missing "
+            "data and is probably outdated (sorry for "
+            "that). Delete the file at "
+            f"{file_path} and start again."
+        )
     cfg.DATA[file_path] = df
     return df
 
 
-def get_temp_bias_dataframe(dataset, regional=False, rgi_version='62'):
+def get_temp_bias_dataframe(dataset, regional=False, rgi_version="62"):
     """Fetches the temperature bias dataframe.
 
     The dataframe was created by the OGGM>=v16 pre-calibration
@@ -1239,25 +1287,29 @@ def get_temp_bias_dataframe(dataset, regional=False, rgi_version='62'):
     a DataFrame with the data.
     """
 
-    if dataset not in ['w5e5', 'era5']:
-        raise NotImplementedError(f'No such dataset available yet: {dataset}')
-    if rgi_version == '60':
-        rgi_version = '62'
-    if rgi_version not in ['62', '70G', '70C']:
-        raise NotImplementedError(f'RGI version not available yet: {rgi_version}')
+    if dataset not in ["w5e5", "era5"]:
+        raise NotImplementedError(f"No such dataset available yet: {dataset}")
+    if rgi_version == "60":
+        rgi_version = "62"
+    if rgi_version not in ["62", "70G", "70C"]:
+        raise NotImplementedError(f"RGI version not available yet: {rgi_version}")
 
     # fetch the file online
-    base_url = 'https://cluster.klima.uni-bremen.de/~oggm/ref_mb_params/oggm_v1.6/'
-    calibtype = 'regional' if regional else 'perglacier'
-    if rgi_version in ['70G', '70C']:
-        file_version = '1'
-    if rgi_version == '62':
-        file_version = '3' if regional else '2'
-        rgi_version = '6'
-    if dataset == 'w5e5':
-        base_url += f'w5e5_rgi{rgi_version}_{calibtype}_temp_bias_v2025.6.{file_version}.csv'
-    if dataset == 'era5':
-        base_url += f'era5_rgi{rgi_version}_{calibtype}_temp_bias_v2025.6.{file_version}.csv'
+    base_url = "https://cluster.klima.uni-bremen.de/~oggm/ref_mb_params/oggm_v1.6/"
+    calibtype = "regional" if regional else "perglacier"
+    if rgi_version in ["70G", "70C"]:
+        file_version = "1"
+    if rgi_version == "62":
+        file_version = "3" if regional else "2"
+        rgi_version = "6"
+    if dataset == "w5e5":
+        base_url += (
+            f"w5e5_rgi{rgi_version}_{calibtype}_temp_bias_v2025.6.{file_version}.csv"
+        )
+    if dataset == "era5":
+        base_url += (
+            f"era5_rgi{rgi_version}_{calibtype}_temp_bias_v2025.6.{file_version}.csv"
+        )
 
     file_path = file_downloader(base_url)
 
@@ -1267,9 +1319,9 @@ def get_temp_bias_dataframe(dataset, regional=False, rgi_version='62'):
 
     # If not let's go
     extension = os.path.splitext(file_path)[1]
-    if extension == '.csv':
+    if extension == ".csv":
         df = pd.read_csv(file_path, index_col=0)
-    elif extension == '.hdf':
+    elif extension == ".hdf":
         df = pd.read_hdf(file_path)
 
     cfg.DATA[file_path] = df
@@ -1277,14 +1329,13 @@ def get_temp_bias_dataframe(dataset, regional=False, rgi_version='62'):
 
 
 def srtm_zone(lon_ex, lat_ex):
-    """Returns a list of SRTM zones covering the desired extent.
-    """
+    """Returns a list of SRTM zones covering the desired extent."""
 
     # SRTM are sorted in tiles of 5 degrees
-    srtm_x0 = -180.
-    srtm_y0 = 60.
-    srtm_dx = 5.
-    srtm_dy = -5.
+    srtm_x0 = -180.0
+    srtm_y0 = 60.0
+    srtm_dx = 5.0
+    srtm_dy = -5.0
 
     # quick n dirty solution to be sure that we will cover the whole range
     mi, ma = np.min(lon_ex), np.max(lon_ex)
@@ -1303,7 +1354,7 @@ def srtm_zone(lon_ex, lat_ex):
                 continue
             zx = np.ceil(dx / srtm_dx)
             zy = np.ceil(dy / srtm_dy)
-            zones.append('{:02.0f}_{:02.0f}'.format(zx, zy))
+            zones.append("{:02.0f}_{:02.0f}".format(zx, zy))
     return list(sorted(set(zones)))
 
 
@@ -1313,37 +1364,34 @@ def _tandem_path(lon_tile, lat_tile):
     # This changed in December 2022
 
     # First folder level is sorted from S to N
-    level_0 = 'S' if lat_tile < 0 else 'N'
-    level_0 += '{:02d}'.format(abs(lat_tile))
+    level_0 = "S" if lat_tile < 0 else "N"
+    level_0 += "{:02d}".format(abs(lat_tile))
 
     # Second folder level is sorted from W to E, but in 10 steps
-    level_1 = 'W' if lon_tile < 0 else 'E'
-    level_1 += '{:03d}'.format(divmod(abs(lon_tile), 10)[0] * 10)
+    level_1 = "W" if lon_tile < 0 else "E"
+    level_1 += "{:03d}".format(divmod(abs(lon_tile), 10)[0] * 10)
 
     # Level 2 is formatting, but depends on lat
-    level_2 = 'W' if lon_tile < 0 else 'E'
+    level_2 = "W" if lon_tile < 0 else "E"
     if abs(lat_tile) <= 60:
-        level_2 += '{:03d}'.format(abs(lon_tile))
+        level_2 += "{:03d}".format(abs(lon_tile))
     elif abs(lat_tile) <= 80:
-        level_2 += '{:03d}'.format(divmod(abs(lon_tile), 2)[0] * 2)
+        level_2 += "{:03d}".format(divmod(abs(lon_tile), 2)[0] * 2)
     else:
-        level_2 += '{:03d}'.format(divmod(abs(lon_tile), 4)[0] * 4)
+        level_2 += "{:03d}".format(divmod(abs(lon_tile), 4)[0] * 4)
 
     # Final path
-    out = (level_0 + '/' + level_1 + '/' +
-           'TDM1_DEM__30_{}{}'.format(level_0, level_2))
+    out = level_0 + "/" + level_1 + "/" + "TDM1_DEM__30_{}{}".format(level_0, level_2)
     return out
 
 
 def tandem_zone(lon_ex, lat_ex):
-    """Returns a list of TanDEM-X zones covering the desired extent.
-    """
+    """Returns a list of TanDEM-X zones covering the desired extent."""
 
     # Files are one by one tiles, so lets loop over them
     # For higher lats they are stored in steps of 2 and 4. My code below
     # is probably giving more files than needed but better safe than sorry
-    lat_tiles = np.arange(np.floor(lat_ex[0]), np.ceil(lat_ex[1]+1e-9),
-                          dtype=int)
+    lat_tiles = np.arange(np.floor(lat_ex[0]), np.ceil(lat_ex[1] + 1e-9), dtype=int)
     zones = []
     for lat in lat_tiles:
         if abs(lat) < 60:
@@ -1355,7 +1403,7 @@ def tandem_zone(lon_ex, lat_ex):
         elif abs(lat) < 90:
             l0 = divmod(lon_ex[0], 4)[0] * 4
             l1 = divmod(lon_ex[1], 4)[0] * 4
-        lon_tiles = np.arange(l0, l1+1, dtype=int)
+        lon_tiles = np.arange(l0, l1 + 1, dtype=int)
         for lon in lon_tiles:
             zones.append(_tandem_path(lon, lat))
     return list(sorted(set(zones)))
@@ -1374,30 +1422,27 @@ def _aw3d30_path(lon_tile, lat_tile):
     # e.g. W095 contains W091 - W095
 
     # get letters
-    ns = 'S' if lat_tile < 0 else 'N'
-    ew = 'W' if lon_tile < 0 else 'E'
+    ns = "S" if lat_tile < 0 else "N"
+    ew = "W" if lon_tile < 0 else "E"
 
     # get lat/lon
-    lon = abs(5 * np.floor(lon_tile/5))
-    lat = abs(5 * np.floor(lat_tile/5))
+    lon = abs(5 * np.floor(lon_tile / 5))
+    lat = abs(5 * np.floor(lat_tile / 5))
 
-    folder = '%s%.3d%s%.3d' % (ns, lat, ew, lon)
-    filename = '%s%.3d%s%.3d' % (ns, abs(lat_tile), ew, abs(lon_tile))
+    folder = "%s%.3d%s%.3d" % (ns, lat, ew, lon)
+    filename = "%s%.3d%s%.3d" % (ns, abs(lat_tile), ew, abs(lon_tile))
 
     # Final path
-    out = folder + '/' + filename
+    out = folder + "/" + filename
     return out
 
 
 def aw3d30_zone(lon_ex, lat_ex):
-    """Returns a list of AW3D30 zones covering the desired extent.
-    """
+    """Returns a list of AW3D30 zones covering the desired extent."""
 
     # Files are one by one tiles, so lets loop over them
-    lon_tiles = np.arange(np.floor(lon_ex[0]), np.ceil(lon_ex[1]+1e-9),
-                          dtype=int)
-    lat_tiles = np.arange(np.floor(lat_ex[0]), np.ceil(lat_ex[1]+1e-9),
-                          dtype=int)
+    lon_tiles = np.arange(np.floor(lon_ex[0]), np.ceil(lon_ex[1] + 1e-9), dtype=int)
+    lat_tiles = np.arange(np.floor(lat_ex[0]), np.ceil(lat_ex[1] + 1e-9), dtype=int)
     zones = []
     for lon in lon_tiles:
         for lat in lat_tiles:
@@ -1419,30 +1464,27 @@ def _extent_to_polygon(lon_ex, lat_ex, to_crs=None):
 
 
 def arcticdem_zone(lon_ex, lat_ex):
-    """Returns a list of Arctic-DEM zones covering the desired extent.
-    """
+    """Returns a list of Arctic-DEM zones covering the desired extent."""
 
-    gdf = gpd.read_file(get_demo_file('ArcticDEM_Tile_Index_Rel7_by_tile.shp'))
+    gdf = gpd.read_file(get_demo_file("ArcticDEM_Tile_Index_Rel7_by_tile.shp"))
     p = _extent_to_polygon(lon_ex, lat_ex, to_crs=gdf.crs)
     gdf = gdf.loc[gdf.intersects(p)]
     return gdf.tile.values if len(gdf) > 0 else []
 
 
 def rema_zone(lon_ex, lat_ex):
-    """Returns a list of REMA-DEM zones covering the desired extent.
-    """
+    """Returns a list of REMA-DEM zones covering the desired extent."""
 
-    gdf = gpd.read_file(get_demo_file('REMA_Tile_Index_Rel1.1.shp'))
+    gdf = gpd.read_file(get_demo_file("REMA_Tile_Index_Rel1.1.shp"))
     p = _extent_to_polygon(lon_ex, lat_ex, to_crs=gdf.crs)
     gdf = gdf.loc[gdf.intersects(p)]
     return gdf.tile.values if len(gdf) > 0 else []
 
 
 def alaska_dem_zone(lon_ex, lat_ex):
-    """Returns a list of Alaska-DEM zones covering the desired extent.
-    """
+    """Returns a list of Alaska-DEM zones covering the desired extent."""
 
-    gdf = gpd.read_file(get_demo_file('Alaska_albers_V3_tiles.shp'))
+    gdf = gpd.read_file(get_demo_file("Alaska_albers_V3_tiles.shp"))
     p = _extent_to_polygon(lon_ex, lat_ex, to_crs=gdf.crs)
     gdf = gdf.loc[gdf.intersects(p)]
     return gdf.tile.values if len(gdf) > 0 else []
@@ -1451,16 +1493,18 @@ def alaska_dem_zone(lon_ex, lat_ex):
 def _copdem_tilelist():
     """Fetches the list of tiles."""
 
-    key = 'copdem_tilelist'
+    key = "copdem_tilelist"
 
     # Did we open it yet?
     if key in cfg.DATA:
         return cfg.DATA[key]
 
     # If not let's go
-    list_url = ('https://cluster.klima.uni-bremen.de/~oggm/'
-                'test_files/copdem/copdem_tiles_202504.csv')
-    with open(file_downloader(list_url), 'r') as f:
+    list_url = (
+        "https://cluster.klima.uni-bremen.de/~oggm/"
+        "test_files/copdem/copdem_tiles_202504.csv"
+    )
+    with open(file_downloader(list_url), "r") as f:
         reader = csv.reader(f)
         next(reader)  # skip header
         coord_set = set(tuple(row) for row in reader)
@@ -1479,34 +1523,34 @@ def copdem_zone(lon_ex, lat_ex, source):
 
     # because we use both meters and arc secs in our filenames...
     dxm = source[-2:]
-    if dxm == '90':
-        asec = '30'
-    elif dxm == '30':
-        asec = '10'
+    if dxm == "90":
+        asec = "30"
+    elif dxm == "30":
+        asec = "10"
     else:
-        raise InvalidDEMError('COPDEM Version not valid.')
+        raise InvalidDEMError("COPDEM Version not valid.")
 
     # Available tiles
     tile_list = _copdem_tilelist()
 
     # adding small buffer for unlikely case where one lon/lat_ex == xx.0
-    lons = np.arange(np.floor(lon_ex[0]-1e-9), np.ceil(lon_ex[1]+1e-9))
-    lats = np.arange(np.floor(lat_ex[0]-1e-9), np.ceil(lat_ex[1]+1e-9))
+    lons = np.arange(np.floor(lon_ex[0] - 1e-9), np.ceil(lon_ex[1] + 1e-9))
+    lats = np.arange(np.floor(lat_ex[0] - 1e-9), np.ceil(lat_ex[1] + 1e-9))
 
-    base_url = f'https://opentopography.s3.sdsc.edu/raster/COP{dxm}/COP{dxm}_hh'
+    base_url = f"https://opentopography.s3.sdsc.edu/raster/COP{dxm}/COP{dxm}_hh"
 
     flist = []
     for lat in lats:
         # north or south?
-        ns = 'S' if lat < 0 else 'N'
+        ns = "S" if lat < 0 else "N"
         for lon in lons:
             # east or west?
-            ew = 'W' if lon < 0 else 'E'
-            lat_str = '{}{:02.0f}'.format(ns, abs(lat))
-            lon_str = '{}{:03.0f}'.format(ew, abs(lon))
-            tilename = f'Copernicus_DSM_{asec}_{lat_str}_00_{lon_str}_00_DEM'
+            ew = "W" if lon < 0 else "E"
+            lat_str = "{}{:02.0f}".format(ns, abs(lat))
+            lon_str = "{}{:03.0f}".format(ew, abs(lon))
+            tilename = f"Copernicus_DSM_{asec}_{lat_str}_00_{lon_str}_00_DEM"
             if (lat_str, lon_str) in tile_list:
-                out = (f'{base_url}/{tilename}.tif', tilename)
+                out = (f"{base_url}/{tilename}.tif", tilename)
             else:
                 out = (None, tilename)
             flist.append(out)
@@ -1521,59 +1565,95 @@ def dem3_viewpano_zone(lon_ex, lat_ex):
     """
 
     for _f in DEM3REG.keys():
-
-        if (np.min(lon_ex) >= DEM3REG[_f][0]) and \
-           (np.max(lon_ex) <= DEM3REG[_f][1]) and \
-           (np.min(lat_ex) >= DEM3REG[_f][2]) and \
-           (np.max(lat_ex) <= DEM3REG[_f][3]):
-
+        if (
+            (np.min(lon_ex) >= DEM3REG[_f][0])
+            and (np.max(lon_ex) <= DEM3REG[_f][1])
+            and (np.min(lat_ex) >= DEM3REG[_f][2])
+            and (np.max(lat_ex) <= DEM3REG[_f][3])
+        ):
             # test some weird inset files in Antarctica
-            if (np.min(lon_ex) >= -91.) and (np.max(lon_ex) <= -90.) and \
-               (np.min(lat_ex) >= -72.) and (np.max(lat_ex) <= -68.):
-                return ['SR15']
+            if (
+                (np.min(lon_ex) >= -91.0)
+                and (np.max(lon_ex) <= -90.0)
+                and (np.min(lat_ex) >= -72.0)
+                and (np.max(lat_ex) <= -68.0)
+            ):
+                return ["SR15"]
 
-            elif (np.min(lon_ex) >= -47.) and (np.max(lon_ex) <= -43.) and \
-                 (np.min(lat_ex) >= -61.) and (np.max(lat_ex) <= -60.):
-                return ['SP23']
+            elif (
+                (np.min(lon_ex) >= -47.0)
+                and (np.max(lon_ex) <= -43.0)
+                and (np.min(lat_ex) >= -61.0)
+                and (np.max(lat_ex) <= -60.0)
+            ):
+                return ["SP23"]
 
-            elif (np.min(lon_ex) >= 162.) and (np.max(lon_ex) <= 165.) and \
-                 (np.min(lat_ex) >= -68.) and (np.max(lat_ex) <= -66.):
-                return ['SQ58']
+            elif (
+                (np.min(lon_ex) >= 162.0)
+                and (np.max(lon_ex) <= 165.0)
+                and (np.min(lat_ex) >= -68.0)
+                and (np.max(lat_ex) <= -66.0)
+            ):
+                return ["SQ58"]
 
             # test some rogue Greenland tiles as well
-            elif (np.min(lon_ex) >= -72.) and (np.max(lon_ex) <= -66.) and \
-                 (np.min(lat_ex) >= 76.) and (np.max(lat_ex) <= 80.):
-                return ['T19']
+            elif (
+                (np.min(lon_ex) >= -72.0)
+                and (np.max(lon_ex) <= -66.0)
+                and (np.min(lat_ex) >= 76.0)
+                and (np.max(lat_ex) <= 80.0)
+            ):
+                return ["T19"]
 
-            elif (np.min(lon_ex) >= -72.) and (np.max(lon_ex) <= -66.) and \
-                 (np.min(lat_ex) >= 80.) and (np.max(lat_ex) <= 83.):
-                return ['U19']
+            elif (
+                (np.min(lon_ex) >= -72.0)
+                and (np.max(lon_ex) <= -66.0)
+                and (np.min(lat_ex) >= 80.0)
+                and (np.max(lat_ex) <= 83.0)
+            ):
+                return ["U19"]
 
-            elif (np.min(lon_ex) >= -66.) and (np.max(lon_ex) <= -60.) and \
-                 (np.min(lat_ex) >= 80.) and (np.max(lat_ex) <= 83.):
-                return ['U20']
+            elif (
+                (np.min(lon_ex) >= -66.0)
+                and (np.max(lon_ex) <= -60.0)
+                and (np.min(lat_ex) >= 80.0)
+                and (np.max(lat_ex) <= 83.0)
+            ):
+                return ["U20"]
 
-            elif (np.min(lon_ex) >= -60.) and (np.max(lon_ex) <= -54.) and \
-                 (np.min(lat_ex) >= 80.) and (np.max(lat_ex) <= 83.):
-                return ['U21']
+            elif (
+                (np.min(lon_ex) >= -60.0)
+                and (np.max(lon_ex) <= -54.0)
+                and (np.min(lat_ex) >= 80.0)
+                and (np.max(lat_ex) <= 83.0)
+            ):
+                return ["U21"]
 
-            elif (np.min(lon_ex) >= -54.) and (np.max(lon_ex) <= -48.) and \
-                 (np.min(lat_ex) >= 80.) and (np.max(lat_ex) <= 83.):
-                return ['U22']
+            elif (
+                (np.min(lon_ex) >= -54.0)
+                and (np.max(lon_ex) <= -48.0)
+                and (np.min(lat_ex) >= 80.0)
+                and (np.max(lat_ex) <= 83.0)
+            ):
+                return ["U22"]
 
-            elif (np.min(lon_ex) >= -25.) and (np.max(lon_ex) <= -13.) and \
-                 (np.min(lat_ex) >= 63.) and (np.max(lat_ex) <= 67.):
-                return ['ISL']
+            elif (
+                (np.min(lon_ex) >= -25.0)
+                and (np.max(lon_ex) <= -13.0)
+                and (np.min(lat_ex) >= 63.0)
+                and (np.max(lat_ex) <= 67.0)
+            ):
+                return ["ISL"]
 
             else:
                 return [_f]
 
     # if the tile doesn't have a special name, its name can be found like this:
     # corrected SRTMs are sorted in tiles of 6 deg longitude and 4 deg latitude
-    srtm_x0 = -180.
-    srtm_y0 = 0.
-    srtm_dx = 6.
-    srtm_dy = 4.
+    srtm_x0 = -180.0
+    srtm_y0 = 0.0
+    srtm_dx = 6.0
+    srtm_dy = 4.0
 
     # quick n dirty solution to be sure that we will cover the whole range
     mi, ma = np.min(lon_ex), np.max(lon_ex)
@@ -1592,11 +1672,11 @@ def dem3_viewpano_zone(lon_ex, lat_ex):
             dy = lat - srtm_y0
             zx = np.ceil(dx / srtm_dx)
             # convert number to letter
-            zy = chr(int(abs(dy / srtm_dy)) + ord('A'))
+            zy = chr(int(abs(dy / srtm_dy)) + ord("A"))
             if lat >= 0:
-                zones.append('%s%02.0f' % (zy, zx))
+                zones.append("%s%02.0f" % (zy, zx))
             else:
-                zones.append('S%s%02.0f' % (zy, zx))
+                zones.append("S%s%02.0f" % (zy, zx))
     return list(sorted(set(zones)))
 
 
@@ -1611,18 +1691,19 @@ def aster_zone(lon_ex, lat_ex):
     """
 
     # adding small buffer for unlikely case where one lon/lat_ex == xx.0
-    lons = np.arange(np.floor(lon_ex[0]-1e-9), np.ceil(lon_ex[1]+1e-9))
-    lats = np.arange(np.floor(lat_ex[0]-1e-9), np.ceil(lat_ex[1]+1e-9))
+    lons = np.arange(np.floor(lon_ex[0] - 1e-9), np.ceil(lon_ex[1] + 1e-9))
+    lats = np.arange(np.floor(lat_ex[0] - 1e-9), np.ceil(lat_ex[1] + 1e-9))
 
     zones = []
     for lat in lats:
         # north or south?
-        ns = 'S' if lat < 0 else 'N'
+        ns = "S" if lat < 0 else "N"
         for lon in lons:
             # east or west?
-            ew = 'W' if lon < 0 else 'E'
-            filename = 'ASTGTMV003_{}{:02.0f}{}{:03.0f}'.format(ns, abs(lat),
-                                                                ew, abs(lon))
+            ew = "W" if lon < 0 else "E"
+            filename = "ASTGTMV003_{}{:02.0f}{}{:03.0f}".format(
+                ns, abs(lat), ew, abs(lon)
+            )
             zones.append(filename)
     return list(sorted(set(zones)))
 
@@ -1638,18 +1719,17 @@ def nasadem_zone(lon_ex, lat_ex):
     """
 
     # adding small buffer for unlikely case where one lon/lat_ex == xx.0
-    lons = np.arange(np.floor(lon_ex[0]-1e-9), np.ceil(lon_ex[1]+1e-9))
-    lats = np.arange(np.floor(lat_ex[0]-1e-9), np.ceil(lat_ex[1]+1e-9))
+    lons = np.arange(np.floor(lon_ex[0] - 1e-9), np.ceil(lon_ex[1] + 1e-9))
+    lats = np.arange(np.floor(lat_ex[0] - 1e-9), np.ceil(lat_ex[1] + 1e-9))
 
     zones = []
     for lat in lats:
         # north or south?
-        ns = 's' if lat < 0 else 'n'
+        ns = "s" if lat < 0 else "n"
         for lon in lons:
             # east or west?
-            ew = 'w' if lon < 0 else 'e'
-            filename = '{}{:02.0f}{}{:03.0f}'.format(ns, abs(lat), ew,
-                                                     abs(lon))
+            ew = "w" if lon < 0 else "e"
+            filename = "{}{:02.0f}{}{:03.0f}".format(ns, abs(lat), ew, abs(lon))
             zones.append(filename)
     return list(sorted(set(zones)))
 
@@ -1663,7 +1743,7 @@ def mapzen_zone(lon_ex, lat_ex, dx_meter=None, zoom=None):
     """
 
     if dx_meter is None and zoom is None:
-        raise InvalidParamsError('Need either zoom level or dx_meter.')
+        raise InvalidParamsError("Need either zoom level or dx_meter.")
 
     bottom, top = lat_ex
     left, right = lon_ex
@@ -1684,24 +1764,35 @@ def mapzen_zone(lon_ex, lat_ex, dx_meter=None, zoom=None):
     if dx_meter:
         # Find out the zoom so that we are close to the desired accuracy
         lat = np.max(np.abs([bottom, top]))
-        zoom = int(np.ceil(math.log2((math.cos(lat * math.pi / 180) *
-                                      2 * math.pi * WEB_EARTH_RADUIS) /
-                                     (WEB_N_PIX * dx_meter))))
+        zoom = int(
+            np.ceil(
+                math.log2(
+                    (math.cos(lat * math.pi / 180) * 2 * math.pi * WEB_EARTH_RADUIS)
+                    / (WEB_N_PIX * dx_meter)
+                )
+            )
+        )
 
         # According to this we should just always stay above 10 (sorry)
         # https://github.com/tilezen/joerd/blob/master/docs/data-sources.md
         zoom = 10 if zoom < 10 else zoom
 
     # Code from planetutils
-    size = 2 ** zoom
+    size = 2**zoom
     xt = lambda x: int((x + 180.0) / 360.0 * size)
-    yt = lambda y: int((1.0 - math.log(math.tan(math.radians(y)) +
-                                       (1 / math.cos(math.radians(y))))
-                        / math.pi) / 2.0 * size)
+    yt = lambda y: int(
+        (
+            1.0
+            - math.log(math.tan(math.radians(y)) + (1 / math.cos(math.radians(y))))
+            / math.pi
+        )
+        / 2.0
+        * size
+    )
     tiles = []
     for x in range(xt(left), xt(right) + 1):
         for y in range(yt(top), yt(bottom) + 1):
-            tiles.append('/'.join(map(str, [zoom, x, str(y) + '.tif'])))
+            tiles.append("/".join(map(str, [zoom, x, str(y) + ".tif"])))
     return tiles
 
 
@@ -1738,14 +1829,14 @@ def get_wgms_files():
     """
 
     download_oggm_files()
-    sdir = os.path.join(cfg.CACHE_DIR,
-                        'oggm-sample-data-%s' % SAMPLE_DATA_COMMIT,
-                        'wgms')
-    datadir = os.path.join(sdir, 'mbdata')
+    sdir = os.path.join(
+        cfg.CACHE_DIR, "oggm-sample-data-%s" % SAMPLE_DATA_COMMIT, "wgms"
+    )
+    datadir = os.path.join(sdir, "mbdata")
     assert os.path.exists(datadir)
 
-    outf = os.path.join(sdir, 'rgi_wgms_links_20220112.csv')
-    outf = pd.read_csv(outf, dtype={'RGI_REG': object})
+    outf = os.path.join(sdir, "rgi_wgms_links_20220112.csv")
+    outf = pd.read_csv(outf, dtype={"RGI_REG": object})
 
     return outf, datadir
 
@@ -1760,14 +1851,15 @@ def get_glathida_file():
 
     # Roll our own
     download_oggm_files()
-    sdir = os.path.join(cfg.CACHE_DIR,
-                        'oggm-sample-data-%s' % SAMPLE_DATA_COMMIT,
-                        'glathida')
-    outf = os.path.join(sdir, 'rgi_glathida_links.csv')
+    sdir = os.path.join(
+        cfg.CACHE_DIR, "oggm-sample-data-%s" % SAMPLE_DATA_COMMIT, "glathida"
+    )
+    outf = os.path.join(sdir, "rgi_glathida_links.csv")
     assert os.path.exists(outf)
     return outf
 
 
+@locked_func
 def get_rgi_dir(version=None, reset=False):
     """Path to the RGI directory.
 
@@ -1787,75 +1879,71 @@ def get_rgi_dir(version=None, reset=False):
         path to the RGI directory
     """
 
-    with get_lock():
-        return _get_rgi_dir_unlocked(version=version, reset=reset)
-
-
-def _get_rgi_dir_unlocked(version=None, reset=False):
-
-    rgi_dir = cfg.PATHS['rgi_dir']
+    rgi_dir = cfg.PATHS["rgi_dir"]
     if version is None:
-        version = cfg.PARAMS['rgi_version']
+        version = cfg.PARAMS["rgi_version"]
 
     if len(version) == 1:
-        version += '0'
+        version += "0"
 
     # Be sure the user gave a sensible path to the RGI dir
     if not rgi_dir:
-        raise InvalidParamsError('The RGI data directory has to be'
-                                 'specified explicitly.')
+        raise InvalidParamsError(
+            "The RGI data directory has to bespecified explicitly."
+        )
     rgi_dir = os.path.abspath(os.path.expanduser(rgi_dir))
-    rgi_dir = os.path.join(rgi_dir, 'RGIV' + version)
+    rgi_dir = os.path.join(rgi_dir, "RGIV" + version)
     mkdir(rgi_dir, reset=reset)
 
-    pattern = '*_rgi{}_*.zip'.format(version)
-    test_file = os.path.join(rgi_dir, f'*_rgi*{version}_manifest.txt')
+    pattern = "*_rgi{}_*.zip".format(version)
+    test_file = os.path.join(rgi_dir, f"*_rgi*{version}_manifest.txt")
 
-    if version == '50':
-        dfile = 'https://cluster.klima.uni-bremen.de/~oggm/rgi/www.glims.org/RGI/rgi50_files/rgi50.zip'
-    elif version == '60':
-        dfile = 'https://cluster.klima.uni-bremen.de/~oggm/rgi/www.glims.org/RGI/rgi60_files/rgi60.zip'
-    elif version == '61':
-        raise InvalidParamsError('You should use RGI62 instead of 61.')
-    elif version == '62':
-        dfile = 'https://cluster.klima.uni-bremen.de/~oggm/rgi/rgi62.zip'
-    elif version == '70G':
-        pattern = 'RGI2000-*.zip'
-        test_file = os.path.join(rgi_dir, 'RGI2000-v7.0-G-01_alaska', 'README.md')
-        dfile = 'https://daacdata.apps.nsidc.org/pub/DATASETS/nsidc0770_rgi_v7/'
-        dfile += 'global_files/RGI2000-v7.0-G-global.zip'
-    elif version == '70C':
-        pattern = 'RGI2000-*.zip'
-        test_file = os.path.join(rgi_dir, 'RGI2000-v7.0-C-01_alaska', 'README.md')
-        dfile = 'https://daacdata.apps.nsidc.org/pub/DATASETS/nsidc0770_rgi_v7/'
-        dfile += 'global_files/RGI2000-v7.0-C-global.zip'
+    if version == "50":
+        dfile = "https://cluster.klima.uni-bremen.de/~oggm/rgi/www.glims.org/RGI/rgi50_files/rgi50.zip"
+    elif version == "60":
+        dfile = "https://cluster.klima.uni-bremen.de/~oggm/rgi/www.glims.org/RGI/rgi60_files/rgi60.zip"
+    elif version == "61":
+        raise InvalidParamsError("You should use RGI62 instead of 61.")
+    elif version == "62":
+        dfile = "https://cluster.klima.uni-bremen.de/~oggm/rgi/rgi62.zip"
+    elif version == "70G":
+        pattern = "RGI2000-*.zip"
+        test_file = os.path.join(rgi_dir, "RGI2000-v7.0-G-01_alaska", "README.md")
+        dfile = "https://daacdata.apps.nsidc.org/pub/DATASETS/nsidc0770_rgi_v7/"
+        dfile += "global_files/RGI2000-v7.0-G-global.zip"
+    elif version == "70C":
+        pattern = "RGI2000-*.zip"
+        test_file = os.path.join(rgi_dir, "RGI2000-v7.0-C-01_alaska", "README.md")
+        dfile = "https://daacdata.apps.nsidc.org/pub/DATASETS/nsidc0770_rgi_v7/"
+        dfile += "global_files/RGI2000-v7.0-C-global.zip"
     else:
-        raise InvalidParamsError(f'RGI version not valid: {version}')
+        raise InvalidParamsError(f"RGI version not valid: {version}")
 
     if len(glob.glob(test_file)) == 0:
         # if not there download it
         ofile = file_downloader(dfile, reset=reset)
         if ofile is None:
-            raise RuntimeError(f'Could not download RGI file: {dfile}')
+            raise RuntimeError(f"Could not download RGI file: {dfile}")
         # Extract root
         try:
             with zipfile.ZipFile(ofile) as zf:
                 zf.extractall(rgi_dir)
         except zipfile.BadZipFile:
-            raise zipfile.BadZipFile(f'RGI file BadZipFile error: {ofile}')
+            raise zipfile.BadZipFile(f"RGI file BadZipFile error: {ofile}")
         # Extract subdirs
-        for root, dirs, files in os.walk(cfg.PATHS['rgi_dir']):
+        for root, dirs, files in os.walk(cfg.PATHS["rgi_dir"]):
             for filename in fnmatch.filter(files, pattern):
                 zfile = os.path.join(root, filename)
                 with zipfile.ZipFile(zfile) as zf:
-                    ex_root = zfile.replace('.zip', '')
+                    ex_root = zfile.replace(".zip", "")
                     mkdir(ex_root)
                     zf.extractall(ex_root)
                 # delete the zipfile after success
                 os.remove(zfile)
         if len(glob.glob(test_file)) == 0:
-            raise RuntimeError('Could not find a readme file in the RGI '
-                               'directory: ' + rgi_dir)
+            raise RuntimeError(
+                "Could not find a readme file in the RGI directory: " + rgi_dir
+            )
     return rgi_dir
 
 
@@ -1880,7 +1968,7 @@ def get_rgi_region_file(region, version=None, reset=False):
     """
 
     rgi_dir = get_rgi_dir(version=version, reset=reset)
-    if version in ['70G', '70C']:
+    if version in ["70G", "70C"]:
         f = list(glob.glob(rgi_dir + f"/*/*-{region}_*.shp"))
     else:
         f = list(glob.glob(rgi_dir + "/*/*{}_*.shp".format(region)))
@@ -1910,16 +1998,16 @@ def get_rgi_glacier_entities(rgi_ids, version=None):
     if version is None:
         if len(rgi_ids[0]) == 14:
             # RGI6
-            version = cfg.PARAMS['rgi_version']
+            version = cfg.PARAMS["rgi_version"]
         else:
             # RGI7 RGI2000-v7.0-G-02-00003
-            assert rgi_ids[0].split('-')[1] == 'v7.0'
-            version = '70' + rgi_ids[0].split('-')[2]
+            assert rgi_ids[0].split("-")[1] == "v7.0"
+            version = "70" + rgi_ids[0].split("-")[2]
 
-    if version in ['70G', '70C']:
-        regions = [s.split('-')[-2] for s in rgi_ids]
+    if version in ["70G", "70C"]:
+        regions = [s.split("-")[-2] for s in rgi_ids]
     else:
-        regions = [s.split('-')[1].split('.')[0] for s in rgi_ids]
+        regions = [s.split("-")[1].split(".")[0] for s in rgi_ids]
 
     selection = []
     for reg in sorted(np.unique(regions)):
@@ -1931,13 +2019,16 @@ def get_rgi_glacier_entities(rgi_ids, version=None):
 
     # Make a new dataframe of those
     selection = pd.concat(selection)
-    selection.set_crs(crs=sh.crs, inplace=True, allow_override=True)  # for geolocalisation
+    selection.set_crs(
+        crs=sh.crs, inplace=True, allow_override=True
+    )  # for geolocalisation
     if len(selection) != len(rgi_ids):
-        raise RuntimeError('Could not find all RGI ids')
+        raise RuntimeError("Could not find all RGI ids")
 
     return selection
 
 
+@locked_func
 def get_rgi_intersects_dir(version=None, reset=False):
     """Path to the RGI directory containing the intersect files.
 
@@ -1956,43 +2047,37 @@ def get_rgi_intersects_dir(version=None, reset=False):
         path to the directory
     """
 
-    with get_lock():
-        return _get_rgi_intersects_dir_unlocked(version=version, reset=reset)
-
-
-def _get_rgi_intersects_dir_unlocked(version=None, reset=False):
-
-    rgi_dir = cfg.PATHS['rgi_dir']
+    rgi_dir = cfg.PATHS["rgi_dir"]
     if version is None:
-        version = cfg.PARAMS['rgi_version']
+        version = cfg.PARAMS["rgi_version"]
 
     if len(version) == 1:
-        version += '0'
+        version += "0"
 
     # Be sure the user gave a sensible path to the RGI dir
     if not rgi_dir:
-        raise InvalidParamsError('The RGI data directory has to be'
-                                 'specified explicitly.')
+        raise InvalidParamsError(
+            "The RGI data directory has to bespecified explicitly."
+        )
 
     rgi_dir = os.path.abspath(os.path.expanduser(rgi_dir))
     mkdir(rgi_dir)
 
-    dfile = 'https://cluster.klima.uni-bremen.de/data/rgi/'
-    dfile += 'RGI_V{}_Intersects.zip'.format(version)
-    if version == '62':
-        dfile = ('https://cluster.klima.uni-bremen.de/~oggm/rgi/'
-                 'rgi62_Intersects.zip')
-    if version == '70G':
-        dfile = 'https://daacdata.apps.nsidc.org/pub/DATASETS/nsidc0770_rgi_v7/'
-        dfile += 'global_files/RGI2000-v7.0-I-global.zip'
+    dfile = "https://cluster.klima.uni-bremen.de/data/rgi/"
+    dfile += "RGI_V{}_Intersects.zip".format(version)
+    if version == "62":
+        dfile = "https://cluster.klima.uni-bremen.de/~oggm/rgi/rgi62_Intersects.zip"
+    if version == "70G":
+        dfile = "https://daacdata.apps.nsidc.org/pub/DATASETS/nsidc0770_rgi_v7/"
+        dfile += "global_files/RGI2000-v7.0-I-global.zip"
 
-    odir = os.path.join(rgi_dir, 'RGI_V' + version + '_Intersects')
+    odir = os.path.join(rgi_dir, "RGI_V" + version + "_Intersects")
     if reset and os.path.exists(odir):
         shutil.rmtree(odir)
 
     # A lot of code for backwards compat (sigh...)
-    if version in ['50', '60']:
-        test_file = os.path.join(odir, 'Intersects_OGGM_Manifest.txt')
+    if version in ["50", "60"]:
+        test_file = os.path.join(odir, "Intersects_OGGM_Manifest.txt")
         if not os.path.exists(test_file):
             # if not there download it
             ofile = file_downloader(dfile, reset=reset)
@@ -2000,10 +2085,11 @@ def _get_rgi_intersects_dir_unlocked(version=None, reset=False):
             with zipfile.ZipFile(ofile) as zf:
                 zf.extractall(odir)
             if not os.path.exists(test_file):
-                raise RuntimeError('Could not find a manifest file in the RGI '
-                                   'directory: ' + odir)
-    elif version == '62':
-        test_file = os.path.join(odir, '*ntersect*anifest.txt')
+                raise RuntimeError(
+                    "Could not find a manifest file in the RGI directory: " + odir
+                )
+    elif version == "62":
+        test_file = os.path.join(odir, "*ntersect*anifest.txt")
         if len(glob.glob(test_file)) == 0:
             # if not there download it
             ofile = file_downloader(dfile, reset=reset)
@@ -2011,21 +2097,22 @@ def _get_rgi_intersects_dir_unlocked(version=None, reset=False):
             with zipfile.ZipFile(ofile) as zf:
                 zf.extractall(odir)
             # Extract subdirs
-            pattern = '*_rgi{}_*.zip'.format(version)
-            for root, dirs, files in os.walk(cfg.PATHS['rgi_dir']):
+            pattern = "*_rgi{}_*.zip".format(version)
+            for root, dirs, files in os.walk(cfg.PATHS["rgi_dir"]):
                 for filename in fnmatch.filter(files, pattern):
                     zfile = os.path.join(root, filename)
                     with zipfile.ZipFile(zfile) as zf:
-                        ex_root = zfile.replace('.zip', '')
+                        ex_root = zfile.replace(".zip", "")
                         mkdir(ex_root)
                         zf.extractall(ex_root)
                     # delete the zipfile after success
                     os.remove(zfile)
             if len(glob.glob(test_file)) == 0:
-                raise RuntimeError('Could not find a manifest file in the RGI '
-                                   'directory: ' + odir)
-    elif version == '70G':
-        test_file = os.path.join(odir, 'README.md')
+                raise RuntimeError(
+                    "Could not find a manifest file in the RGI directory: " + odir
+                )
+    elif version == "70G":
+        test_file = os.path.join(odir, "README.md")
         if len(glob.glob(test_file)) == 0:
             # if not there download it
             ofile = file_downloader(dfile, reset=reset)
@@ -2033,19 +2120,21 @@ def _get_rgi_intersects_dir_unlocked(version=None, reset=False):
             with zipfile.ZipFile(ofile) as zf:
                 zf.extractall(odir)
             # Extract subdirs
-            pattern = 'RGI2000-*.zip'
-            for root, dirs, files in os.walk(cfg.PATHS['rgi_dir']):
+            pattern = "RGI2000-*.zip"
+            for root, dirs, files in os.walk(cfg.PATHS["rgi_dir"]):
                 for filename in fnmatch.filter(files, pattern):
                     zfile = os.path.join(root, filename)
                     with zipfile.ZipFile(zfile) as zf:
-                        ex_root = zfile.replace('.zip', '')
+                        ex_root = zfile.replace(".zip", "")
                         mkdir(ex_root)
                         zf.extractall(ex_root)
                     # delete the zipfile after success
                     os.remove(zfile)
             if len(glob.glob(test_file)) == 0:
-                raise RuntimeError('Could not find a README file in the RGI intersects'
-                                   'directory: ' + odir)
+                raise RuntimeError(
+                    "Could not find a README file in the RGI intersects"
+                    "directory: " + odir
+                )
 
     return odir
 
@@ -2073,25 +2162,32 @@ def get_rgi_intersects_region_file(region=None, version=None, reset=False):
     """
 
     if version is None:
-        version = cfg.PARAMS['rgi_version']
+        version = cfg.PARAMS["rgi_version"]
     if len(version) == 1:
-        version += '0'
+        version += "0"
 
     rgi_dir = get_rgi_intersects_dir(version=version, reset=reset)
 
-    if region == '00':
-        if version in ['50', '60']:
-            version = 'AllRegs'
-            region = '*'
+    if region == "00":
+        if version in ["50", "60"]:
+            version = "AllRegs"
+            region = "*"
         else:
-            raise InvalidParamsError("From RGI version 61 onwards, please use "
-                                     "get_rgi_intersects_entities() instead.")
+            raise InvalidParamsError(
+                "From RGI version 61 onwards, please use "
+                "get_rgi_intersects_entities() instead."
+            )
 
-    if version == '70G':
-        f = list(glob.glob(os.path.join(rgi_dir, "*", f'*-{region}_*.shp')))
+    if version == "70G":
+        f = list(glob.glob(os.path.join(rgi_dir, "*", f"*-{region}_*.shp")))
     else:
-        f = list(glob.glob(os.path.join(rgi_dir, "*", '*intersects*' + region +
-                                        '_rgi*' + version + '*.shp')))
+        f = list(
+            glob.glob(
+                os.path.join(
+                    rgi_dir, "*", "*intersects*" + region + "_rgi*" + version + "*.shp"
+                )
+            )
+        )
     assert len(f) == 1
     return f[0]
 
@@ -2113,38 +2209,42 @@ def get_rgi_intersects_entities(rgi_ids, version=None):
     """
 
     if version is None:
-        version = cfg.PARAMS['rgi_version']
+        version = cfg.PARAMS["rgi_version"]
 
     if len(version) == 1:
-        version += '0'
+        version += "0"
 
     # RGI V6 or 7
-    if version == '70G':
-        regions = [s.split('-')[-2] for s in rgi_ids]
+    if version == "70G":
+        regions = [s.split("-")[-2] for s in rgi_ids]
     else:
         try:
-            regions = [s.split('-')[3] for s in rgi_ids]
+            regions = [s.split("-")[3] for s in rgi_ids]
         except IndexError:
-            regions = [s.split('-')[1].split('.')[0] for s in rgi_ids]
+            regions = [s.split("-")[1].split(".")[0] for s in rgi_ids]
 
     selection = []
     for reg in sorted(np.unique(regions)):
         sh = gpd.read_file(get_rgi_intersects_region_file(reg, version=version))
-        if version == '70G':
-            selection.append(sh.loc[sh.rgi_g_id_1.isin(rgi_ids) |
-                                    sh.rgi_g_id_2.isin(rgi_ids)])
+        if version == "70G":
+            selection.append(
+                sh.loc[sh.rgi_g_id_1.isin(rgi_ids) | sh.rgi_g_id_2.isin(rgi_ids)]
+            )
         else:
-            selection.append(sh.loc[sh.RGIId_1.isin(rgi_ids) |
-                                    sh.RGIId_2.isin(rgi_ids)])
+            selection.append(
+                sh.loc[sh.RGIId_1.isin(rgi_ids) | sh.RGIId_2.isin(rgi_ids)]
+            )
 
     # Make a new dataframe of those
     selection = pd.concat(selection)
-    selection.set_crs(crs=sh.crs, inplace=True, allow_override=True)  # for geolocalisation
+    selection.set_crs(
+        crs=sh.crs, inplace=True, allow_override=True
+    )  # for geolocalisation
 
     return selection
 
 
-def get_rgi7c_to_g_links(region, version='70C', reset=False):
+def get_rgi7c_to_g_links(region, version="70C", reset=False):
     """Path to the RGI7 glacier complex to glacier json file.
 
     This is for version 7C only!
@@ -2163,7 +2263,7 @@ def get_rgi7c_to_g_links(region, version='70C', reset=False):
     a dictionary containing the links
     """
     jfile = get_rgi_region_file(region, version=version, reset=reset)
-    jfile = jfile.replace('.shp', '-CtoG_links.json')
+    jfile = jfile.replace(".shp", "-CtoG_links.json")
     with open(jfile) as f:
         out = json.load(f)
     return out
@@ -2189,48 +2289,49 @@ def is_dem_source_available(source, lon_ex, lat_ex):
     True or False
     """
     from oggm.utils import tolist
+
     lon_ex = tolist(lon_ex, length=2)
     lat_ex = tolist(lat_ex, length=2)
 
     def _in_grid(grid_json, lon, lat):
-        i, j = cfg.DATA['dem_grids'][grid_json].transform(lon, lat,
-                                                          maskout=True)
-        return np.all(~ (i.mask | j.mask))
+        i, j = cfg.DATA["dem_grids"][grid_json].transform(lon, lat, maskout=True)
+        return np.all(~(i.mask | j.mask))
 
-    if source == 'GIMP':
-        return _in_grid('gimpdem_90m_v01.1.json', lon_ex, lat_ex)
-    elif source == 'ARCTICDEM':
-        return _in_grid('arcticdem_mosaic_100m_v3.0.json', lon_ex, lat_ex)
-    elif source == 'RAMP':
-        return _in_grid('AntarcticDEM_wgs84.json', lon_ex, lat_ex)
-    elif source == 'REMA':
-        return _in_grid('REMA_100m_dem.json', lon_ex, lat_ex)
-    elif source == 'ALASKA':
-        return _in_grid('Alaska_albers_V3.json', lon_ex, lat_ex)
-    elif source == 'TANDEM':
+    if source == "GIMP":
+        return _in_grid("gimpdem_90m_v01.1.json", lon_ex, lat_ex)
+    elif source == "ARCTICDEM":
+        return _in_grid("arcticdem_mosaic_100m_v3.0.json", lon_ex, lat_ex)
+    elif source == "RAMP":
+        return _in_grid("AntarcticDEM_wgs84.json", lon_ex, lat_ex)
+    elif source == "REMA":
+        return _in_grid("REMA_100m_dem.json", lon_ex, lat_ex)
+    elif source == "ALASKA":
+        return _in_grid("Alaska_albers_V3.json", lon_ex, lat_ex)
+    elif source == "TANDEM":
         return True
-    elif source == 'AW3D30':
+    elif source == "AW3D30":
         return np.min(lat_ex) > -60
-    elif source == 'MAPZEN':
+    elif source == "MAPZEN":
         return True
-    elif source == 'DEM3':
+    elif source == "DEM3":
         return True
-    elif source == 'ASTER':
+    elif source == "ASTER":
         return True
-    elif source == 'SRTM':
+    elif source == "SRTM":
         return np.max(np.abs(lat_ex)) < 60
-    elif source in ['COPDEM30', 'COPDEM90']:
+    elif source in ["COPDEM30", "COPDEM90"]:
         return True
-    elif source == 'NASADEM':
+    elif source == "NASADEM":
         return (np.min(lat_ex) > -56) and (np.max(lat_ex) < 60)
-    elif source == 'USER':
+    elif source == "USER":
         return True
     elif source is None:
         return True
 
 
-def get_topo_file(lon_ex=None, lat_ex=None, gdir=None, *,
-                  dx_meter=None, zoom=None, source=None):
+def get_topo_file(
+    lon_ex=None, lat_ex=None, gdir=None, *, dx_meter=None, zoom=None, source=None
+):
     """Path(s) to the DEM file(s) covering the desired extent.
 
     If the needed files for covering the extent are not present, download them.
@@ -2267,111 +2368,114 @@ def get_topo_file(lon_ex=None, lat_ex=None, gdir=None, *,
     tuple: (list with path(s) to the DEM file(s), data source str)
     """
     from oggm.utils import tolist
+
     lon_ex = tolist(lon_ex, length=2)
     lat_ex = tolist(lat_ex, length=2)
 
     if source is not None and not isinstance(source, str):
         # check all user options
         for s in source:
-            demf, source_str = get_topo_file(lon_ex=lon_ex, lat_ex=lat_ex,
-                                             gdir=gdir, source=s)
+            demf, source_str = get_topo_file(
+                lon_ex=lon_ex, lat_ex=lat_ex, gdir=gdir, source=s
+            )
             if demf[0]:
                 return demf, source_str
 
     # Did the user specify a specific DEM file?
-    if 'dem_file' in cfg.PATHS and os.path.isfile(cfg.PATHS['dem_file']):
-        source = 'USER' if source is None else source
-        if source == 'USER':
-            return [cfg.PATHS['dem_file']], source
+    if "dem_file" in cfg.PATHS and os.path.isfile(cfg.PATHS["dem_file"]):
+        source = "USER" if source is None else source
+        if source == "USER":
+            return [cfg.PATHS["dem_file"]], source
 
     # Some logic to decide which source to take if unspecified
     if source is None:
         if gdir is None:
-            raise InvalidParamsError('gdir is needed if source=None')
-        source = getattr(gdir, 'rgi_dem_source')
+            raise InvalidParamsError("gdir is needed if source=None")
+        source = getattr(gdir, "rgi_dem_source")
         if source is None:
-            raise InvalidParamsError('DEM source now needs to be specified '
-                                     'explicitly, either via the RGI file '
-                                     'or the `source` kwarg.')
+            raise InvalidParamsError(
+                "DEM source now needs to be specified "
+                "explicitly, either via the RGI file "
+                "or the `source` kwarg."
+            )
 
     if source not in DEM_SOURCES:
-        raise InvalidParamsError('`source` must be one of '
-                                 '{}'.format(DEM_SOURCES))
+        raise InvalidParamsError("`source` must be one of {}".format(DEM_SOURCES))
 
     # OK go
     files = []
-    if source == 'GIMP':
-        _file = _download_topo_file_from_cluster('gimpdem_90m_v01.1.tif')
+    if source == "GIMP":
+        _file = _download_topo_file_from_cluster("gimpdem_90m_v01.1.tif")
         files.append(_file)
 
-    if source == 'ARCTICDEM':
+    if source == "ARCTICDEM":
         zones = arcticdem_zone(lon_ex, lat_ex)
         for z in zones:
             with get_lock():
-                url = 'https://cluster.klima.uni-bremen.de/~oggm/'
-                url += 'dem/ArcticDEM_100m_v3.0/'
-                url += '{}_100m_v3.0/{}_100m_v3.0_reg_dem.tif'.format(z, z)
+                url = "https://cluster.klima.uni-bremen.de/~oggm/"
+                url += "dem/ArcticDEM_100m_v3.0/"
+                url += "{}_100m_v3.0/{}_100m_v3.0_reg_dem.tif".format(z, z)
                 files.append(file_downloader(url))
 
-    if source == 'RAMP':
-        _file = _download_topo_file_from_cluster('AntarcticDEM_wgs84.tif')
+    if source == "RAMP":
+        _file = _download_topo_file_from_cluster("AntarcticDEM_wgs84.tif")
         files.append(_file)
 
-    if source == 'ALASKA':
+    if source == "ALASKA":
         zones = alaska_dem_zone(lon_ex, lat_ex)
         for z in zones:
             with get_lock():
-                url = 'https://cluster.klima.uni-bremen.de/~oggm/'
-                url += 'dem/Alaska_albers_V3/'
-                url += '{}_Alaska_albers_V3/'.format(z)
-                url += '{}_Alaska_albers_V3.tif'.format(z)
+                url = "https://cluster.klima.uni-bremen.de/~oggm/"
+                url += "dem/Alaska_albers_V3/"
+                url += "{}_Alaska_albers_V3/".format(z)
+                url += "{}_Alaska_albers_V3.tif".format(z)
                 files.append(file_downloader(url))
 
-    if source == 'REMA':
+    if source == "REMA":
         zones = rema_zone(lon_ex, lat_ex)
         for z in zones:
             with get_lock():
-                url = 'https://cluster.klima.uni-bremen.de/~oggm/'
-                url += 'dem/REMA_100m_v1.1/'
-                url += '{}_100m_v1.1/{}_100m_v1.1_reg_dem.tif'.format(z, z)
+                url = "https://cluster.klima.uni-bremen.de/~oggm/"
+                url += "dem/REMA_100m_v1.1/"
+                url += "{}_100m_v1.1/{}_100m_v1.1_reg_dem.tif".format(z, z)
                 files.append(file_downloader(url))
 
-    if source == 'TANDEM':
+    if source == "TANDEM":
         zones = tandem_zone(lon_ex, lat_ex)
         for z in zones:
             files.append(_download_tandem_file(z))
 
-    if source == 'AW3D30':
+    if source == "AW3D30":
         zones = aw3d30_zone(lon_ex, lat_ex)
         for z in zones:
             files.append(_download_aw3d30_file(z))
 
-    if source == 'MAPZEN':
+    if source == "MAPZEN":
         zones = mapzen_zone(lon_ex, lat_ex, dx_meter=dx_meter, zoom=zoom)
         for z in zones:
             files.append(_download_mapzen_file(z))
 
-    if source == 'ASTER':
+    if source == "ASTER":
         zones = aster_zone(lon_ex, lat_ex)
         for z in zones:
             files.append(_download_aster_file(z))
 
-    if source == 'DEM3':
+    if source == "DEM3":
         zones = dem3_viewpano_zone(lon_ex, lat_ex)
         for z in zones:
             files.append(_download_dem3_viewpano(z))
 
-    if source == 'SRTM':
+    if source == "SRTM":
         zones = srtm_zone(lon_ex, lat_ex)
         for z in zones:
             files.append(_download_srtm_file(z))
 
-    if source in ['COPDEM30', 'COPDEM90']:
+    if source in ["COPDEM30", "COPDEM90"]:
         tilenames = copdem_zone(lon_ex, lat_ex, source)
         for tile_url, _ in tilenames:
             files.append(_download_copdem_file(tile_url))
 
-    if source == 'NASADEM':
+    if source == "NASADEM":
         zones = nasadem_zone(lon_ex, lat_ex)
         for z in zones:
             files.append(_download_nasadem_file(z))
@@ -2381,6 +2485,7 @@ def get_topo_file(lon_ex=None, lat_ex=None, gdir=None, *,
     if files:
         return files, source
     else:
-        raise InvalidDEMError('Source: {2} no topography file available for '
-                              'extent lat:{0}, lon:{1}!'.
-                              format(lat_ex, lon_ex, source))
+        raise InvalidDEMError(
+            "Source: {2} no topography file available for "
+            "extent lat:{0}, lon:{1}!".format(lat_ex, lon_ex, source)
+        )


### PR DESCRIPTION
## Summary
- Replace 14 `wrapper + _unlocked` function pairs with `@locked_func` decorator
- Move `locked_func` definition right after `get_lock()` to avoid forward references
- Remove all `_unlocked` suffixes — decorated functions keep the public API names
- Inline `with get_lock():` usages in other files (loops, partial locking) left as-is

Closes #1845

## Test plan
- [ ] Verify imports work: `from oggm.utils._downloads import get_lock, locked_func`
- [ ] Run download-related tests to confirm locking behavior preserved
- [ ] Grep for `_unlocked` — should return zero matches
- [ ] Verify no circular import or initialization-order issues