### PR TITLE
Incorporate SfcTypeTIModel in FlowlineModel and run_with_climate_data

### DIFF
--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -262,6 +262,12 @@ BASENAMES['climate_historical_daily'] = ('climate_historical_daily.nc', _doc)
 _doc = "A dict containing the glacier's mass balance calibration parameters."
 BASENAMES['mb_calib'] = ('mb_calib.json', _doc)
 
+_doc = ('A group netcdf file containing the complete state of a SfcTypeTIModel '
+        'instance. This is useful for projeciton runs to start from historical '
+        'snow bucket state. Netcdf groups = fl_{i}, with i between 0 and '
+        'n_flowlines - 1')
+BASENAMES['mb_diagnostics'] = ('mb_diagnostics.nc', _doc)
+
 _doc = 'The monthly GCM climate timeseries stored in a netCDF file.'
 BASENAMES['gcm_data'] = ('gcm_data.nc', _doc)
 

--- a/oggm/core/dynamic_spinup.py
+++ b/oggm/core/dynamic_spinup.py
@@ -1021,7 +1021,10 @@ def define_new_melt_f_in_gdir(gdir, new_melt_f):
     -------
 
     """
-    if 'melt_f' not in gdir.settings:
+    # this is for backwards-compatiblity, it would be cleaner to call
+    # if 'melt_f' not in gdir.settings (only possible when mb was calibrated
+    # using the new settings system)
+    if gdir.settings['melt_f'] is None:
         raise InvalidWorkflowError('No `melt_f` in gdir.settings. '
                                    'You first need to calibrate the whole '
                                    'MassBalanceModel before changing melt_f '

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -4065,7 +4065,10 @@ def run_from_climate_data(gdir, settings_filesuffix='',
                           init_model_filesuffix=None, init_model_yr=None,
                           init_model_fls=None, zero_initial_glacier=False,
                           bias=0, temperature_bias=None,
-                          precipitation_factor=None, **kwargs):
+                          precipitation_factor=None,
+                          mb_diagnostics_filesuffix=None,
+                          save_mb_diagnostics_filesuffix=None,
+                          **kwargs):
     """ Runs a glacier with climate input from e.g. CRU or a GCM.
 
     This will initialize a
@@ -4143,6 +4146,20 @@ def run_from_climate_data(gdir, settings_filesuffix='',
         starting from the chosen year. The only output affected are the
         glacier wide diagnostic files - all other outputs are set
         to constants during "spinup"
+    mb_diagnostics_filesuffix : str, optional
+        if provided, the mass balance model is loaded from a previously saved
+        ``mb_diagnostics{mb_diagnostics_filesuffix}.nc`` file via
+        :meth:`MultipleFlowlineMassBalance.load_from_file` instead of being
+        constructed from scratch.  ``climate_filename`` and
+        ``climate_input_filesuffix`` are forwarded so you can branch from a
+        historical state into a new scenario.  Ignored when ``mb_model`` is
+        also provided.
+    save_mb_diagnostics_filesuffix : str, optional
+        if provided, the mass balance model state is saved to
+        ``mb_diagnostics{save_mb_diagnostics_filesuffix}.nc`` after the run
+        completes, via :meth:`MultipleFlowlineMassBalance.save_to_file`.
+        Useful for saving a historical run before branching into multiple
+        projection scenarios.
     kwargs : dict
         kwargs to pass to the flowline_model_run task
     """
@@ -4183,13 +4200,27 @@ def run_from_climate_data(gdir, settings_filesuffix='',
         ys = ys if ys < max_ys else max_ys
 
     if mb_model is None:
-        mb_model = MultipleFlowlineMassBalance(gdir,
-                                               mb_model_class=mb_model_class,
-                                               filename=climate_filename,
-                                               bias=bias,
-                                               input_filesuffix=climate_input_filesuffix,
-                                               settings_filesuffix=settings_filesuffix,
-                                               )
+        if mb_diagnostics_filesuffix is not None:
+            # Only forward climate params when explicitly changed from defaults
+            _branch_fn = (climate_filename
+                          if climate_filename != 'climate_historical' else None)
+            _branch_isuf = (climate_input_filesuffix
+                            if climate_input_filesuffix != '' else None)
+            mb_model = MultipleFlowlineMassBalance.load_from_file(
+                gdir,
+                filesuffix=mb_diagnostics_filesuffix,
+                climate_filename=_branch_fn,
+                climate_input_filesuffix=_branch_isuf,
+            )
+        else:
+            mb_model = MultipleFlowlineMassBalance(
+                gdir,
+                mb_model_class=mb_model_class,
+                filename=climate_filename,
+                bias=bias,
+                input_filesuffix=climate_input_filesuffix,
+                settings_filesuffix=settings_filesuffix,
+            )
 
     if temperature_bias is not None:
         mb_model.temp_bias += temperature_bias
@@ -4200,16 +4231,21 @@ def run_from_climate_data(gdir, settings_filesuffix='',
         # Decide from climate (we can run the last year with data as well)
         ye = mb_model.flowline_mb_models[0].ye + 1
 
-    return flowline_model_run(gdir, settings_filesuffix=settings_filesuffix,
-                              output_filesuffix=output_filesuffix,
-                              mb_model=mb_model, ys=ys, ye=ye,
-                              store_monthly_step=store_monthly_step,
-                              store_model_geometry=store_model_geometry,
-                              store_fl_diagnostics=store_fl_diagnostics,
-                              init_model_fls=init_model_fls,
-                              zero_initial_glacier=zero_initial_glacier,
-                              fixed_geometry_spinup_yr=fixed_geometry_spinup_yr,
-                              **kwargs)
+    out = flowline_model_run(gdir, settings_filesuffix=settings_filesuffix,
+                             output_filesuffix=output_filesuffix,
+                             mb_model=mb_model, ys=ys, ye=ye,
+                             store_monthly_step=store_monthly_step,
+                             store_model_geometry=store_model_geometry,
+                             store_fl_diagnostics=store_fl_diagnostics,
+                             init_model_fls=init_model_fls,
+                             zero_initial_glacier=zero_initial_glacier,
+                             fixed_geometry_spinup_yr=fixed_geometry_spinup_yr,
+                             **kwargs)
+
+    if save_mb_diagnostics_filesuffix is not None:
+        out.mb_model.save_to_file(filesuffix=save_mb_diagnostics_filesuffix)
+
+    return out
 
 
 @entity_task(log)

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -609,7 +609,8 @@ class FlowlineModel(object):
                  fs=None, inplace=False, smooth_trib_influx=True,
                  is_tidewater=False, is_lake_terminating=False,
                  mb_elev_feedback='annual', check_for_boundaries=None,
-                 water_level=None, required_model_steps='monthly'):
+                 water_level=None, required_model_steps='monthly',
+                 include_mb_model_heights=False, include_firn_outputs=False, ):
         """Create a new flowline model from the flowlines and a MB model.
 
         Parameters
@@ -658,6 +659,16 @@ class FlowlineModel(object):
             only annual updates are required. You may want to change this
             for optimisation reasons for models that don't require adaptive
             steps (for example the deltaH method).
+        include_mb_model_heights : bool, default False
+            If True we add the snow/firn height of the current mb_model (if
+            available) to include this in the elevation feedback of the mb
+            calculation.
+        include_firn_outputs : bool, default False
+            If True we include firn/snow output for volume, mass and thickness.
+            With this you get for each of them three output variables. E.g. for
+            volume: volume_m3 = volume_ice_m3 + volume_firn_m3. If False only
+            the ice output is stored (e.g. volume_m3 = volume_ice_m3, but in the
+            output you only find volume_m3).
         """
 
         if gdir is not None:
@@ -677,6 +688,8 @@ class FlowlineModel(object):
             self.mb_step = 'annual'
         elif self.mb_elev_feedback in ['always', 'monthly']:
             self.mb_step = 'monthly'
+        self.include_mb_model_heights = include_mb_model_heights
+        self.separate_ice_and_firn = include_firn_outputs
         self.mb_model = mb_model
 
         # Defaults
@@ -687,7 +700,7 @@ class FlowlineModel(object):
         self.glen_a = glen_a
         self.fs = fs
         self.glen_n = self.settings['glen_n']
-        self.rho = self.settings['ice_density']
+        self.ice_density = self.settings['ice_density']
         if check_for_boundaries is None:
             check_for_boundaries = self.settings[('error_when_glacier_reaches_'
                                                'boundaries')]
@@ -707,6 +720,8 @@ class FlowlineModel(object):
         self.required_model_steps = required_model_steps
         self.y0 = None
         self.t = None
+        self._yr_lookup_cumul = None
+        self._yr_lookup_y0 = None
         self.reset_y0(y0)
 
         self.fls = None
@@ -730,18 +745,118 @@ class FlowlineModel(object):
             else:
                 raise ValueError('mb_elev_feedback not understood')
             # some models have a climatic and ice mb (e.g. SfcTIModel), for
-            # dynamics we want ice; if not available it is ignored
-            _mb_call = partial(_mb_call, climatic_mb_or_ice_mb='ice_mb')
+            # dynamics we want ice; if not available it is ignored; Similarly
+            # some models include a bucket height, and we can add this height on
+            # top to the ice surface height
+            _mb_call = partial(_mb_call, climatic_mb_or_ice_mb='ice_mb',
+                               include_mb_model_heights=self.include_mb_model_heights)
         self._mb_model = value
         self._mb_call = _mb_call
         self._mb_current_date = None
         self._mb_current_out = dict()
         self._mb_current_heights = dict()
 
+    def _get_sec_in_year(self, yr):
+        # use sec of mb model to include potential leap years
+        mb_model = self._get_fl_mb_model(fl_id=0)
+        return mb_model.sec_in_year(yr)
+
+    def _get_sec_in_month(self, yr):
+        # use sec of mb model to include potential leap years
+        mb_model = self._get_fl_mb_model(fl_id=0)
+        return mb_model.sec_in_month(yr)
+
     def reset_y0(self, y0):
         """Reset the initial model time"""
         self.y0 = y0
         self.t = 0
+        if self._yr_lookup_cumul is not None:
+            self._yr_lookup_cumul = None
+            self._yr_lookup_y0 = None
+        if self.use_leap_years:
+            self._build_yr_lookup()
+
+    @property
+    def use_leap_years(self):
+        """Whether the mass balance model uses leap years."""
+        try:
+            return self._get_fl_mb_model(fl_id=0).use_leap_years
+        except Exception:
+            return False
+
+    def _build_yr_lookup(self, y_max=None):
+        """Build or extend the cumulative-seconds lookup table.
+
+        Stores elapsed seconds from y0 at each integer year boundary:
+        ``_yr_lookup_cumul[i]`` = seconds from start of y0 to start of year
+        ``(_yr_lookup_y0 + i)``.
+
+        Parameters
+        ----------
+        y_max : int or None
+            Ensure the table covers at least up to this year (inclusive).
+            If None, the initial window is y0 + 100. When a later call
+            requires a year beyond the current window, the table is extended
+            by another 100 years (or to y_max, whichever is larger).
+        """
+        y0_int = int(self.y0)
+        desired_y_max = int(y_max) if y_max is not None else y0_int + 100
+
+        if self._yr_lookup_cumul is None:
+            # Initial build — always cover at least 100 years
+            n_years = max(desired_y_max - y0_int, 100)
+            years = np.arange(y0_int, y0_int + n_years + 1, dtype=int)
+            sec = utils.get_seconds_of_year(years[:-1].astype(float),
+                                            use_leap_years=True)
+            self._yr_lookup_cumul = np.concatenate([[0.], np.cumsum(sec)])
+            self._yr_lookup_y0 = y0_int
+            return
+
+        # current_y_max: last year fully covered by the table
+        # cumul has N+1 entries for N years → max usable year = y0 + N - 1
+        current_y_max = self._yr_lookup_y0 + len(self._yr_lookup_cumul) - 2
+        if desired_y_max <= current_y_max:
+            return  # already covered — fast exit
+
+        # Extend: always grow by at least 100 years
+        new_y_max = max(desired_y_max, current_y_max + 100)
+        n_new = new_y_max - current_y_max
+        years_new = np.arange(current_y_max + 1, current_y_max + n_new + 1, dtype=int)
+        sec_new = utils.get_seconds_of_year(years_new.astype(float),
+                                            use_leap_years=True)
+        self._yr_lookup_cumul = np.concatenate([
+            self._yr_lookup_cumul,
+            self._yr_lookup_cumul[-1] + np.cumsum(sec_new)
+        ])
+
+    def _yr_to_seconds(self, yr):
+        """Convert a float year to elapsed seconds since self.y0.
+
+        Accounts for leap years when self.use_leap_years is True.
+        """
+        if not self.use_leap_years:
+            return (yr - self.y0) * SEC_IN_YEAR
+        yr_int = int(yr)
+        self._build_yr_lookup(y_max=yr_int + 1)
+        idx = yr_int - self._yr_lookup_y0
+        sec_in_yr = self._yr_lookup_cumul[idx + 1] - self._yr_lookup_cumul[idx]
+        return self._yr_lookup_cumul[idx] + (yr - yr_int) * sec_in_yr
+
+    def _seconds_to_yr(self, t_sec):
+        """Convert elapsed seconds since self.y0 to a float year.
+
+        Accounts for leap years when self.use_leap_years is True.
+        """
+        if not self.use_leap_years:
+            return self.y0 + t_sec / SEC_IN_YEAR
+        # Approximate target year to check whether an extension is needed
+        approx_yr = int(self.y0 + t_sec / SEC_IN_YEAR) + 2
+        self._build_yr_lookup(y_max=approx_yr)
+        idx = int(np.searchsorted(self._yr_lookup_cumul, t_sec, side='right')) - 1
+        idx = max(0, min(idx, len(self._yr_lookup_cumul) - 2))
+        y_int = self._yr_lookup_y0 + idx
+        sec_in_yr = self._yr_lookup_cumul[idx + 1] - self._yr_lookup_cumul[idx]
+        return float(y_int) + (t_sec - self._yr_lookup_cumul[idx]) / sec_in_yr
 
     def reset_flowlines(self, flowlines, inplace=False,
                         smooth_trib_influx=True):
@@ -789,15 +904,54 @@ class FlowlineModel(object):
 
     @property
     def yr(self):
-        return self.y0 + self.t / SEC_IN_YEAR
+        return self._seconds_to_yr(self.t)
 
     @property
     def area_m2(self):
         return np.sum([f.area_m2 for f in self.fls])
 
     @property
-    def volume_m3(self):
+    def volume_ice_m3(self):
         return np.sum([f.volume_m3 for f in self.fls])
+
+    @property
+    def volume_ice_km3(self):
+        return self.volume_ice_m3 * 1e-9
+
+    def _get_fl_mb_model(self, fl_id):
+        if isinstance(self._mb_model, MultipleFlowlineMassBalance):
+            return self._mb_model.flowline_mb_models[fl_id]
+        else:
+            # we only allow a single flowline for this case
+            assert len(self.fls) == 1
+            return self._mb_model
+
+    def _get_along_fl_thickness_firn_m(self, fl_id):
+        return self._get_fl_mb_model(fl_id).columns_thickness_m
+
+    def _get_along_fl_volume_firn_m3(self, fl_id):
+        # we assume the firn/snow is just a box on top without considering any
+        # bed shape for calculation
+        return (self._get_along_fl_thickness_firn_m(fl_id) *
+                self.fls[fl_id].bin_area_m2)
+
+    @property
+    def volume_firn_m3(self):
+        volume = 0
+        for fl_id in range(len(self.fls)):
+            volume += np.sum(self._get_along_fl_volume_firn_m3(fl_id))
+        return volume
+
+    @property
+    def volume_firn_km3(self):
+        return self.volume_firn_m3 * 1e-9
+
+    @property
+    def volume_m3(self):
+        if not self.separate_ice_and_firn:
+            return self.volume_ice_m3
+        else:
+            return self.volume_ice_m3 + self.volume_firn_m3
 
     @property
     def volume_km3(self):
@@ -826,6 +980,40 @@ class FlowlineModel(object):
     @property
     def length_m(self):
         return self.fls[-1].length_m
+
+    @property
+    def mass_ice_kg(self):
+        return self.volume_ice_m3 * self.ice_density
+
+    @property
+    def mass_ice_Mt(self):
+        return self.mass_ice_kg * 1e-9
+
+    def _get_along_fl_mass_firn_kg(self, fl_id):
+        return (self._get_fl_mb_model(fl_id).columns_mass_kg_per_sqm *
+                self.fls[fl_id].bin_area_m2)
+
+    @property
+    def mass_firn_kg(self):
+        mass = 0
+        for fl_id in range(len(self.fls)):
+            mass += np.sum(self._get_along_fl_mass_firn_kg(fl_id))
+        return mass
+
+    @property
+    def mass_firn_Mt(self):
+        return self.mass_firn_kg * 1e-9
+
+    @property
+    def mass_kg(self):
+        if not self.separate_ice_and_firn:
+            return self.mass_ice_kg
+        else:
+            return self.mass_ice_kg + self.mass_firn_kg
+
+    @property
+    def mass_Mt(self):
+        return self.mass_kg * 1e-9
 
     def get_mb(self, heights, year=None, fl_id=None, fls=None):
         """Get the mass balance at the requested height and time.
@@ -883,7 +1071,9 @@ class FlowlineModel(object):
         try:
             ds.attrs['description'] = 'OGGM model output'
             ds.attrs['oggm_version'] = __version__
-            ds.attrs['calendar'] = '365-day no leap'
+            ds.attrs['calendar'] = ('365/366-day (Gregorian, leap years)'
+                                    if self.use_leap_years
+                                    else '365-day (no leap)')
             ds.attrs['creation_date'] = strftime("%Y-%m-%d %H:%M:%S", gmtime())
             ds['flowlines'] = ('flowlines', np.arange(len(flows_to_id)))
             ds['flows_to_id'] = ('flowlines', flows_to_id)
@@ -948,7 +1138,7 @@ class FlowlineModel(object):
 
         # Loop over the steps we want to meet
         for y in ts:
-            t = (y - self.y0) * SEC_IN_YEAR
+            t = self._yr_to_seconds(y)
             # because of CFL, step() doesn't ensure that the end date is met
             # lets run the steps until we reach our desired date
             while self.t < t:
@@ -1100,7 +1290,9 @@ class FlowlineModel(object):
         # Global attributes
         diag_ds.attrs['description'] = 'OGGM model output'
         diag_ds.attrs['oggm_version'] = __version__
-        diag_ds.attrs['calendar'] = '365-day no leap'
+        diag_ds.attrs['calendar'] = ('365/366-day (Gregorian, leap years)'
+                                     if self.use_leap_years
+                                     else '365-day (no leap)')
         diag_ds.attrs['creation_date'] = strftime("%Y-%m-%d %H:%M:%S",
                                                   gmtime())
         diag_ds.attrs['water_level'] = self.water_level
@@ -1135,6 +1327,15 @@ class FlowlineModel(object):
             diag_ds['volume_m3'] = ('time', np.zeros(nm) * np.nan)
             diag_ds['volume_m3'].attrs['description'] = 'Total glacier volume'
             diag_ds['volume_m3'].attrs['unit'] = 'm 3'
+
+            if self.separate_ice_and_firn:
+                diag_ds['volume_ice_m3'] = ('time', np.zeros(nm) * np.nan)
+                diag_ds['volume_ice_m3'].attrs['description'] = 'Total ice volume'
+                diag_ds['volume_ice_m3'].attrs['unit'] = 'm 3'
+
+                diag_ds['volume_firn_m3'] = ('time', np.zeros(nm) * np.nan)
+                diag_ds['volume_firn_m3'].attrs['description'] = 'Total snow and firn volume'
+                diag_ds['volume_firn_m3'].attrs['unit'] = 'm 3'
 
         if 'volume_bsl' in ovars:
             diag_ds['volume_bsl_m3'] = ('time', np.zeros(nm) * np.nan)
@@ -1171,6 +1372,20 @@ class FlowlineModel(object):
             diag_ds['length_m'].attrs['description'] = 'Glacier length'
             diag_ds['length_m'].attrs['unit'] = 'm'
 
+        if 'mass' in ovars:
+            diag_ds['mass_kg'] = ('time', np.zeros(nm) * np.nan)
+            diag_ds['mass_kg'].attrs['description'] = 'Total glacier mass'
+            diag_ds['mass_kg'].attrs['unit'] = 'kg'
+
+            if self.separate_ice_and_firn:
+                diag_ds['mass_ice_kg'] = ('time', np.zeros(nm) * np.nan)
+                diag_ds['mass_ice_kg'].attrs['description'] = 'Total ice mass'
+                diag_ds['mass_ice_kg'].attrs['unit'] = 'kg'
+
+                diag_ds['mass_firn_kg'] = ('time', np.zeros(nm) * np.nan)
+                diag_ds['mass_firn_kg'].attrs['description'] = 'Total snow and firn mass'
+                diag_ds['mass_firn_kg'].attrs['unit'] = 'kg'
+
         if 'calving' in ovars:
             diag_ds['calving_m3'] = ('time', np.zeros(nm) * np.nan)
             diag_ds['calving_m3'].attrs['description'] = ('Total accumulated '
@@ -1206,7 +1421,9 @@ class FlowlineModel(object):
             for ds in fl_diag_dss:
                 ds.attrs['description'] = 'OGGM model output'
                 ds.attrs['oggm_version'] = __version__
-                ds.attrs['calendar'] = '365-day no leap'
+                ds.attrs['calendar'] = ('365/366-day (Gregorian, leap years)'
+                                        if self.use_leap_years
+                                        else '365-day (no leap)')
                 ds.attrs['creation_date'] = strftime("%Y-%m-%d %H:%M:%S", gmtime())
                 ds.attrs['water_level'] = self.water_level
                 ds.attrs['glen_a'] = self.glen_a
@@ -1241,9 +1458,18 @@ class FlowlineModel(object):
 
             for ds, sect, width, bucket in zip(fl_diag_dss, sects, widths, buckets):
                 if 'volume' in ovars_fl:
-                    ds['volume_m3'] = (('time', 'dis_along_flowline'), sect)
+                    ds['volume_m3'] = (('time', 'dis_along_flowline'), sect * np.nan)
                     ds['volume_m3'].attrs['description'] = 'Section volume'
                     ds['volume_m3'].attrs['unit'] = 'm 3'
+
+                    if self.separate_ice_and_firn:
+                        ds['volume_ice_m3'] = (('time', 'dis_along_flowline'), sect * np.nan)
+                        ds['volume_ice_m3'].attrs['description'] = 'Section ice volume'
+                        ds['volume_ice_m3'].attrs['unit'] = 'm 3'
+
+                        ds['volume_firn_m3'] = (('time', 'dis_along_flowline'), sect * np.nan)
+                        ds['volume_firn_m3'].attrs['description'] = 'Section snow and firn volume'
+                        ds['volume_firn_m3'].attrs['unit'] = 'm 3'
                 if 'volume_bsl' in ovars_fl:
                     ds['volume_bsl_m3'] = (('time', 'dis_along_flowline'), sect * 0)
                     ds['volume_bsl_m3'].attrs['description'] = 'Section volume below sea level'
@@ -1260,6 +1486,29 @@ class FlowlineModel(object):
                     ds['thickness_m'] = (('time', 'dis_along_flowline'), width * np.nan)
                     ds['thickness_m'].attrs['description'] = 'Section thickness'
                     ds['thickness_m'].attrs['unit'] = 'm'
+
+                    if self.separate_ice_and_firn:
+                        ds['thickness_ice_m'] = (('time', 'dis_along_flowline'), width * np.nan)
+                        ds['thickness_ice_m'].attrs['description'] = 'Section ice thickness'
+                        ds['thickness_ice_m'].attrs['unit'] = 'm'
+
+                        ds['thickness_firn_m'] = (('time', 'dis_along_flowline'), width * np.nan)
+                        ds['thickness_firn_m'].attrs['description'] = (
+                            'Section snow and firn thickness')
+                        ds['thickness_firn_m'].attrs['unit'] = 'm'
+                if 'mass' in ovars_fl:
+                    ds['mass_kg'] = (('time', 'dis_along_flowline'), sect * 0)
+                    ds['mass_kg'].attrs['description'] = 'Section mass'
+                    ds['mass_kg'].attrs['unit'] = 'kg'
+
+                    if self.separate_ice_and_firn:
+                        ds['mass_ice_kg'] = (('time', 'dis_along_flowline'), sect * 0)
+                        ds['mass_ice_kg'].attrs['description'] = 'Section ice mass'
+                        ds['mass_ice_kg'].attrs['unit'] = 'm 3'
+
+                        ds['mass_firn_kg'] = (('time', 'dis_along_flowline'), sect * 0)
+                        ds['mass_firn_kg'].attrs['description'] = 'Section snow and firn mass'
+                        ds['mass_firn_kg'].attrs['unit'] = 'kg'
                 if 'ice_velocity' in ovars_fl:
                     if not (hasattr(self, '_surf_vel_fac') or hasattr(self, 'u_stag')):
                         raise InvalidParamsError('This flowline model does not seem '
@@ -1334,9 +1583,9 @@ class FlowlineModel(object):
                     # depening on resolution we get seconds of period -> we want
                     # total mass not per second
                     if store_monthly_step:
-                        seconds = self.mb_model.sec_in_month(yr)
+                        seconds = self._get_sec_in_month(yr)
                     else:
-                        seconds = self.mb_model.sec_in_year(yr)
+                        seconds = self._get_sec_in_year(yr)
                     spinup_vol[j] -= np.sum(smb * a) * seconds  # minus because backwards
 
             # per unit time
@@ -1367,16 +1616,52 @@ class FlowlineModel(object):
                     for fl_id, (ds, fl) in enumerate(zip(fl_diag_dss, self.fls)):
                         # area and volume are already being taken care of above
                         if 'thickness' in ovars_fl:
-                            ds['thickness_m'].data[i, :] = fl.thick
+                            if not self.separate_ice_and_firn:
+                                ds['thickness_m'].data[i, :] = fl.thick
+                            else:
+                                ds['thickness_ice_m'].data[i, :] = fl.thick
+                                ds['thickness_firn_m'].data[i, :] = (
+                                    self._get_along_fl_thickness_firn_m(fl_id))
+                                ds['thickness_m'].data[i, :] = (
+                                    ds['thickness_ice_m'].data[i, :] +
+                                    ds['thickness_firn_m'].data[i, :]
+                                )
+                        if 'volume' in ovars_fl:
+                            if not self.separate_ice_and_firn:
+                                ds['volume_m3'].data[i, :] = (
+                                    fl.section * fl.dx_meter)
+                            else:
+                                ds['volume_ice_m3'].data[i, :] = (
+                                    fl.section * fl.dx_meter)
+                                ds['volume_firn_m3'].data[i, :] = (
+                                    self._get_along_fl_volume_firn_m3(fl_id))
+                                ds['volume_m3'].data[i, :] = (
+                                    ds['volume_ice_m3'].data[i, :] +
+                                    ds['volume_firn_m3'].data[i, :]
+                                )
                         if 'volume_bsl' in ovars_fl:
                             ds['volume_bsl_m3'].data[i, :] = fl.volume_bsl_m3
                         if 'volume_bwl' in ovars_fl:
                             ds['volume_bwl_m3'].data[i, :] = fl.volume_bwl_m3
+                        if 'mass' in ovars_fl:
+                            if not self.separate_ice_and_firn:
+                                ds['mass_kg'].data[i, :] = (
+                                        fl.section * fl.dx_meter * self.ice_density)
+                            else:
+                                ds['mass_ice_kg'].data[i, :] = (
+                                        fl.section * fl.dx_meter * self.ice_density)
+                                ds['mass_firn_kg'].data[i, :] = (
+                                    self._get_along_fl_mass_firn_kg(fl_id))
+                                ds['mass_kg'].data[i, :] = (
+                                    ds['mass_ice_kg'].data[i, :] +
+                                    ds['mass_firn_kg'].data[i, :]
+                                )
                         if 'ice_velocity' in ovars_fl and (yr > self.y0):
                             # Velocity can only be computed with dynamics
                             var = self.u_stag[fl_id]
                             val = (var[1:fl.nx + 1] + var[:fl.nx]) / 2 * self._surf_vel_fac
-                            ds['ice_velocity_myr'].data[i, :] = val * cfg.SEC_IN_YEAR
+                            ds['ice_velocity_myr'].data[i, :] = (
+                                    val * self._get_sec_in_year(yr))
                         if 'dhdt' in ovars_fl and (yr > self.y0):
                             # dhdt can only be computed after one step
                             val = fl.thick - thickness_previous_dhdt[fl_id]
@@ -1392,7 +1677,10 @@ class FlowlineModel(object):
                             # isclose for avoiding numeric represention artefacts
                             dhdt_zero = np.isclose(ds['dhdt'].data[i, :],
                                                    0.)
-                            fac_sec = cfg.SEC_IN_MONTH if store_monthly_step else cfg.SEC_IN_YEAR
+                            if store_monthly_step:
+                                fac_sec = self._get_sec_in_month(monthly_time[i - 1])
+                            else:
+                                fac_sec = self._get_sec_in_year(monthly_time[i - 1])
                             ds['climatic_mb'].data[i, :] = np.where(
                                 dhdt_zero,
                                 0.,
@@ -1421,10 +1709,18 @@ class FlowlineModel(object):
             # Diagnostics
             if 'volume' in ovars:
                 diag_ds['volume_m3'].data[i] = self.volume_m3
+                if self.separate_ice_and_firn:
+                    diag_ds['volume_ice_m3'].data[i] = self.volume_ice_m3
+                    diag_ds['volume_firn_m3'].data[i] = self.volume_firn_m3
             if 'area' in ovars:
                 diag_ds['area_m2'].data[i] = self.area_m2
             if 'length' in ovars:
                 diag_ds['length_m'].data[i] = self.length_m
+            if 'mass' in ovars:
+                diag_ds['mass_kg'].data[i] = self.mass_kg
+                if self.separate_ice_and_firn:
+                    diag_ds['mass_ice_kg'].data[i] = self.mass_ice_kg
+                    diag_ds['mass_firn_kg'].data[i] = self.mass_firn_kg
             if 'calving' in ovars:
                 diag_ds['calving_m3'].data[i] = self.calving_m3_since_y0
             if 'calving_rate' in ovars:
@@ -1460,7 +1756,9 @@ class FlowlineModel(object):
                 ds = xr.Dataset()
                 ds.attrs['description'] = 'OGGM model output'
                 ds.attrs['oggm_version'] = __version__
-                ds.attrs['calendar'] = '365-day no leap'
+                ds.attrs['calendar'] = ('365/366-day (Gregorian, leap years)'
+                                        if self.use_leap_years
+                                        else '365-day (no leap)')
                 ds.attrs['creation_date'] = strftime("%Y-%m-%d %H:%M:%S",
                                                      gmtime())
                 ds.attrs['water_level'] = self.water_level
@@ -1510,7 +1808,6 @@ class FlowlineModel(object):
                 dx = ds.attrs['map_dx'] * ds.attrs['dx']
                 # No inplace because the other dataset uses them
                 # These variables are always there (see above)
-                ds['volume_m3'] = ds['volume_m3'] * dx
                 ds['area_m2'] = ds['area_m2'].where(ds['volume_m3'] > 0, 0) * dx
                 if stop_criterion is not None:
                     # Remove probable nans
@@ -1892,7 +2189,7 @@ class FluxBasedModel(FlowlineModel):
             # Staggered velocity (Deformation + Sliding)
             # _fd = 2/(N+2) * self.glen_a
             N = self.glen_n
-            rhogh = (self.rho*G*slope_stag)**N
+            rhogh = (self.ice_density * G * slope_stag) ** N
             u_stag[:] = (thick_stag**(N+1)) * self._fd * rhogh * sf_stag**N + \
                         (thick_stag**(N-1)) * self.fs * rhogh
 
@@ -1927,7 +2224,7 @@ class FluxBasedModel(FlowlineModel):
                             'bin_id {} and max_u {:.3f} m yr-1.'
                             ''.format(cfl_dt, self.min_dt, self.yr, fl_id,
                                       np.argmax(np.abs(u_stag)),
-                                      maxu * cfg.SEC_IN_YEAR))
+                                      maxu * self._get_sec_in_year(self.yr)))
 
             # Since we are in this loop, reset the tributary flux
             trib_flux[:] = 0
@@ -2194,7 +2491,7 @@ class KarthausModel(FlowlineModel):
 
         # Diffusivity
         N = self.glen_n
-        Diffusivity = width * (self.rho*G)**3 * thick**3 * SurfaceGradient**2
+        Diffusivity = width * (self.ice_density * G) ** 3 * thick ** 3 * SurfaceGradient ** 2
         Diffusivity *= 2/(N+2) * self.glen_a * thick**2 + self.fs
 
         # on stagger
@@ -2345,7 +2642,7 @@ class SemiImplicitModel(FlowlineModel):
         self.d_matrix_banded = np.zeros((3, nx))
         w0 = self.fls[0]._w0_m
         self.w0_stag = (w0[0:-1] + w0[1:]) / 2
-        self.rhog = (self.rho * G) ** self.glen_n
+        self.rhog = (self.ice_density * G) ** self.glen_n
 
         # variables needed for the calculation of some diagnostics, this
         # calculations are done with @property, because they are not computed
@@ -2474,7 +2771,7 @@ class SemiImplicitModel(FlowlineModel):
                         'bin_id {} and max_D {:.3f} m2 yr-1.'
                         ''.format(cfl_dt, self.min_dt, self.yr, 0,
                                   np.argmax(np.abs(d_stag)),
-                                  divisor * cfg.SEC_IN_YEAR))
+                                  divisor * self._get_sec_in_year(self.yr)))
 
         # calculate diagonals of Amat
         d0 = dt / dx ** 2 * (d_stag[:-1] + d_stag[1:]) / width
@@ -2781,13 +3078,13 @@ class MassRedistributionCurveModel(FlowlineModel):
         # Just a check to avoid useless computations
         if dt <= 0:
             raise InvalidParamsError('dt needs to be strictly positive')
-        if dt > cfg.SEC_IN_YEAR:
+        if dt > self._get_sec_in_year(self.yr):
             # This should not happen from how run_until is built, but
             # to match the adaptive time stepping scheme of other models
             # we don't complain here and just do one year
-            dt = cfg.SEC_IN_YEAR
+            dt = self._get_sec_in_year(self.yr)
 
-        elif dt < cfg.SEC_IN_YEAR:
+        elif dt < self._get_sec_in_year(self.yr):
             # Here however we complain - we really want one year exactly
             raise InvalidWorkflowError('I was asked to run for less than one '
                                        'year. Delta-H models can\'t do that.')
@@ -2815,7 +3112,7 @@ class MassRedistributionCurveModel(FlowlineModel):
         # Annual glacier mass balance [m ice s-1]
         mb = self.get_mb(height, year=self.yr, fls=self.fls, fl_id=fl_id)
         # [m ice yr-1]
-        mb *= cfg.SEC_IN_YEAR
+        mb *= self._get_sec_in_year(self.yr)
 
         # Ok now to the bulk of it
         # Mass redistribution according to empirical equations from

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -1273,11 +1273,6 @@ class FlowlineModel(object):
             self.to_geometry_netcdf(geom_path)
 
         nm = len(monthly_time)
-        if nm == 1:
-            yrs = [yrs]
-            hyrs = [hyrs]
-            months = [months]
-            hmonths = [hmonths]
 
         if do_geom or do_fl_diag:
             sects = [(np.zeros((nm, fl.nx)) * np.nan) for fl in self.fls]

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -61,9 +61,9 @@ class MassBalanceModel(object, metaclass=SuperclassMeta):
         self.valid_bounds = None
         self.hemisphere = None
         if gdir is None:
-            self.rho = cfg.PARAMS['ice_density']
+            self.ice_density = cfg.PARAMS['ice_density']
         else:
-            self.rho = gdir.settings['ice_density']
+            self.ice_density = gdir.settings['ice_density']
             self.gdir = gdir
         self.use_leap_years = use_leap_years
 
@@ -318,7 +318,7 @@ class MassBalanceModel(object, metaclass=SuperclassMeta):
             mbs *= unit_conversion(mb_yr)
             stack.append(mbs)
 
-        return set_array_type(stack) * self.rho
+        return set_array_type(stack) * self.ice_density
 
     def get_ela(self, year=None, **kwargs):
         """Get the equilibrium line altitude for a given year.
@@ -354,7 +354,7 @@ class MassBalanceModel(object, metaclass=SuperclassMeta):
 
                 def to_minimize(x):
                     return (self.get_annual_mb([x], year=mb_year, **kwargs)[0] *
-                            year_length * self.rho)
+                            year_length * self.ice_density)
                 stack.append(optimize.brentq(to_minimize, *self.valid_bounds,
                                              xtol=0.1))
 
@@ -378,26 +378,28 @@ class MassBalanceModel(object, metaclass=SuperclassMeta):
 class ScalarMassBalance(MassBalanceModel):
     """Constant mass balance, everywhere."""
 
-    def __init__(self, mb=0.):
+    def __init__(self, mb=0., use_leap_years=False):
         """ Initialize.
 
         Parameters
         ----------
         mb : float
             Fix the mass balance to a certain value (unit: [mm w.e. yr-1])
+        use_leap_years : bool
+            If the calendar should use leap years
         """
-        super(ScalarMassBalance, self).__init__()
+        super(ScalarMassBalance, self).__init__(use_leap_years=use_leap_years)
         self.hemisphere = 'nh'
         self.valid_bounds = [-2e4, 2e4]  # in m
         self._mb = mb
 
     def get_monthly_mb(self, heights, **kwargs):
         mb = np.asarray(heights) * 0 + self._mb
-        return mb / SEC_IN_YEAR / self.rho
+        return mb / SEC_IN_YEAR / self.ice_density
 
     def get_annual_mb(self, heights, **kwargs):
         mb = np.asarray(heights) * 0 + self._mb
-        return mb / SEC_IN_YEAR / self.rho
+        return mb / SEC_IN_YEAR / self.ice_density
 
     def is_year_valid(self, year):
         return True
@@ -417,7 +419,7 @@ class LinearMassBalance(MassBalanceModel):
     temp_bias
     """
 
-    def __init__(self, ela_h, grad=3., max_mb=None):
+    def __init__(self, ela_h, grad=3., max_mb=None, use_leap_years=False):
         """ Initialize.
 
         Parameters
@@ -428,8 +430,10 @@ class LinearMassBalance(MassBalanceModel):
             Mass balance gradient (unit: [mm w.e. yr-1 m-1])
         max_mb: float
             Cap the mass balance to a certain value (unit: [mm w.e. yr-1])
+        use_leap_years : bool
+            If the calendar should use leap years
         """
-        super(LinearMassBalance, self).__init__()
+        super(LinearMassBalance, self).__init__(use_leap_years=use_leap_years)
         self.hemisphere = 'nh'
         self.valid_bounds = [-1e4, 2e4]  # in m
         self.orig_ela_h = ela_h
@@ -457,7 +461,7 @@ class LinearMassBalance(MassBalanceModel):
         mb = (np.asarray(heights) - self.ela_h) * self.grad
         if self.max_mb is not None:
             clip_max(mb, self.max_mb, out=mb)
-        return mb / SEC_IN_YEAR / self.rho
+        return mb / SEC_IN_YEAR / self.ice_density
 
     def get_annual_mb(self, heights, **kwargs):
         return self.get_monthly_mb(heights, **kwargs)
@@ -949,8 +953,8 @@ class MonthlyTIModel(MassBalanceModel):
         sec_in_month = self.sec_in_month(year=year)
         mb_month -= (self.bias * sec_in_month / self.sec_in_year(year=year))
         if add_climate:
-            return mb_month / sec_in_month / self.rho, t, tmelt, prcp, prcpsol
-        return mb_month / sec_in_month / self.rho
+            return mb_month / sec_in_month / self.ice_density, t, tmelt, prcp, prcpsol
+        return mb_month / sec_in_month / self.ice_density
 
     def get_annual_mb(self, heights, year=None, add_climate=False, **kwargs):
         """Get annual mass balance.
@@ -986,7 +990,7 @@ class MonthlyTIModel(MassBalanceModel):
 
         mb_annual = np.sum(prcpsol - self.melt_f * tmelt, axis=1)
         mb_annual = ((mb_annual - self.bias) / self.sec_in_year(year=year) /
-                     self.rho)
+                     self.ice_density)
         if add_climate:
             return (mb_annual, t.mean(axis=1), tmelt.sum(axis=1),
                     prcp.sum(axis=1), prcpsol.sum(axis=1))
@@ -1228,9 +1232,9 @@ class DailyTIModel(MonthlyTIModel):
         mb_daily -= (self.bias * SEC_IN_DAY / self.sec_in_year(year=year))
 
         if add_climate:
-            return (mb_daily / SEC_IN_DAY / self.rho,
+            return (mb_daily / SEC_IN_DAY / self.ice_density,
                     t, tmelt, prcp, prcpsol)
-        return mb_daily / SEC_IN_DAY / self.rho
+        return mb_daily / SEC_IN_DAY / self.ice_density
 
     def get_monthly_mb(self,
                        heights: np.ndarray,
@@ -1272,10 +1276,10 @@ class DailyTIModel(MonthlyTIModel):
         mb_month -= (self.bias * sec_in_month / self.sec_in_year(year=year))
 
         if add_climate:
-            return (mb_month / sec_in_month / self.rho, t.mean(axis=1),
+            return (mb_month / sec_in_month / self.ice_density, t.mean(axis=1),
                     tmelt.sum(axis=1), prcp.sum(axis=1), prcpsol.sum(axis=1))
 
-        return mb_month / sec_in_month / self.rho
+        return mb_month / sec_in_month / self.ice_density
 
     def get_annual_mb(self,
                       heights: np.ndarray,
@@ -1314,7 +1318,7 @@ class DailyTIModel(MonthlyTIModel):
         mb_annual = np.sum(prcpsol - self.melt_f * tmelt,
                            axis=1)
         mb_annual = ((mb_annual - self.bias) / self.sec_in_year(year=year) /
-                     self.rho)
+                     self.ice_density)
 
         if add_climate:
             return (mb_annual, t.mean(axis=1), tmelt.sum(axis=1),
@@ -1335,8 +1339,8 @@ class SfcTypeTIModel(MassBalanceModel):
         settings_filesuffix: str = "",
         use_leap_years: bool = True,
         mb_model_class=DailyTIModel,
-        climate_resolution: str = "annual",
-        aging_frequency: str = "annual",
+        climate_resolution: str = "monthly",
+        aging_frequency: str = "monthly",
         melt_f_ratio: float = 0.5,
         melt_f_change: str = "neg_exp",
         tau_e: float = 1.0,
@@ -1352,6 +1356,8 @@ class SfcTypeTIModel(MassBalanceModel):
         use_previous_mbs: bool = False,
         store_snowline: bool = False,
         store_snowline_start_month: str = 'Oct',
+        snow_density: float = 300,
+        density_change: str = "neg_exp",
         **kwargs,
     ):
         """Surface type temperature index model.
@@ -1444,6 +1450,14 @@ class SfcTypeTIModel(MassBalanceModel):
             the snowline. E.g. with the default 'Oct', if you want to derive the
             snowline at Mar, all buckets starting from the previous Oct are
             considered.
+        snow_density: float, default 300
+            The assumed density of fresh snow.
+        density_change: str, default "neg_exp"
+            How the density from snow to firn to ice changes over time. The
+            options "linear" or "neg_exp" (see `tau_e` for the equation) just
+            mimik the implementations for melt_f (assuming a one to one relation
+            between melt_f and density). This is currently experimental and
+            needs further research.
         **kwargs:
             keyword arguments to pass to the mb_model_class
         """
@@ -1565,7 +1579,15 @@ class SfcTypeTIModel(MassBalanceModel):
         self.melt_f_ratio = melt_f_ratio
         self.melt_f_change = melt_f_change
         self.melt_f_buckets = None
+        self._melt_f_buckets_np = None
         self.set_melt_f_buckets()
+
+        # stuff related to varying density for each bucket
+        self.snow_density = snow_density
+        self.density_change = density_change
+        self.density_buckets = None
+        self._density_buckets_np = None
+        self.set_density_buckets()
 
         # define if some additonal outputs should be saved along the way
         if ((store_buckets == 'monthly' and
@@ -1709,6 +1731,20 @@ class SfcTypeTIModel(MassBalanceModel):
                             index=self.buckets_grid_point_label)
 
     @property
+    def columns_thickness_m(self):
+        # total thickness of all snow and firn buckets, ignoring ice bucket
+        return np.sum(self.buckets_thickness_m, axis=1)
+
+    @property
+    def buckets_thickness_m(self):
+        # individual thickness of each bucket, ignoring ice bucket
+        return self.mb_buckets_np[:, :-1] / self._density_buckets_np[:, :-1]
+
+    @property
+    def columns_mass_kg_per_sqm(self):
+        return np.sum(self.mb_buckets_np, axis=1)
+
+    @property
     def snowline(self):
         return np.array(self._snowline)
 
@@ -1776,6 +1812,38 @@ class SfcTypeTIModel(MassBalanceModel):
         else:
             raise NotImplementedError(f"melt_f_change: {self.melt_f_change}")
 
+        # save the melt_f values as pure numpy array
+        self._melt_f_buckets_np = np.asarray(
+            list(self.melt_f_buckets.values())[:-1], dtype=float)[None, :]
+
+    def set_density_buckets(self):
+        """Set the density for each bucket."""
+        if self.density_change == "linear":
+            self.density_buckets = dict(
+                zip(self.buckets,
+                    np.linspace(self.snow_density, self.ice_density,
+                                len(self.buckets),),
+                    )
+            )
+        elif self.density_change == "neg_exp":
+            if self.tau_e <= 0:
+                raise InvalidParamsError("`tau_e` must be above zero for"
+                                         "`density_change` = 'neg_exp'.")
+            buckets_linspace = np.linspace(0, self.spinup_years,
+                                           len(self.buckets))
+            self.density_buckets = dict(
+                zip(self.buckets,
+                    self.ice_density + (self.snow_density - self.ice_density) *
+                    np.exp(-buckets_linspace / self.tau_e),
+                    )
+            )
+        else:
+            raise NotImplementedError(f"density_change: {self.density_change}")
+
+        # save the density values as pure numpy array
+        self._density_buckets_np = np.asarray(
+            list(self.density_buckets.values()), dtype=float)[None, :]
+
     def _apply_climate_step_and_aging_to_buckets(
         self,
         heights: ArrayLike,
@@ -1841,8 +1909,7 @@ class SfcTypeTIModel(MassBalanceModel):
         # we need the sum of the old buckets later for calculating delta kg m-2
         snow_buckets_old_sum = snow_buckets_new.sum(axis=1)
         # melt_f per bucket without ice, (1, nr_buckets)
-        melt_f_buckets = np.asarray(list(self.melt_f_buckets.values())[:-1],
-                                    dtype=float)[None, :]
+        melt_f_buckets = self._melt_f_buckets_np
         # add one axis to tmelt for correct shape, (nr_grid_points, 1)
         tmelt = tmelt[:, None]
 
@@ -2140,6 +2207,7 @@ class SfcTypeTIModel(MassBalanceModel):
                       year: int or float,
                       add_climate: bool = False,
                       climatic_mb_or_ice_mb: str = 'climatic_mb',
+                      include_mb_model_heights: bool = False,
                       **kwargs,
                       ) -> np.float64 or tuple:
         """Get annual climatic mass balance or the ice mass balance.
@@ -2164,6 +2232,9 @@ class SfcTypeTIModel(MassBalanceModel):
             Defines if you want to retrive the climatic mass balance or the mass
             balance only for ice. The later one is meant to be used together
             with ice dynamics
+        include_mb_model_heights : bool, default False
+            If True we add the current bucket heights to the provided heights
+            to account for elevation feedback due to the bucket heights.
         **kwargs
             Extra arguments passed to subclasses of this method.
 
@@ -2175,6 +2246,10 @@ class SfcTypeTIModel(MassBalanceModel):
             temperature, the sums of melt temperature, total precipitation, and
             solid precipitation.
         """
+
+        # check if we should add the current bucket heights
+        if include_mb_model_heights:
+            heights = heights + self.columns_thickness_m
 
         # compute all steps up to the desired target year using constant heights
         self._run_until(heights=heights, year=year,
@@ -2208,7 +2283,7 @@ class SfcTypeTIModel(MassBalanceModel):
 
         # convert from kg m-2 to m s-1
         annual_mb = ((annual_mb - self.mbmod.bias) / self.sec_in_year(year) /
-                     self.mbmod.rho)
+                     self.mbmod.ice_density)
 
         if add_climate:
             # because of the use of different climate resolutions we always need
@@ -2225,6 +2300,7 @@ class SfcTypeTIModel(MassBalanceModel):
                        year: float,
                        add_climate: bool = False,
                        climatic_mb_or_ice_mb: str = 'climatic_mb',
+                       include_mb_model_heights: bool = False,
                        **kwargs,
                        ) -> np.float64 or tuple:
         """Get monthly climatic mass balance or the ice mass balance.
@@ -2249,6 +2325,9 @@ class SfcTypeTIModel(MassBalanceModel):
             Defines if you want to retrive the climatic mass balance or the mass
             balance only for ice. The later one is meant to be used together
             with ice dynamics
+        include_mb_model_heights : bool, default False
+            If True we add the current bucket heights to the provided heights
+            to account for elevation feedback due to the bucket heights.
         **kwargs
             Extra arguments passed to subclasses of this method.
 
@@ -2260,6 +2339,10 @@ class SfcTypeTIModel(MassBalanceModel):
             temperature, the sums of melt temperature, total precipitation, and
             solid precipitation.
         """
+
+        # check if we should add the current bucket heights
+        if include_mb_model_heights:
+            heights = heights + self.columns_thickness_m
 
         # compute all steps up to the desired target year using constant heights
         self._run_until(heights=heights, year=year,
@@ -2303,7 +2386,7 @@ class SfcTypeTIModel(MassBalanceModel):
         # convert from kg m-2 to m s-1
         monthly_mb = ((monthly_mb / self.sec_in_month(year=year) -
                        self.mbmod.bias / self.sec_in_year(year)) /
-                      self.mbmod.rho)
+                      self.mbmod.ice_density)
 
         if add_climate:
             # because of the use of different climate resolutions we always need
@@ -2320,6 +2403,7 @@ class SfcTypeTIModel(MassBalanceModel):
                      year: float,
                      add_climate: bool = False,
                      climatic_mb_or_ice_mb: str = 'climatic_mb',
+                     include_mb_model_heights: bool = False,
                      **kwargs,
                      ) -> np.float64 or tuple:
         """Get daily climatic mass balance or the ice mass balance.
@@ -2344,6 +2428,9 @@ class SfcTypeTIModel(MassBalanceModel):
             Defines if you want to retrive the climatic mass balance or the mass
             balance only for ice. The later one is meant to be used together
             with ice dynamics
+        include_mb_model_heights : bool, default False
+            If True we add the current bucket heights to the provided heights
+            to account for elevation feedback due to the bucket heights.
         **kwargs
             Extra arguments passed to subclasses of this method.
 
@@ -2355,6 +2442,10 @@ class SfcTypeTIModel(MassBalanceModel):
             temperature, the sums of melt temperature, total precipitation, and
             solid precipitation.
         """
+
+        # check if we should add the current bucket heights
+        if include_mb_model_heights:
+            heights = heights + self.columns_thickness_m
 
         # compute all steps up to the desired target year using constant heights
         self._run_until(heights=heights, year=year,
@@ -2382,7 +2473,7 @@ class SfcTypeTIModel(MassBalanceModel):
         # convert from kg m-2 to m s-1
         daily_mb = ((daily_mb / SEC_IN_DAY -
                      self.mbmod.bias / self.sec_in_year(year)) /
-                    self.mbmod.rho)
+                    self.mbmod.ice_density)
 
         if add_climate:
             # because of the use of different climate resolutions we always need
@@ -2959,7 +3050,7 @@ class MultipleFlowlineMassBalance(MassBalanceModel):
 
         self.valid_bounds = self.flowline_mb_models[-1].valid_bounds
         self.hemisphere = gdir.hemisphere
-        self.rho = self.flowline_mb_models[-1].rho
+        self.ice_density = self.flowline_mb_models[-1].ice_density
         self.use_leap_years = self.flowline_mb_models[-1].use_leap_years
 
     @property
@@ -2997,6 +3088,12 @@ class MultipleFlowlineMassBalance(MassBalanceModel):
 
     def is_year_valid(self, year):
         return self.flowline_mb_models[0].is_year_valid(year)
+
+    def sec_in_month(self, year):
+        return self.flowline_mb_models[0].sec_in_month(year)
+
+    def sec_in_year(self, year):
+        return self.flowline_mb_models[0].sec_in_year(year)
 
     def get_daily_mb(self, heights, year=None, fl_id=None, **kwargs):
         if fl_id is None:

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -26,7 +26,7 @@ from oggm.utils import (SuperclassMeta, get_geodetic_mb_dataframe,
                         get_seconds_of_month, )
 from oggm.exceptions import (InvalidWorkflowError, InvalidParamsError,
                              MassBalanceCalibrationError)
-from oggm import entity_task
+from oggm import entity_task, __version__
 
 # Module logger
 log = logging.getLogger(__name__)
@@ -1472,6 +1472,7 @@ class SfcTypeTIModel(MassBalanceModel):
         # melt_f, prcp_fac and temp_bias
         if mb_model_class not in [MonthlyTIModel, DailyTIModel]:
             raise NotImplementedError(f"mb_model_class: {mb_model_class}")
+        self.mb_model_class = mb_model_class.__name__
         self.mbmod = mb_model_class(gdir=gdir,
                                     settings_filesuffix=settings_filesuffix,
                                     **kwargs)
@@ -1530,29 +1531,32 @@ class SfcTypeTIModel(MassBalanceModel):
 
         # defining the number of grid points and the spinup heights, either with
         # fl or hbins
-        self.hbins = hbins  # TODO: need to test with constant_mb (maybe hbins[::-1])
+        # TODO: need to test with constant_mb (maybe hbins[::-1])
+        self.hbins = hbins
+
+        # resolve the flowline into grid labels and spinup heights; the fl
+        # object itself is not stored — only the derived arrays are needed
         if fl is not None:
-            self.fl = fl
+            _fl = fl
         else:
-            if use_main_fl_from == 'inversion_flowlines':
-                self.fl = self.gdir.read_pickle("inversion_flowlines")[-1]
+            if self.hbins is not None:
+                _fl = None
+            elif use_main_fl_from == 'inversion_flowlines':
+                _fl = self.gdir.read_pickle("inversion_flowlines")[-1]
             elif use_main_fl_from == 'model_flowlines':
-                self.fl = self.gdir.read_pickle("model_flowlines")[-1]
-            elif self.hbins is not None:
-                # ok we are working with height bins here, don't need the fl
-                self.fl = None
+                _fl = self.gdir.read_pickle("model_flowlines")[-1]
             else:
                 raise InvalidParamsError("We need a flowline or height bins "
                                          "(hbins) for defining the number of "
                                          "buckets we want to compute!")
 
         # create labels for the grid_points and define heights used during spinup
-        if self.fl is not None:
+        if _fl is not None:
             # for the flowline we use the distance along the flowline
-            self.buckets_grid_point_label = self.fl.dx_meter * np.arange(self.fl.nx)
-            self.spinup_heights = self.fl.surface_h
+            self.buckets_grid_point_label = _fl.dx_meter * np.arange(_fl.nx)
+            self.spinup_heights = _fl.surface_h
         else:
-            # for hbins we just use numbers
+            # for hbins we just use numbers for the labels
             self.buckets_grid_point_label = np.arange(len(self.hbins))
             self.spinup_heights = self.hbins
 
@@ -1809,12 +1813,14 @@ class SfcTypeTIModel(MassBalanceModel):
                     np.exp(-buckets_linspace / self.tau_e),
                     )
             )
+            # ice bucket should be exactly melt_f (neg_exp only asymptotes)
+            self.melt_f_buckets[self.buckets[-1]] = self.melt_f
         else:
             raise NotImplementedError(f"melt_f_change: {self.melt_f_change}")
 
         # save the melt_f values as pure numpy array
         self._melt_f_buckets_np = np.asarray(
-            list(self.melt_f_buckets.values())[:-1], dtype=float)[None, :]
+            list(self.melt_f_buckets.values()), dtype=float)[None, :]
 
     def set_density_buckets(self):
         """Set the density for each bucket."""
@@ -1837,6 +1843,8 @@ class SfcTypeTIModel(MassBalanceModel):
                     np.exp(-buckets_linspace / self.tau_e),
                     )
             )
+            # ice bucket should be exactly ice_density (neg_exp only asymptotes)
+            self.density_buckets[self.buckets[-1]] = self.ice_density
         else:
             raise NotImplementedError(f"density_change: {self.density_change}")
 
@@ -1909,7 +1917,7 @@ class SfcTypeTIModel(MassBalanceModel):
         # we need the sum of the old buckets later for calculating delta kg m-2
         snow_buckets_old_sum = snow_buckets_new.sum(axis=1)
         # melt_f per bucket without ice, (1, nr_buckets)
-        melt_f_buckets = self._melt_f_buckets_np
+        melt_f_buckets_firn = self._melt_f_buckets_np[0, : -1]
         # add one axis to tmelt for correct shape, (nr_grid_points, 1)
         tmelt = tmelt[:, None]
 
@@ -1919,9 +1927,9 @@ class SfcTypeTIModel(MassBalanceModel):
         # now calculate cumulative tfm needed to melt each bucket and subtract
         # available tmelt, finally we convert back to mass in each bucket
         # (nr_grid_points, nr_buckets)
-        buckets_kg_m2_cumsum_left = (((snow_buckets_new / melt_f_buckets
+        buckets_kg_m2_cumsum_left = (((snow_buckets_new / melt_f_buckets_firn
                                        ).cumsum(axis=1) - tmelt) *
-                                     melt_f_buckets)
+                                     melt_f_buckets_firn)
 
         # when the cumsum is negative this bucket and all above have melted
         # completely, (nr_grid_points, nr_buckets)
@@ -1945,9 +1953,11 @@ class SfcTypeTIModel(MassBalanceModel):
         # melting all buckets
         all_melted_grid_points = (nr_melted_buckets == nr_buckets)
         if np.any(all_melted_grid_points):
+            # convert to tfm using melt_f of last firn bucket
             remaining_tfm = -(buckets_kg_m2_cumsum_left[all_melted_grid_points, -1] /
-                              melt_f_buckets[:, -1])
-            ice_melt_kg_m2 = remaining_tfm * self.melt_f_buckets['ice']
+                              melt_f_buckets_firn[-1])
+            # _melt_f_buckets_np[0, -1] is ice melt_f
+            ice_melt_kg_m2 = remaining_tfm * self._melt_f_buckets_np[0, -1]
             # we use -= here because there could be some newly formed ice
             # already in the ice bucket after aging
             self.mb_buckets_np[all_melted_grid_points, -1] -= ice_melt_kg_m2
@@ -2143,7 +2153,7 @@ class SfcTypeTIModel(MassBalanceModel):
         # calculate all needed time steps with the same heights
         if self.climate_resolution == 'annual':
             if mb_resolution == 'annual':
-                missing_float_years = range(self.mb_buckets_year, int(year) + 1)
+                missing_float_years = range(int(self.mb_buckets_year), int(year) + 1)
             else:
                 # mb_resolution can not be shorter than climate_resolution
                 raise NotImplementedError(f"mb_resolution: {mb_resolution}")
@@ -2495,6 +2505,375 @@ class SfcTypeTIModel(MassBalanceModel):
         # in dynamic spinup
         raise NotImplementedError("Getting the ela for SfcTypeTIModel is"
                                   "currently not supported.")
+
+    def _to_dataset(self):
+        """Build and return the xr.Dataset representing the full model state.
+
+        Used by :meth:`save_to_file` and by
+        :meth:`MultipleFlowlineMassBalance.save_to_file` (which writes each
+        flowline as a separate nc group in one shared file).
+        """
+        current_index = self._current_index
+
+        n_pts = self.mb_buckets_np.shape[0]
+        n_buckets = self.mb_buckets_np.shape[1]  # snow + firn + ice
+
+        # coordinates
+        coords = {
+            'grid_point': xr.DataArray(
+                np.arange(n_pts),
+                dims=['grid_point'],
+                attrs={'description': 'grid points along the flowline'},
+            ),
+            'bucket': xr.DataArray(
+                np.arange(n_buckets),
+                dims=['bucket'],
+                attrs={'description': 'buckets per grid point '
+                                      '(snow, firn_1 … firn_N, ice)'},
+            ),
+            'time': xr.DataArray(
+                np.array(list(self._year_to_index.keys()), dtype=float),
+                dims=['time'],
+                attrs={'description': 'Floating year'},
+            ),
+        }
+
+        # data variables
+        data_vars = {
+            # full bucket state including ice
+            'mb_buckets': xr.DataArray(
+                self.mb_buckets_np.copy(),
+                dims=['grid_point', 'bucket'],
+                attrs={'units': 'kg m-2',
+                       'long_name': 'bucket mass per grid point '
+                                    '(snow, firn_1 … firn_N, ice)'},
+            ),
+            # per-bucket arrays including ice
+            'melt_f_buckets': xr.DataArray(
+                np.array(list(self.melt_f_buckets.values())),
+                dims=['bucket'],
+                attrs={'units': 'kg m-2 day-1 K-1',
+                       'long_name': 'melt factor per bucket '
+                                    '(snow, firn_1 … firn_N, ice)'},
+            ),
+            'density_buckets': xr.DataArray(
+                np.array(list(self.density_buckets.values())),
+                dims=['bucket'],
+                attrs={'units': 'kg m-3',
+                       'long_name': 'density per bucket '
+                                    '(snow, firn_1 … firn_N, ice)'},
+            ),
+            # grid geometry
+            'buckets_grid_point_label': xr.DataArray(
+                self.buckets_grid_point_label,
+                dims=['grid_point'],
+                attrs={'long_name': 'grid point label '
+                                    '(distance along flowline or bin index)'},
+            ),
+            'spinup_heights': xr.DataArray(
+                self.spinup_heights,
+                dims=['grid_point'],
+                attrs={'units': 'm', 'long_name': 'heights used during spinup'},
+            ),
+            # computed MB output arrays (only filled portion);
+            # 'time' coordinate carries the float-year values
+            'climatic_mb': xr.DataArray(
+                self._climatic_mb[:current_index],
+                dims=['time', 'grid_point'],
+                attrs={'units': 'kg m-2',
+                       'long_name': 'climatic mass balance per timestep'},
+            ),
+            'ice_mb': xr.DataArray(
+                self._ice_mb[:current_index],
+                dims=['time', 'grid_point'],
+                attrs={'units': 'kg m-2',
+                       'long_name': 'ice mass balance per timestep'},
+            ),
+            'mb_heights_stored': xr.DataArray(
+                self._mb_heights[:current_index],
+                dims=['time', 'grid_point'],
+                attrs={'units': 'm',
+                       'long_name': 'heights used per timestep'},
+            ),
+        }
+
+        # conditional data variables
+        if self.store_snowline and len(self._snowline) > 0:
+            data_vars['snowline'] = xr.DataArray(
+                np.array(self._snowline),
+                dims=['snowline_step'],
+                attrs={'units': 'm', 'long_name': 'snowline elevation'},
+            )
+            data_vars['snowline_year'] = xr.DataArray(
+                np.array(self._snowline_year),
+                dims=['snowline_step'],
+                attrs={'long_name': 'float year of snowline record'},
+            )
+
+        if self.store_buckets_dates is not None:
+            data_vars['store_buckets_dates_arr'] = xr.DataArray(
+                np.array(self.store_buckets_dates, dtype=float),
+                dims=['bucket_date'],
+                attrs={'long_name': 'float years for which buckets are stored'},
+            )
+
+        if self.hbins is not None:
+            data_vars['hbins'] = xr.DataArray(
+                np.array(self.hbins),
+                dims=['grid_point'],
+                attrs={'units': 'm', 'long_name': 'height bins'},
+            )
+
+        # attributes (scalars / strings)
+        _snowline_month_to_str = {
+            11: 'Jan', 10: 'Feb', 9: 'Mar', 8: 'Apr', 7: 'May', 6: 'Jun',
+            5: 'Jul', 4: 'Aug', 3: 'Sep', 2: 'Oct', 1: 'Nov', 0: 'Dec',
+        }
+        store_snowline_start_month_str = (
+            _snowline_month_to_str[self._snowline_start_month]
+            if self.store_snowline else 'Oct'
+        )
+
+        attrs = {
+            # model class
+            'mb_model_class': self.mb_model_class,
+            # construction parameters
+            'settings_filesuffix': self.settings_filesuffix,
+            'use_leap_years': int(self.use_leap_years),
+            'climate_resolution': self.climate_resolution,
+            'aging_frequency': self.aging_frequency,
+            'melt_f_ratio': float(self.melt_f_ratio),
+            'melt_f_change': self.melt_f_change,
+            'tau_e': float(self.tau_e),
+            'ys': int(self.ys),
+            'spinup_years': int(self.spinup_years),
+            'save_spinup_mbs': int(self.save_spinup_mbs),
+            'use_previous_mbs': int(self.use_previous_mbs),
+            'store_snowline': int(self.store_snowline),
+            'store_snowline_start_month': store_snowline_start_month_str,
+            'store_buckets': str(self.store_buckets),
+            'snow_density': float(self.snow_density),
+            'ice_density': float(self.ice_density),
+            'density_change': self.density_change,
+            'bucket_names': ','.join(self.buckets),
+            # mbmod calibrated parameters
+            'melt_f': float(self.mbmod.melt_f),
+            'temp_bias': float(self.mbmod.temp_bias),
+            'prcp_fac': float(self.mbmod.prcp_fac),
+            'bias': float(self.mbmod.bias),
+            'mb_filename': self.mbmod.filename,
+            'mb_input_filesuffix': self.mbmod.input_filesuffix,
+            'mb_ys': int(self.mbmod.ys),
+            'mb_ye': int(self.mbmod.ye),
+            'temp_melt': float(self.mbmod.temp_melt),
+            'repeat': int(self.mbmod.repeat),
+            'fl_id': (int(self.mbmod.fl_id)
+                      if self.mbmod.fl_id is not None else -1),
+            # current runtime state
+            'mb_buckets_year': float(self.mb_buckets_year),
+            'current_index': int(current_index),
+        }
+
+        return xr.Dataset(data_vars=data_vars, coords=coords, attrs=attrs)
+
+    def save_to_file(self, filesuffix=""):
+        """Save the complete state of this model to a NetCDF file.
+
+        The file is written to the glacier directory as
+        ``mb_diagnostics{filesuffix}.nc``.  All information required to
+        reproduce an identical model via :meth:`load_from_file` is stored.
+
+        Parameters
+        ----------
+        filesuffix : str, optional
+            Appended to the output filename, e.g. ``'_v2'`` gives
+            ``mb_diagnostics_v2.nc``.
+        """
+        fp = self.gdir.get_filepath('mb_diagnostics', filesuffix=filesuffix)
+        self._to_dataset().to_netcdf(fp)
+
+    @classmethod
+    def load_from_file(cls, gdir, filesuffix="", group=None,
+                       climate_filename=None, climate_input_filesuffix=None):
+        """Load a previously saved :class:`SfcTypeTIModel` from a NetCDF file.
+
+        Reads ``mb_diagnostics{filesuffix}.nc`` from the glacier directory and
+        re-constructs the model.
+
+        **Continue** (``climate_filename`` and ``climate_input_filesuffix`` both
+        ``None``):
+        The complete runtime state (MB arrays, snowline) is
+        restored so that integration continues seamlessly using the same climate
+        input.
+
+        **Scenario branching** (either climate parameter supplied):
+        Only the bucket state is restored.  The MB output arrays are freshly
+        allocated for the new climate period (from ``int(mb_buckets_year)`` to
+        the new ``ye``).  ``current_index`` is reset to zero; the historical MB
+        record is not carried over.
+
+        Parameters
+        ----------
+        gdir : GlacierDirectory
+            The glacier directory containing the saved file.
+        filesuffix : str, optional
+            Suffix appended to ``mb_diagnostics`` when the file was saved.
+        group : str, optional
+            nc group to read from (used internally by
+            :meth:`MultipleFlowlineMassBalance.load_from_file`).
+        climate_filename : str, optional
+            Override the stored climate filename (e.g. ``'gcm_data'``).
+            If ``None``, the filename from the saved file is used.
+        climate_input_filesuffix : str, optional
+            Override the stored climate input filesuffix (e.g. ``'_ssp585'``).
+            If ``None``, the filesuffix from the saved file is used.
+
+        Returns
+        -------
+        SfcTypeTIModel
+        """
+        fp = gdir.get_filepath('mb_diagnostics', filesuffix=filesuffix)
+        new_climate = (climate_filename is not None or
+                       climate_input_filesuffix is not None)
+
+        open_kw = {'group': group} if group is not None else {}
+        with xr.open_dataset(fp, **open_kw) as ds:
+            attrs = ds.attrs
+
+            # mb_model_class
+            mb_model_class_str = attrs['mb_model_class']
+            if mb_model_class_str == 'DailyTIModel':
+                mb_model_class = DailyTIModel
+            elif mb_model_class_str == 'MonthlyTIModel':
+                mb_model_class = MonthlyTIModel
+            else:
+                raise NotImplementedError(
+                    f"mb_model_class: {mb_model_class_str}")
+
+            # store_buckets
+            store_buckets_str = attrs['store_buckets']
+            if store_buckets_str == 'False':
+                store_buckets_val = False
+            elif store_buckets_str == 'True':
+                # store_buckets was overridden to True by store_buckets_dates;
+                # pass False here and let the dates re-trigger the override
+                store_buckets_val = False
+            else:
+                store_buckets_val = store_buckets_str  # 'annual'/'monthly'/'daily'
+
+            # store_buckets_dates
+            store_buckets_dates = None
+            if 'store_buckets_dates_arr' in ds:
+                store_buckets_dates = list(
+                    ds['store_buckets_dates_arr'].values.tolist())
+
+            # saved arrays
+            saved_mb_buckets = ds['mb_buckets'].values      # (n_pts, n_buckets)
+            saved_spinup_heights = ds['spinup_heights'].values  # (n_pts,)
+            saved_grid_label = ds['buckets_grid_point_label'].values  # (n_pts,)
+
+            # fl_id
+            fl_id = int(attrs['fl_id'])
+            fl_id = None if fl_id == -1 else fl_id
+
+            # construct the model
+            # We always pass hbins=saved_spinup_heights so that the constructor
+            # builds the correct grid size without needing the original flowline.
+            # buckets_grid_point_label is overridden below to restore the exact
+            # saved labels (which may differ from np.arange(n_pts) when a
+            # flowline was originally used).
+            # spinup_buckets skips the actual spinup computation.
+            saved_mb_buckets_year = float(attrs['mb_buckets_year'])
+            if new_climate:
+                ys_for_model = int(saved_mb_buckets_year)
+                save_spinup_mbs_for_model = False
+            else:
+                ys_for_model = int(attrs['ys'])
+                save_spinup_mbs_for_model = bool(attrs['save_spinup_mbs'])
+
+            fn_for_model = (climate_filename
+                            if climate_filename is not None
+                            else attrs['mb_filename'])
+            isuf_for_model = (climate_input_filesuffix
+                              if climate_input_filesuffix is not None
+                              else attrs['mb_input_filesuffix'])
+
+            model = cls(
+                gdir=gdir,
+                settings_filesuffix=attrs['settings_filesuffix'],
+                use_leap_years=bool(attrs['use_leap_years']),
+                mb_model_class=mb_model_class,
+                climate_resolution=attrs['climate_resolution'],
+                aging_frequency=attrs['aging_frequency'],
+                melt_f_ratio=float(attrs['melt_f_ratio']),
+                melt_f_change=attrs['melt_f_change'],
+                tau_e=float(attrs['tau_e']),
+                ys=ys_for_model,
+                spinup_years=int(attrs['spinup_years']),
+                save_spinup_mbs=save_spinup_mbs_for_model,
+                spinup_buckets=saved_mb_buckets[:, :-1],
+                hbins=saved_spinup_heights,
+                store_buckets=store_buckets_val,
+                store_buckets_dates=store_buckets_dates,
+                use_previous_mbs=bool(attrs['use_previous_mbs']),
+                store_snowline=bool(attrs['store_snowline']),
+                store_snowline_start_month=attrs['store_snowline_start_month'],
+                snow_density=float(attrs['snow_density']),
+                density_change=attrs['density_change'],
+                # mbmod kwargs (passed through **kwargs to mb_model_class)
+                melt_f=float(attrs['melt_f']),
+                temp_bias=float(attrs['temp_bias']),
+                prcp_fac=float(attrs['prcp_fac']),
+                bias=float(attrs['bias']),
+                filename=fn_for_model,
+                input_filesuffix=isuf_for_model,
+                temp_melt=float(attrs['temp_melt']),
+                repeat=bool(attrs['repeat']),
+                fl_id=fl_id,
+                check_calib_params=False,
+            )
+
+            # Restore exact grid labels
+            model.buckets_grid_point_label = saved_grid_label
+
+            # _init_buckets already placed saved_mb_buckets[:,:-1] into
+            # mb_buckets_np via spinup_buckets and set mb_buckets_year = ys.
+            # Override with the full saved array (ice column included).
+            model.mb_buckets_np[:] = saved_mb_buckets
+            model.mb_buckets_year = saved_mb_buckets_year
+
+            if new_climate:
+                # start fresh, no historical MB to restore
+                pass
+            else:
+                # restore full MB history
+                current_index = int(attrs['current_index'])
+                model._current_index = current_index
+
+                if current_index > 0:
+                    model._climatic_mb[:current_index] = (
+                        ds['climatic_mb'].values)
+                    model._ice_mb[:current_index] = ds['ice_mb'].values
+                    model._mb_heights[:current_index] = (
+                        ds['mb_heights_stored'].values)
+
+                    # 'time' coordinate holds the float-year keys; array
+                    # indices are simply 0…N-1
+                    y2i_keys = ds.coords['time'].values
+                    model._year_to_index = {
+                        float(k): int(i)
+                        for i, k in enumerate(y2i_keys)
+                    }
+
+                # snowline state
+                if bool(attrs['store_snowline']) and 'snowline' in ds:
+                    model._snowline = list(ds['snowline'].values.tolist())
+                    model._snowline_year = list(
+                        ds['snowline_year'].values.tolist())
+                    # snowline_inf_values is repopulated automatically on the
+                    # next climate step
+
+        return model
 
 
 class ConstantMassBalance(MassBalanceModel):
@@ -3010,6 +3389,7 @@ class MultipleFlowlineMassBalance(MassBalanceModel):
         """
 
         gdir.settings_filesuffix = settings_filesuffix
+        self.gdir = gdir
 
         # Read in the flowlines
         if use_inversion_flowlines:
@@ -3267,6 +3647,95 @@ class MultipleFlowlineMassBalance(MassBalanceModel):
             stack.append(weighted_average_1d(elas, areas))
 
         return set_array_type(stack)
+
+    def save_to_file(self, filesuffix=""):
+        """Save the state of all flowline MB models to a single NetCDF file.
+
+        Writes ``mb_diagnostics{filesuffix}.nc`` to the glacier directory.
+        Each :class:`SfcTypeTIModel` is stored as a separate nc group named
+        (``fl_0``, ``fl_1``, ...) matching the flowline index. The root of the
+        file carries a ``n_flowlines`` attribute so that :meth:`load_from_file`
+        knows how many groups to expect.
+
+        Only supported when all ``flowline_mb_models`` are instances of
+        :class:`SfcTypeTIModel`.
+
+        Parameters
+        ----------
+        filesuffix : str, optional
+            Appended to the output filename.
+        """
+        fp = self.gdir.get_filepath('mb_diagnostics', filesuffix=filesuffix)
+
+        # Welcome ds
+        ds = xr.Dataset()
+        ds.attrs['description'] = ('OGGM SfcTypeTIModel state on flowlines. '
+                                   'Check groups for data.')
+        ds.attrs['oggm_version'] = __version__
+        ds.attrs['n_flowlines'] = len(self.flowline_mb_models)
+        ds.to_netcdf(fp, 'w')
+        # append each state as a group
+        for i, mb_mod in enumerate(self.flowline_mb_models):
+            mb_mod._to_dataset().to_netcdf(fp, group=f'fl_{i}', mode='a')
+
+    @classmethod
+    def load_from_file(cls, gdir, filesuffix="", climate_filename=None,
+                       climate_input_filesuffix=None):
+        """Load a :class:`MultipleFlowlineMassBalance` from a saved nc file.
+
+        Reads ``mb_diagnostics{filesuffix}.nc``, reconstructs one
+        :class:`SfcTypeTIModel` per flowline from the corresponding nc group,
+        and returns a fully initialised :class:`MultipleFlowlineMassBalance`.
+
+        To continue with same climate input leave ``climate_filename`` and
+        ``climate_input_filesuffix`` as ``None``. For scenario branching
+        (switch to a new climate file while keeping the bucket state), supply
+        the new climate parameters. The MB history is then reset and the
+        output arrays are sized for the new climate period.
+
+        Parameters
+        ----------
+        gdir : GlacierDirectory
+        filesuffix : str, optional
+        climate_filename : str, optional
+            Override the stored climate filename (e.g. ``'gcm_data'``).
+        climate_input_filesuffix : str, optional
+            Override the stored climate input filesuffix (e.g. ``'_ssp585'``).
+
+        Returns
+        -------
+        MultipleFlowlineMassBalance
+        """
+        fp = gdir.get_filepath('mb_diagnostics', filesuffix=filesuffix)
+
+        with xr.open_dataset(fp) as ds_root:
+            n_fls = int(ds_root.attrs['n_flowlines'])
+
+        flowline_mb_models = [
+            SfcTypeTIModel.load_from_file(
+                gdir,
+                filesuffix=filesuffix,
+                group=f'fl_{i}',
+                climate_filename=climate_filename,
+                climate_input_filesuffix=climate_input_filesuffix,
+            )
+            for i in range(n_fls)
+        ]
+
+        # Build without triggering __init__ (which would re-run spinup and
+        # re-read flowlines from disk).
+        obj = object.__new__(cls)
+        try:
+            obj.fls = gdir.read_pickle('model_flowlines')
+        except FileNotFoundError:
+            obj.fls = None
+        obj.gdir = gdir
+        obj.flowline_mb_models = flowline_mb_models
+        obj.valid_bounds = flowline_mb_models[-1].valid_bounds
+        obj.hemisphere = gdir.hemisphere
+        obj.ice_density = flowline_mb_models[-1].ice_density
+        obj.use_leap_years = flowline_mb_models[-1].use_leap_years
+        return obj
 
 
 def calving_mb(gdir):

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -3853,7 +3853,7 @@ def mb_calibration_from_wgms_mb(gdir, settings_filesuffix='',
 
 
 @entity_task(log, writes=['mb_calib'])
-def mb_calibration_to_rmsd(gdir, *,
+def mb_calibration_to_rmsd(gdir, settings_filesuffix='',
                            ref_df=None,
                            write_to_gdir=True,
                            overwrite_gdir=False,
@@ -3921,32 +3921,32 @@ def mb_calibration_to_rmsd(gdir, *,
             'melt_f', 'temp_bias', 'prcp_fac'. Defaults to ('melt_f',)
     melt_f: float
         the default value to use as melt factor (or the starting value when
-        optimizing MB). Defaults to cfg.PARAMS['melt_f'].
+        optimizing MB). Defaults to gdir.settings['melt_f'].
     melt_f_min: float
         the minimum accepted value for the melt factor during optimisation.
-        Defaults to cfg.PARAMS['melt_f_min'].
+        Defaults to gdir.settings['melt_f_min'].
     melt_f_max: float
         the maximum accepted value for the melt factor during optimisation.
-        Defaults to cfg.PARAMS['melt_f_max'].
+        Defaults to gdir.settings['melt_f_max'].
     prcp_fac: float
         the default value to use as precipitation scaling factor
         (or the starting value when optimizing MB). Defaults to the method
         chosen in `params.cfg` (winter prcp or global factor).
     prcp_fac_min: float
         the minimum accepted value for the precipitation scaling factor during
-        optimisation. Defaults to cfg.PARAMS['prcp_fac_min'].
+        optimisation. Defaults to gdir.settings['prcp_fac_min'].
     prcp_fac_max: float
         the maximum accepted value for the precipitation scaling factor during
-        optimisation. Defaults to cfg.PARAMS['prcp_fac_max'].
+        optimisation. Defaults to gdir.settings['prcp_fac_max'].
     temp_bias: float
         the default value to use as temperature bias (or the starting value when
         optimizing MB). Defaults to 0.
     temp_bias_min: float
         the minimum accepted value for the temperature bias during optimisation.
-        Defaults to cfg.PARAMS['temp_bias_min'].
+        Defaults to gdir.settings['temp_bias_min'].
     temp_bias_max: float
         the maximum accepted value for the temperature bias during optimisation.
-        Defaults to cfg.PARAMS['temp_bias_max'].
+        Defaults to gdir.settings['temp_bias_max'].
     filesuffix: str
         add a filesuffix to mb_calib.json. This could be useful for sensitivity
         analyses with MB models, if they need to fetch other sets of params for
@@ -3955,17 +3955,17 @@ def mb_calibration_to_rmsd(gdir, *,
 
     # Param constraints
     if melt_f_min is None:
-        melt_f_min = cfg.PARAMS['melt_f_min']
+        melt_f_min = gdir.settings['melt_f_min']
     if melt_f_max is None:
-        melt_f_max = cfg.PARAMS['melt_f_max']
+        melt_f_max = gdir.settings['melt_f_max']
     if prcp_fac_min is None:
-        prcp_fac_min = cfg.PARAMS['prcp_fac_min']
+        prcp_fac_min = gdir.settings['prcp_fac_min']
     if prcp_fac_max is None:
-        prcp_fac_max = cfg.PARAMS['prcp_fac_max']
+        prcp_fac_max = gdir.settings['prcp_fac_max']
     if temp_bias_min is None:
-        temp_bias_min = cfg.PARAMS['temp_bias_min']
+        temp_bias_min = gdir.settings['temp_bias_min']
     if temp_bias_max is None:
-        temp_bias_max = cfg.PARAMS['temp_bias_max']
+        temp_bias_max = gdir.settings['temp_bias_max']
 
     if not use_2d_mb:
         fls = gdir.read_pickle('inversion_flowlines')
@@ -3992,19 +3992,20 @@ def mb_calibration_to_rmsd(gdir, *,
 
     # Ok, regardless on how we want to calibrate, we start with defaults
     if melt_f is None:
-        melt_f = cfg.PARAMS['melt_f']
+        melt_f = gdir.settings['melt_f']
 
     if prcp_fac is None:
-        if cfg.PARAMS['prcp_fac'] is None:
+        if gdir.settings['prcp_fac'] is None:
             prcp_fac = decide_winter_precip_factor(gdir)
         else:
-            prcp_fac = cfg.PARAMS['prcp_fac']
+            prcp_fac = gdir.settings['prcp_fac']
 
     if temp_bias is None:
         temp_bias = 0
 
     # Create the MB model we will calibrate
     mb_mod = mb_model_class(gdir,
+                            settings_filesuffix=settings_filesuffix,
                             melt_f=melt_f,
                             temp_bias=temp_bias,
                             prcp_fac=prcp_fac,
@@ -4032,7 +4033,8 @@ def mb_calibration_to_rmsd(gdir, *,
         elif param == 'temp_bias':
             bounds.append((temp_bias_min, temp_bias_max))
 
-    # Optimises all three mass balance parameters at the same time to minimize the RMSD between the simulated and reference MB timeseries
+    # Optimises all three mass balance parameters at the same time to minimize
+    # the RMSD between the simulated and reference MB timeseries
     def rmsd_cost_function(x, *model_attrs: tuple):
         for i, model_attr in enumerate(model_attrs):
             setattr(mb_mod, model_attr, x[i])
@@ -4068,7 +4070,7 @@ def mb_calibration_to_rmsd(gdir, *,
                            f'Try another technique.')
 
     # Store parameters
-    df = gdir.read_json('mb_calib', allow_empty=True)
+    df = {}
     df['rgi_id'] = gdir.rgi_id
     df['bias'] = 0
     df['melt_f'] = melt_f
@@ -4081,16 +4083,20 @@ def mb_calibration_to_rmsd(gdir, *,
 
     # Add the climate related params to the GlacierDir to make sure
     # other tools cannot fool around without re-calibration
-    df['mb_global_params'] = {k: cfg.PARAMS[k] for k in MB_GLOBAL_PARAMS}
+    df['mb_global_params'] = {k: gdir.settings[k] for k in MB_GLOBAL_PARAMS}
     df['baseline_climate_source'] = gdir.get_climate_info()['baseline_climate_source']
     # Write
     if write_to_gdir:
-        if gdir.has_file('mb_calib', filesuffix=filesuffix) and not overwrite_gdir:
-            raise InvalidWorkflowError('`mb_calib.json` already exists for '
-                                       'this repository. Set `overwrite_gdir` '
-                                       'to True if you want to overwrite '
-                                       'a previous calibration.')
-        gdir.write_json(df, 'mb_calib', filesuffix=filesuffix)
+        if any(key in gdir.get_stored_settings(filesuffix=settings_filesuffix)
+               for key in ['melt_f', 'prcp_fac', 'temp_bias']) and not overwrite_gdir:
+            raise InvalidWorkflowError('Their are already mass balance parameters '
+                                       'stored in the settings file. Set '
+                                       '`overwrite_gdir` to True if you want to '
+                                       'overwrite a previous calibration.')
+        for key in ['rgi_id', 'bias', 'melt_f', 'prcp_fac', 'temp_bias',
+                    'reference_mb', 'reference_period',
+                    'mb_global_params', 'baseline_climate_source']:
+            gdir.settings[key] = df[key]
     return df
 
 
@@ -4203,35 +4209,35 @@ def mb_calibration_from_hugonnet_mb(gdir, *,
         if not ref_mb_period:
             ref_mb_period = gdir.settings['geodetic_mb_period']
 
-    # Get the reference data
-    ref_mb_err = np.nan
-    if use_regional_avg:
-        ref_mb_df_o = get_geodetic_mb_dataframe(regional=True)
-        ref_mb_df = ref_mb_df_o.loc[ref_mb_df_o.period == ref_mb_period].set_index('reg')
-        if len(ref_mb_df) == 0:
-            raise InvalidParamsError(f'Ref period {ref_mb_period} not found in file: '
-                                     f'{ref_mb_df_o.period.unique()}')
-        # dmdtda: in meters water-equivalent per year -> we convert to kg m-2 yr-1
-        ref_mb = ref_mb_df.loc[int(gdir.rgi_region), 'dmdtda'] * 1000
-        ref_mb_err = ref_mb_df.loc[int(gdir.rgi_region), 'err_dmdtda'] * 1000
-    else:
-        try:
-            ref_mb_df = get_geodetic_mb_dataframe().loc[gdir.rgi_id]
-            ref_mb_df = ref_mb_df.loc[ref_mb_df['period'] == ref_mb_period]
+        # Get the reference data
+        ref_mb_err = np.nan
+        if use_regional_avg:
+            ref_mb_df_o = get_geodetic_mb_dataframe(regional=True)
+            ref_mb_df = ref_mb_df_o.loc[ref_mb_df_o.period == ref_mb_period].set_index('reg')
+            if len(ref_mb_df) == 0:
+                raise InvalidParamsError(f'Ref period {ref_mb_period} not found '
+                                         f'in file: {ref_mb_df_o.period.unique()}')
             # dmdtda: in meters water-equivalent per year -> we convert to kg m-2 yr-1
-            ref_mb = ref_mb_df['dmdtda'].iloc[0] * 1000
-            ref_mb_err = ref_mb_df['err_dmdtda'].iloc[0] * 1000
-        except KeyError:
-            if override_missing is None:
-                raise
-            ref_mb = override_missing
+            ref_mb = ref_mb_df.loc[int(gdir.rgi_region), 'dmdtda'] * 1000
+            ref_mb_err = ref_mb_df.loc[int(gdir.rgi_region), 'err_dmdtda'] * 1000
+        else:
+            try:
+                ref_mb_df = get_geodetic_mb_dataframe().loc[gdir.rgi_id]
+                ref_mb_df = ref_mb_df.loc[ref_mb_df['period'] == ref_mb_period]
+                # dmdtda: in meters water-equivalent per year -> we convert to kg m-2 yr-1
+                ref_mb = ref_mb_df['dmdtda'].iloc[0] * 1000
+                ref_mb_err = ref_mb_df['err_dmdtda'].iloc[0] * 1000
+            except KeyError:
+                if override_missing is None:
+                    raise
+                ref_mb = override_missing
 
-    ref_mb_use = {
-        'value': ref_mb,
-        'unit': 'kg m-2 yr-1',
-        'period': ref_mb_period,
-        'err': ref_mb_err,
-    }
+        ref_mb_use = {
+            'value': ref_mb,
+            'unit': 'kg m-2 yr-1',
+            'period': ref_mb_period,
+            'err': ref_mb_err,
+        }
 
     gdir.observations['ref_mb'] = ref_mb_use
 
@@ -4847,7 +4853,8 @@ def mb_calibration_from_scalar_mb(gdir, *,
 
 
 @entity_task(log, writes=['mb_calib'])
-def perturbate_mb_params(gdir, perturbation=None, reset_default=False, filesuffix=''):
+def perturbate_mb_params(gdir, input_filesuffix='', perturbation=None,
+                         reset_default=False, output_filesuffix=''):
     """Replaces pre-calibrated MB params with perturbed ones for this glacier.
 
     It simply replaces the existing `mb_calib.json` file with an
@@ -4885,7 +4892,7 @@ def perturbate_mb_params(gdir, perturbation=None, reset_default=False, filesuffi
         Note that it's always the default, precalibrated params
         file which is read to start with.
     """
-    df = gdir.read_yml('settings')
+    df = gdir.read_yml('settings', filesuffix=input_filesuffix)
 
     # Save original params if not there
     if 'bias_orig' not in df:
@@ -4895,7 +4902,7 @@ def perturbate_mb_params(gdir, perturbation=None, reset_default=False, filesuffi
     if reset_default:
         for k in ['bias', 'melt_f', 'prcp_fac', 'temp_bias']:
             df[k] = df[k + '_orig']
-        gdir.write_yml(df, 'settings', filesuffix=filesuffix)
+        gdir.write_yml(df, 'settings', filesuffix=output_filesuffix)
         return df
 
     for k, v in perturbation.items():
@@ -4906,7 +4913,7 @@ def perturbate_mb_params(gdir, perturbation=None, reset_default=False, filesuffi
         else:
             raise InvalidParamsError(f'Perturbation not valid: {k}')
 
-    gdir.write_yml(df, 'settings', filesuffix=filesuffix)
+    gdir.write_yml(df, 'settings', filesuffix=output_filesuffix)
     return df
 
 

--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -417,7 +417,7 @@ store_model_geometry = False
 #   melt_residual_off_glacier, melt_residual_on_glacier
 #   model_mb, residual_mb, snow_bucket,
 # You need to keep all variables in one line unfortunately
-store_diagnostic_variables =  volume, volume_bsl, volume_bwl, area, length, calving, calving_rate, off_area, on_area, melt_off_glacier, melt_on_glacier, liq_prcp_off_glacier, liq_prcp_on_glacier, snowfall_off_glacier, snowfall_on_glacier
+store_diagnostic_variables =  volume, volume_bsl, volume_bwl, area, length, mass, calving, calving_rate, off_area, on_area, melt_off_glacier, melt_on_glacier, liq_prcp_off_glacier, liq_prcp_on_glacier, snowfall_off_glacier, snowfall_on_glacier
 
 # Whether to store the model flowline diagnostic files during operational runs
 # This can be useful for advanced diagnostics along the flowlines but is
@@ -426,4 +426,4 @@ store_fl_diagnostics = False
 # What variables would you like to store in the flowline diagnostics files
 # Note: area and volume are mandatory
 # You need to keep all variables in one line unfortunately
-store_fl_diagnostic_variables =  area, thickness, volume, volume_bsl, volume_bwl, calving_bucket, ice_velocity, dhdt, climatic_mb, flux_divergence
+store_fl_diagnostic_variables =  area, thickness, volume, volume_bsl, volume_bwl, mass, calving_bucket, ice_velocity, dhdt, climatic_mb, flux_divergence

--- a/oggm/sandbox/calving_fabi.py
+++ b/oggm/sandbox/calving_fabi.py
@@ -307,7 +307,7 @@ class CalvingFluxBasedModelFabi(FlowlineModel):
                 # - decide on whether calving is happening or not
 
                 rho_ocean = cfg.PARAMS['ocean_density']
-                eff_water_depth = (rho_ocean / self.rho) * water_depth
+                eff_water_depth = (rho_ocean / self.ice_density) * water_depth
 
                 # above_wl -> above floatation
                 ice_above_wl = (fl.bed_below_wl & (fl.thick >= eff_water_depth))
@@ -345,7 +345,7 @@ class CalvingFluxBasedModelFabi(FlowlineModel):
                 if calving_is_happening:
 
                     # Calculate the additional (pull) force
-                    pull_last = 0.5 * G * (self.rho * h ** 2 - rho_ocean * d ** 2)
+                    pull_last = 0.5 * G * (self.ice_density * h ** 2 - rho_ocean * d ** 2)
                     if pull_last < 0:
                         pull_last = 0
 
@@ -372,7 +372,7 @@ class CalvingFluxBasedModelFabi(FlowlineModel):
 
                 # OK now we compute the deformation stress, which might
                 # be slightly different at the front if calving is happening
-                stress = self.rho * G * slope_stag * thick_stag
+                stress = self.ice_density * G * slope_stag * thick_stag
 
                 # Add "stretching stress" to basal shear/driving stress
                 if calving_is_happening:
@@ -384,7 +384,7 @@ class CalvingFluxBasedModelFabi(FlowlineModel):
 
                 # Sliding is increased where there is water
                 # Determine height above buoyancy
-                eff_water_depth_stag = (rho_ocean / self.rho) * water_depth_stag
+                eff_water_depth_stag = (rho_ocean / self.ice_density) * water_depth_stag
                 # Avoid dividing by zero where thick equals water depth
                 z_a_b = utils.clip_min(thick_stag - eff_water_depth_stag, 0.01)
                 z_a_b[thick_stag == 0] = 1  # Stress is zero there
@@ -418,11 +418,11 @@ class CalvingFluxBasedModelFabi(FlowlineModel):
             else:
 
                 # Simplest case (no water): velocity is deformation + sliding
-                rhogh = (self.rho * G * slope_stag)**N
+                rhogh = (self.ice_density * G * slope_stag) ** N
                 ud_stag[:] = (thick_stag**(N + 1)) * self._fd * rhogh
 
                 # Temporary check for above
-                stress = self.rho * G * slope_stag * thick_stag
+                stress = self.ice_density * G * slope_stag * thick_stag
                 vel = thick_stag * stress ** N * self._fd
                 assert np.allclose(ud_stag, vel)
 

--- a/oggm/sandbox/calving_jan.py
+++ b/oggm/sandbox/calving_jan.py
@@ -332,7 +332,7 @@ class CalvingFluxBasedModelJan(FlowlineModel):
             # We compute more complex dynamics when we have ice below water
             if fl.has_ice() and np.any(ice_below_wl) and self.do_calving:
                 ice_above_wl = ((fl.bed_h < self.water_level) &
-                                (fl.thick >= (rho_ocean / self.rho) * depth))
+                                (fl.thick >= (rho_ocean / self.ice_density) * depth))
                 # Some shenanigans to make sure we are at the front and not
                 # an upstream basin
                 if np.any(ice_above_wl):
@@ -360,7 +360,7 @@ class CalvingFluxBasedModelJan(FlowlineModel):
 
                 # Determine height above buoancy
                 z_a_b = utils.clip_min(0, thick_stag - depth_stag *
-                                       (rho_ocean / self.rho))
+                                       (rho_ocean / self.ice_density))
 
                 # Compute net hydrostatic force at the front. One could think
                 # about incorporating ice mélange / sea ice here as an
@@ -368,8 +368,8 @@ class CalvingFluxBasedModelJan(FlowlineModel):
                 # formulation below.)
                 if not land_interface:
                     # Calculate the additional (pull) force
-                    pull_last = utils.clip_min(0, 0.5 * G * (self.rho * h**2 -
-                                               rho_ocean * d**2))
+                    pull_last = utils.clip_min(0, 0.5 * G * (self.ice_density * h ** 2 -
+                                                             rho_ocean * d ** 2))
 
                     # Determine distance over which above force is distributed
                     stretch_length = (last_above_wl - first_ice) * dx
@@ -396,7 +396,7 @@ class CalvingFluxBasedModelJan(FlowlineModel):
                         slope_stag[last_above_wl+1] = np.nanmean(slope_stag
                                                                  [stretch_first-1:
                                                                   stretch_last-1])
-                stress = self.rho * G * slope_stag * thick_stag
+                stress = self.ice_density * G * slope_stag * thick_stag
                 # Add "stretching stress" to basal shear/driving stress
                 if not land_interface:
                     stress[stretch_first:stretch_last] = (stress[stretch_first:
@@ -443,7 +443,7 @@ class CalvingFluxBasedModelJan(FlowlineModel):
 
             # Usual ice dynamics
             else:
-                rhogh = (self.rho*G*slope_stag)**N
+                rhogh = (self.ice_density * G * slope_stag) ** N
                 u_drag[:] = (thick_stag**(N+1)) * self._fd * rhogh * \
                              sf_stag**N
                 u_slide[:] = (thick_stag**(N-1)) * self.fs * rhogh * \
@@ -608,7 +608,7 @@ class CalvingFluxBasedModelJan(FlowlineModel):
             # We do calving only if there is some ice grounded below water
             depth = utils.clip_min(0, self.water_level - fl.bed_h)
             ice_above_wl = ((fl.bed_h < self.water_level) &
-                            (fl.thick >= (rho_ocean / self.rho) * depth))
+                            (fl.thick >= (rho_ocean / self.ice_density) * depth))
             ice_below_wl = ((fl.bed_h < self.water_level) & (fl.thick > 0))
             # If there is only ice below water, we just remove it
             if np.all(fl.surface_h[fl.thick > 0] < self.water_level):
@@ -654,7 +654,7 @@ class CalvingFluxBasedModelJan(FlowlineModel):
                 fl.section = section
                 section = fl.section
                 if ((fl.bed_h[last_above_wl+1] < self.water_level) &
-                    (fl.thick[last_above_wl+1] >= (rho_ocean / self.rho) *
+                    (fl.thick[last_above_wl+1] >= (rho_ocean / self.ice_density) *
                      depth[last_above_wl+1])):
                     last_above_wl += 1
                 else:

--- a/oggm/tests/conftest.py
+++ b/oggm/tests/conftest.py
@@ -11,7 +11,7 @@ import pytest
 import shapely.geometry as shpg
 import matplotlib.pyplot as plt
 
-from oggm import cfg, tasks
+from oggm import cfg, tasks, DEFAULT_BASE_URL
 from oggm.core import flowline
 from oggm.tests.funcs import init_hef, get_test_dir
 from oggm import utils
@@ -194,6 +194,7 @@ def patch_download_url_allowlist():
         base_extra_v14.format('L2'),
         base_extra_v14l3.format('L3'),
         base_extra_l3,
+        DEFAULT_BASE_URL,
     ]
     cfg.PARAMS.do_log = old_do_log
 

--- a/oggm/tests/ext/sia_fluxlim.py
+++ b/oggm/tests/ext/sia_fluxlim.py
@@ -85,7 +85,7 @@ class MUSCLSuperBeeModel(FlowlineModel):
             # define Glen's law here
             N = self.glen_n
             # this is the correct Gamma !!
-            Gamma = 2.*self.glen_a*(self.rho*G)**N / (N+2.)
+            Gamma = 2. * self.glen_a * (self.ice_density * G) ** N / (N + 2.)
             # time stepping
             c_stab = 0.165
 

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -1413,7 +1413,7 @@ class TestMassBalanceModels:
                                       input_filesuffix, clim_res, aging)
 
             assert inv_fl.nx == mb_mod.mb_buckets_np.shape[0]
-            np.testing.assert_allclose(inv_fl.surface_h, mb_mod.fl.surface_h)
+            np.testing.assert_allclose(inv_fl.surface_h, mb_mod.spinup_heights)
 
             target_year_annual = 2002
             # after making this call all mbs from ys to 2002 were calculated and
@@ -1764,6 +1764,253 @@ class TestMassBalanceModels:
         mb_mod.prcp_fac = 1
         np.testing.assert_allclose(mb_mod.mb_buckets, mb_buckets_2006)
 
+    @pytest.mark.slow
+    def test_sfc_type_save_load(self, hef_gdir):
+        """Test SfcTypeTIModel.save_to_file and load_from_file."""
+
+        gdir = hef_gdir
+        init_present_time_glacier(gdir)
+        h = gdir.read_pickle('inversion_flowlines')[-1].surface_h
+
+        # Helper: verify that two model instances have identical state
+        def assert_models_equal(m1, m2, check_snowline=False):
+            np.testing.assert_allclose(m1.mb_buckets_np, m2.mb_buckets_np)
+            assert m1.mb_buckets_year == m2.mb_buckets_year
+            assert m1._current_index == m2._current_index
+            assert m1._year_to_index == m2._year_to_index
+            np.testing.assert_allclose(
+                m1._climatic_mb[:m1._current_index],
+                m2._climatic_mb[:m2._current_index])
+            np.testing.assert_allclose(
+                m1._ice_mb[:m1._current_index],
+                m2._ice_mb[:m2._current_index])
+            np.testing.assert_allclose(
+                m1._mb_heights[:m1._current_index],
+                m2._mb_heights[:m2._current_index])
+            assert m1.buckets == m2.buckets
+            np.testing.assert_allclose(
+                list(m1.melt_f_buckets.values()),
+                list(m2.melt_f_buckets.values()))
+            np.testing.assert_allclose(
+                list(m1.density_buckets.values()),
+                list(m2.density_buckets.values()))
+            np.testing.assert_allclose(m1.spinup_heights, m2.spinup_heights)
+            np.testing.assert_allclose(
+                m1.buckets_grid_point_label, m2.buckets_grid_point_label)
+            if check_snowline:
+                np.testing.assert_allclose(m1.snowline, m2.snowline)
+                np.testing.assert_allclose(m1.snowline_year, m2.snowline_year)
+
+        # Test 1: annual climate / annual aging
+
+        # 1a: save before any computation (current_index == 0)
+        mb_mod = massbalance.SfcTypeTIModel(
+            gdir, mb_model_class=massbalance.MonthlyTIModel,
+            climate_resolution='annual', aging_frequency='annual',
+            ys=1990, check_calib_params=False)
+        mb_mod.save_to_file(filesuffix='_test_annual')
+        mb_loaded = massbalance.SfcTypeTIModel.load_from_file(
+            gdir, filesuffix='_test_annual')
+        assert_models_equal(mb_mod, mb_loaded)
+
+        # 1b: continue on both models; results must match exactly
+        mb1 = mb_mod.get_annual_mb(h, year=1996)
+        mb2 = mb_loaded.get_annual_mb(h, year=1996)
+        np.testing.assert_allclose(mb1, mb2)
+        assert_models_equal(mb_mod, mb_loaded)
+
+        # 1c: save after computation and reload
+        mb_mod.save_to_file(filesuffix='_test_annual_mid')
+        mb_loaded_mid = massbalance.SfcTypeTIModel.load_from_file(
+            gdir, filesuffix='_test_annual_mid')
+        assert_models_equal(mb_mod, mb_loaded_mid)
+
+        # 1d: continue from loaded mid-state; must give identical output
+        for yr in range(1997, 2000):
+            mb_orig = mb_mod.get_annual_mb(h, year=yr)
+            mb_file = mb_loaded_mid.get_annual_mb(h, year=yr)
+            np.testing.assert_allclose(mb_orig, mb_file)
+
+        # 1e: custom fl behaves identically (spinup_heights and
+        #     buckets_grid_point_label are restored, no fl object needed)
+        custom_fl = gdir.read_pickle('inversion_flowlines')[-1]
+        mb_mod_fl = massbalance.SfcTypeTIModel(
+            gdir, mb_model_class=massbalance.MonthlyTIModel,
+            fl=custom_fl,
+            climate_resolution='annual', aging_frequency='annual',
+            ys=1990, check_calib_params=False)
+        mb_mod_fl.get_annual_mb(h, year=1996)
+        mb_mod_fl.save_to_file(filesuffix='_test_custom_fl')
+        mb_loaded_fl = massbalance.SfcTypeTIModel.load_from_file(
+            gdir, filesuffix='_test_custom_fl')
+        assert_models_equal(mb_mod_fl, mb_loaded_fl)
+
+        for yr in range(1997, 2000):
+            mb_orig = mb_mod_fl.get_annual_mb(h, year=yr)
+            mb_file = mb_loaded_fl.get_annual_mb(h, year=yr)
+            np.testing.assert_allclose(mb_orig, mb_file)
+
+        # Test 2: monthly climate / monthly aging
+        mb_mod_m = massbalance.SfcTypeTIModel(
+            gdir, mb_model_class=massbalance.MonthlyTIModel,
+            climate_resolution='monthly', aging_frequency='monthly',
+            ys=1990, check_calib_params=False,
+            use_previous_mbs=True)
+
+        # advance a couple of years via annual mb (triggers all monthly steps)
+        mb_mod_m.get_annual_mb(h, year=1993)
+
+        mb_mod_m.save_to_file(filesuffix='_test_monthly')
+        mb_loaded_m = massbalance.SfcTypeTIModel.load_from_file(
+            gdir, filesuffix='_test_monthly')
+        assert_models_equal(mb_mod_m, mb_loaded_m)
+
+        # previously computed year can be retrieved from both after load
+        mb_prev_orig = mb_mod_m.get_annual_mb(h, year=1992)
+        mb_prev_loaded = mb_loaded_m.get_annual_mb(h, year=1992)
+        np.testing.assert_allclose(mb_prev_orig, mb_prev_loaded)
+
+        # continue forward
+        for yr in range(1994, 2000):
+            mb_orig = mb_mod_m.get_annual_mb(h, year=yr)
+            mb_file = mb_loaded_m.get_annual_mb(h, year=yr)
+            np.testing.assert_allclose(mb_orig, mb_file)
+        assert_models_equal(mb_mod_m, mb_loaded_m)
+
+        # Test 3: store_snowline
+        mb_mod_sl = massbalance.SfcTypeTIModel(
+            gdir, mb_model_class=massbalance.MonthlyTIModel,
+            climate_resolution='monthly', aging_frequency='annual',
+            ys=1990, check_calib_params=False,
+            store_snowline=True, store_snowline_start_month='Oct')
+        mb_mod_sl.get_annual_mb(h, year=1993)
+        assert len(mb_mod_sl.snowline) > 0  # sanity check
+
+        mb_mod_sl.save_to_file(filesuffix='_test_snowline')
+        mb_loaded_sl = massbalance.SfcTypeTIModel.load_from_file(
+            gdir, filesuffix='_test_snowline')
+        assert_models_equal(mb_mod_sl, mb_loaded_sl, check_snowline=True)
+
+        # snowline continues to accumulate correctly after load
+        mb_mod_sl.get_annual_mb(h, year=2000)
+        mb_loaded_sl.get_annual_mb(h, year=2000)
+        np.testing.assert_allclose(mb_mod_sl.snowline, mb_loaded_sl.snowline)
+        np.testing.assert_allclose(
+            mb_mod_sl.snowline_year, mb_loaded_sl.snowline_year)
+
+        # Test 4: filesuffix parameter is respected
+        mb_mod.save_to_file(filesuffix='_suffix_check')
+        mb_loaded_suffix = massbalance.SfcTypeTIModel.load_from_file(
+            gdir, filesuffix='_suffix_check')
+        assert_models_equal(mb_mod, mb_loaded_suffix)
+
+        # Test 5: scenario branch: new climate_input_filesuffix resets MB
+        #         history but preserves bucket state
+        mb_mod_branch = massbalance.SfcTypeTIModel(
+            gdir, mb_model_class=massbalance.MonthlyTIModel,
+            climate_resolution='annual', aging_frequency='annual',
+            ys=1990, check_calib_params=False)
+        mb_mod_branch.get_annual_mb(h, year=1995)
+        mb_mod_branch.save_to_file(filesuffix='_test_branch')
+
+        # Passing climate_input_filesuffix (even if identical, default is None)
+        # triggers the scenario-branch path: bucket state is kept, MB history is
+        # reset.
+        mb_loaded_branch = massbalance.SfcTypeTIModel.load_from_file(
+            gdir, filesuffix='_test_branch',
+            climate_input_filesuffix='')
+
+        # bucket state must be preserved exactly
+        np.testing.assert_allclose(
+            mb_mod_branch.mb_buckets_np, mb_loaded_branch.mb_buckets_np)
+        assert (mb_loaded_branch.mb_buckets_year ==
+                mb_mod_branch.mb_buckets_year)
+        # scenario branch: MB output history is reset
+        assert mb_loaded_branch._current_index == 0
+        assert mb_loaded_branch._year_to_index == {}
+        # ys is set to int(mb_buckets_year) so arrays are sized for the new period
+        assert mb_loaded_branch.ys == int(mb_mod_branch.mb_buckets_year)
+
+        # Test 6: MultipleFlowlineMassBalance save_to_file / load_from_file
+        mb_multi = massbalance.MultipleFlowlineMassBalance(
+            gdir,
+            mb_model_class=partial(massbalance.SfcTypeTIModel,
+                                   mb_model_class=massbalance.MonthlyTIModel,
+                                   ys=1990,
+                                   ),
+            check_calib_params=False)
+        # advance state so there is something non-trivial to save
+        fls = gdir.read_pickle('model_flowlines')
+        for i, fl in enumerate(fls):
+            mb_multi.get_annual_mb(fl.surface_h, year=1997, fl_id=i)
+
+        mb_multi.save_to_file(filesuffix='_test_multi')
+
+        # load without new climate
+        mb_multi_loaded = massbalance.MultipleFlowlineMassBalance.load_from_file(
+            gdir, filesuffix='_test_multi')
+        assert len(mb_multi_loaded.flowline_mb_models) == len(
+            mb_multi.flowline_mb_models)
+        for i, fl in enumerate(fls):
+            assert_models_equal(mb_multi.flowline_mb_models[i],
+                                mb_multi_loaded.flowline_mb_models[i])
+
+        # load with new climate, scenario branch (bucket state kept, history reset)
+        mb_multi_branch = massbalance.MultipleFlowlineMassBalance.load_from_file(
+            gdir, filesuffix='_test_multi', climate_input_filesuffix='')
+        for i, fl in enumerate(fls):
+            np.testing.assert_allclose(
+                mb_multi.flowline_mb_models[i].mb_buckets_np,
+                mb_multi_branch.flowline_mb_models[i].mb_buckets_np)
+            assert mb_multi_branch.flowline_mb_models[i]._current_index == 0
+
+        # Test 7: test with dynamic run and multiple flowlines
+        continues_run = tasks.run_from_climate_data(
+            gdir,
+            mb_model_class=partial(
+                massbalance.SfcTypeTIModel,
+                mb_model_class=massbalance.MonthlyTIModel,
+                ys=1990,),
+            ys=1990, ye=2000,
+            mb_elev_feedback='monthly',
+            save_mb_diagnostics_filesuffix='continues_run',
+        )
+
+        part1_run = tasks.run_from_climate_data(
+            gdir,
+            mb_model_class=partial(
+                massbalance.SfcTypeTIModel,
+                mb_model_class=massbalance.MonthlyTIModel,
+                ys=1990, ),
+            ys=1990, ye=1995,
+            mb_elev_feedback='monthly',
+            save_mb_diagnostics_filesuffix='part1_run',
+        )
+        # pass part1_run.fls for glacier geometry
+        part2_run = tasks.run_from_climate_data(
+            gdir,
+            mb_diagnostics_filesuffix='part1_run',
+            ys=1995, ye=2000,
+            init_model_fls=part1_run.fls,
+            mb_elev_feedback='monthly',
+            save_mb_diagnostics_filesuffix='part2_run',
+        )
+
+        np.testing.assert_allclose(continues_run.volume_m3, part2_run.volume_m3,
+                                   rtol=1e-5)
+
+        continues_mb = massbalance.MultipleFlowlineMassBalance.load_from_file(
+            gdir, filesuffix='continues_run')
+        part2_mb = massbalance.MultipleFlowlineMassBalance.load_from_file(
+            gdir, filesuffix='part2_run')
+        # buckets are not too different
+        for i, fl in enumerate(fls):
+            np.testing.assert_allclose(
+                continues_mb.flowline_mb_models[i].mb_buckets_np,
+                part2_mb.flowline_mb_models[i].mb_buckets_np,
+                rtol=5e-3)
+
+    @pytest.mark.slow
     def test_sfc_type_mb_model_calib_dynamics(self, hef_gdir):
 
         # sfc tracking only works with a single flowline
@@ -1831,7 +2078,8 @@ class TestMassBalanceModels:
             ys=mbdf.index[0])
         # by calling one of the last years, all previous values need to be
         # computed as well
-        mb_mod_new.get_specific_mb(fls=[mb_mod_new.fl], year=2019)
+        mb_mod_new.get_specific_mb(
+            fls=gdir.read_pickle('inversion_flowlines'), year=2019)
         assert mb_mod_calib.mb_buckets_year == mb_mod_new.mb_buckets_year
         np.testing.assert_allclose(mb_mod_calib.mb_buckets_np,
                                    mb_mod_new.mb_buckets_np)
@@ -1980,7 +2228,102 @@ class TestMassBalanceModels:
         np.testing.assert_allclose(ds_daily_sfc.mass_kg,
                                    ds_daily_sfc_firn.mass_ice_kg)
 
+        # test save_mb_diagnostics_filesuffix and mb_diagnostics_filesuffix
+
+        # (a) Run historical period to 2010, saving MB state at the end
+        dyn_model_hist = tasks.run_from_climate_data(
+            gdir, settings_filesuffix='_daily_sfc',
+            mb_model_class=partial(
+                massbalance.SfcTypeTIModel,
+                mb_model_class=massbalance.DailyTIModel,
+                ys=mbdf.index[0]),
+            climate_input_filesuffix='_daily',
+            ys=1980, ye=2010,
+            store_model_geometry=True,
+            mb_elev_feedback='monthly',
+            output_filesuffix='_daily_sfc_hist',
+            save_mb_diagnostics_filesuffix='_hist_checkpoint')
+
+        # saved file must exist
+        assert gdir.has_file(
+            'mb_diagnostics', filesuffix='_hist_checkpoint')
+
+        # (b) Load the saved MultipleFlowlineMassBalance and verify bucket state
+        mb_loaded = massbalance.MultipleFlowlineMassBalance.load_from_file(
+            gdir, filesuffix='_hist_checkpoint')
+        hist_mb_mod = dyn_model_hist.mb_model.flowline_mb_models[0]
+        loaded_mb_mod = mb_loaded.flowline_mb_models[0]
+        np.testing.assert_allclose(hist_mb_mod.mb_buckets_np,
+                                   loaded_mb_mod.mb_buckets_np)
+        assert hist_mb_mod.mb_buckets_year == loaded_mb_mod.mb_buckets_year
+        assert hist_mb_mod._current_index == loaded_mb_mod._current_index
+
+        # (c) Projection from the saved state using mb_diagnostics_filesuffix.
+        # We pass climate_input_filesuffix='_daily' (same file) to trigger the
+        # scenario-branch path: bucket state is kept, MB history is reset, and
+        # the output arrays are sized for 2010 to 2020.
+        dyn_model_proj = tasks.run_from_climate_data(
+            gdir, settings_filesuffix='_daily_sfc',
+            climate_input_filesuffix='_daily',
+            ys=2010, ye=2020,
+            mb_elev_feedback='monthly',
+            init_model_filesuffix='_daily_sfc_hist',
+            output_filesuffix='_daily_sfc_proj',
+            mb_diagnostics_filesuffix='_hist_checkpoint')
+
+        # projection MB model is in scenario-branch state: history reset
+        proj_mb_mod = dyn_model_proj.mb_model.flowline_mb_models[0]
+        assert proj_mb_mod.ys == int(hist_mb_mod.mb_buckets_year)
+        # historical mb should cover the entire period provided (ys to ye)
+        assert hist_mb_mod._climatic_mb.shape[0] == (2020 - mbdf.index[0]) * 12
+        # the projection only should start at ys = 2010
+        assert proj_mb_mod._climatic_mb.shape[0] == (2020 - 2010) * 12
+
+        # (d) Running the same projection twice from the same saved state must
+        # give identical volume output
+        dyn_model_proj2 = tasks.run_from_climate_data(
+            gdir, settings_filesuffix='_daily_sfc',
+            climate_input_filesuffix='_daily',
+            ys=2010, ye=2020,
+            mb_elev_feedback='monthly',
+            init_model_filesuffix='_daily_sfc_hist',
+            output_filesuffix='_daily_sfc_proj2',
+            mb_diagnostics_filesuffix='_hist_checkpoint')
+
+        ds_proj = utils.compile_run_output(
+            gdir, input_filesuffix='_daily_sfc_proj')
+        ds_proj2 = utils.compile_run_output(
+            gdir, input_filesuffix='_daily_sfc_proj2')
+        np.testing.assert_allclose(ds_proj.volume.values,
+                                   ds_proj2.volume.values)
+
+        # we should get the same when doing a continues run
+        dyn_model_hist = tasks.run_from_climate_data(
+            gdir, settings_filesuffix='_daily_sfc',
+            mb_model_class=partial(
+                massbalance.SfcTypeTIModel,
+                mb_model_class=massbalance.DailyTIModel,
+                ys=mbdf.index[0]),
+            climate_input_filesuffix='_daily',
+            ys=1980, ye=2020,
+            store_model_geometry=True,
+            mb_elev_feedback='monthly',
+            output_filesuffix='_daily_sfc_continues_run',
+            save_mb_diagnostics_filesuffix='_hist_continues_run')
+
+        # a continues run should end up at the same volume at the end
+        np.testing.assert_allclose(dyn_model_hist.volume_m3,
+                                   ds_proj.volume.values[-1])
+
+        # also snow buckets should be the same at the end
+        continues_mb = massbalance.MultipleFlowlineMassBalance.load_from_file(
+            gdir, filesuffix='_hist_continues_run')
+        np.testing.assert_allclose(
+            continues_mb.flowline_mb_models[0].mb_buckets_np,
+            proj_mb_mod.mb_buckets_np, )
+
         # test run_with_hydro, just testing if it runs without errors
+        # TODO: run_with_hydro needs to be adapted for SfcTypeTIModel
         gdir.settings_filesuffix = '_daily'
         gdir.settings['store_model_geometry'] = True
         tasks.run_with_hydro(

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -633,13 +633,14 @@ class TestMassBalanceModels:
             - hemisphere: nh
             - ice_density: 900.0
             - use_leap_years: True
+            - mb_model_class: DailyTIModel
             - filename: climate_historical_daily
             - input_filesuffix: 
             - bias: 0.0
             - ys: 2000
             - ye: 2019
-            - aging_frequency: annual
-            - climate_resolution: annual
+            - aging_frequency: monthly
+            - climate_resolution: monthly
             - spinup_years: 6
             - save_spinup_mbs: False
             - tau_e: 1.0
@@ -650,8 +651,8 @@ class TestMassBalanceModels:
             - store_buckets: False
             - use_previous_mbs: False
             - store_snowline: False
-            - nr_timesteps: 20
-            - mb_buckets_year: 2000
+            - nr_timesteps: 240
+            - mb_buckets_year: 2000.0
         """)
         mb_mod = massbalance.SfcTypeTIModel(hef_gdir,
                                             settings_filesuffix='_daily',
@@ -3407,7 +3408,7 @@ class TestIO():
 
         # Check attrs
         assert ds.attrs['mb_model_class'] == 'LinearMassBalance'
-        assert ds.attrs['mb_model_rho'] == cfg.PARAMS['ice_density']
+        assert ds.attrs['mb_model_ice_density'] == cfg.PARAMS['ice_density']
         assert ds_diag.attrs['mb_model_class'] == 'LinearMassBalance'
         assert ds_diag.attrs['mb_model_ela_h'] == 2600
 
@@ -3452,7 +3453,7 @@ class TestIO():
                              model.get_mb(surface_h_previous_timestep,
                                           years[i-1],
                                           fl_id=0) *
-                             SEC_IN_MONTH)  # converted to m yr-1
+                             model._get_sec_in_month(years[i-1]))  # converted to m yr-1
                 )
                 surface_h_previous_timestep = model.fls[0].surface_h
 

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -2009,7 +2009,7 @@ class TestMassBalanceModels:
             np.testing.assert_allclose(
                 continues_mb.flowline_mb_models[i].mb_buckets_np,
                 part2_mb.flowline_mb_models[i].mb_buckets_np,
-                rtol=1e-2)
+                rtol=2e-2)
 
     @pytest.mark.slow
     def test_sfc_type_mb_model_calib_dynamics(self, hef_gdir):

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -545,7 +545,7 @@ class TestMassBalanceModels:
         np.testing.assert_allclose(np.sum(prcpsol_m, axis=0), prcpsol_a)
         np.testing.assert_allclose((np.sum(prcpsol_m, axis=0) -
                                     mb_mod.melt_f * np.sum(tmelt_m,axis=0)) /
-                                   mb_mod.sec_in_year(yr) / mb_mod.rho,
+                                   mb_mod.sec_in_year(yr) / mb_mod.ice_density,
                                    mb_annual)
 
         # test implementation of days of month in MonthlyTIModel.get_annual_mb
@@ -569,7 +569,7 @@ class TestMassBalanceModels:
             - temp_bias: 0.00
             - bias: 0.00
             - settings_filesuffix: 
-            - rho: 900.0
+            - ice_density: 900.0
             - use_leap_years: False
             - filename: climate_historical
             - input_filesuffix: 
@@ -603,7 +603,7 @@ class TestMassBalanceModels:
             - temp_bias: 0.00
             - bias: 0.00
             - settings_filesuffix: _daily
-            - rho: 900.0
+            - ice_density: 900.0
             - use_leap_years: True
             - filename: climate_historical_daily
             - input_filesuffix: 
@@ -631,7 +631,7 @@ class TestMassBalanceModels:
           Attributes:
             - settings_filesuffix: _daily
             - hemisphere: nh
-            - rho: 900.0
+            - ice_density: 900.0
             - use_leap_years: True
             - filename: climate_historical_daily
             - input_filesuffix: 
@@ -645,6 +645,8 @@ class TestMassBalanceModels:
             - tau_e: 1.0
             - melt_f_ratio: 0.5
             - melt_f_change: neg_exp
+            - snow_density: 300
+            - density_change: neg_exp
             - store_buckets: False
             - use_previous_mbs: False
             - store_snowline: False
@@ -969,7 +971,7 @@ class TestMassBalanceModels:
             assert isinstance(ela_z, float)
             assert ela_z == ela_array
             totest = (mb_mod.flowline_mb_models[-1].get_annual_mb([ela_z], year=yr) *
-                      mb_mod.flowline_mb_models[-1].sec_in_year(yr) * mb_mod.rho)
+                      mb_mod.flowline_mb_models[-1].sec_in_year(yr) * mb_mod.ice_density)
             assert_allclose(totest[0], 0, atol=1)
 
     def test_daily_mb_model(self, hef_gdir):
@@ -1243,7 +1245,7 @@ class TestMassBalanceModels:
         mb_mod = massbalance.DailyTIModel(gdir, settings_filesuffix='_daily')
         for yr in mbdf.index.values:
             my_mb_on_h = (mb_mod.get_annual_mb(h, yr) * mb_mod.sec_in_year(yr) *
-                          mb_mod.rho)
+                          mb_mod.ice_density)
             mbdf.loc[yr, 'MY_MB'] = np.average(my_mb_on_h, weights=w)
 
         np.testing.assert_allclose(mbdf['ANNUAL_BALANCE'].mean(),
@@ -1257,7 +1259,7 @@ class TestMassBalanceModels:
                                           bias=0)
         for yr in mbdf.index.values:
             my_mb_on_h = (mb_mod.get_annual_mb(h, yr) * mb_mod.sec_in_year(yr) *
-                          mb_mod.rho)
+                          mb_mod.ice_density)
             mbdf.loc[yr, 'MY_MB'] = np.average(my_mb_on_h, weights=w)
 
         np.testing.assert_allclose(mbdf['ANNUAL_BALANCE'].mean(),
@@ -1267,11 +1269,11 @@ class TestMassBalanceModels:
         mb_mod = massbalance.DailyTIModel(gdir, settings_filesuffix='_daily')
         for yr in mbdf.index.values:
             my_mb_on_h = (mb_mod.get_annual_mb(h, yr) * mb_mod.sec_in_year(yr) *
-                          mb_mod.rho)
+                          mb_mod.ice_density)
             mbdf.loc[yr, 'MY_MB'] = np.average(my_mb_on_h, weights=w)
             mb_mod.temp_bias = 1
             my_mb_on_h = (mb_mod.get_annual_mb(h, yr) * mb_mod.sec_in_year(yr) *
-                          mb_mod.rho)
+                          mb_mod.ice_density)
             mbdf.loc[yr, 'BIASED_MB'] = np.average(my_mb_on_h, weights=w)
             mb_mod.temp_bias = 0
 
@@ -1392,19 +1394,23 @@ class TestMassBalanceModels:
             else:
                 raise NotImplementedError(f"ti_model: {ti_model}")
 
-            mb_mod = massbalance.SfcTypeTIModel(
-                gdir,
-                settings_filesuffix=settings_filesuffix,
-                mb_model_class=mb_model_class,
-                ys=2000,
-                climate_resolution=clim_res,
-                aging_frequency=aging,
-                save_spinup_mbs=True,
-                store_buckets=clim_res,
-                use_previous_mbs=True,
-                check_calib_params=False,
-                input_filesuffix=input_filesuffix,
-            )
+            def get_fresh_mb_mod(settings_filesuffix, mb_model_class,
+                                 input_filesuffix, clim_res, aging):
+                return massbalance.SfcTypeTIModel(
+                    gdir,
+                    settings_filesuffix=settings_filesuffix,
+                    mb_model_class=mb_model_class,
+                    ys=2000,
+                    climate_resolution=clim_res,
+                    aging_frequency=aging,
+                    save_spinup_mbs=True,
+                    store_buckets=clim_res,
+                    use_previous_mbs=True,
+                    check_calib_params=False,
+                    input_filesuffix=input_filesuffix,
+                )
+            mb_mod = get_fresh_mb_mod(settings_filesuffix, mb_model_class,
+                                      input_filesuffix, clim_res, aging)
 
             assert inv_fl.nx == mb_mod.mb_buckets_np.shape[0]
             np.testing.assert_allclose(inv_fl.surface_h, mb_mod.fl.surface_h)
@@ -1421,6 +1427,19 @@ class TestMassBalanceModels:
                 heights=h, year=target_year_annual,
                 climatic_mb_or_ice_mb='ice_mb')
 
+            # test elevation feedback of mb_buckets heights for get_annual_mb
+            # need a fresh mb model, because of 'buckets-memory'
+            mb_mod_elev = get_fresh_mb_mod(
+                settings_filesuffix, mb_model_class, input_filesuffix, clim_res,
+                aging)
+            smb_annual_mb_elev = mb_mod_elev.get_annual_mb(
+                heights=h, year=target_year_annual,
+                include_mb_model_heights=True)
+            # including extra height of buckets gives the same (bucket_height=0)
+            # or a more positive (less negative) smb value
+            assert np.all(smb_annual_mb_elev - smb_annual[setting] >= 0.)
+            assert np.any(smb_annual_mb_elev - smb_annual[setting] > 0.)
+
             if clim_res in ['monthly', 'daily']:
                 target_year_month = target_year_annual + 1
                 # test get_monthly_mb call
@@ -1434,6 +1453,16 @@ class TestMassBalanceModels:
                 assert mb_mod.mb_buckets_year == date_to_floatyear(
                     y=target_year_month, m=9)
 
+                # test elevation feedback of mb_buckets heights for get_monthly_mb
+                smb_monthly_4_mb_elev = mb_mod_elev.get_monthly_mb(
+                    heights=h, year=date_to_floatyear(y=target_year_month, m=4),
+                    include_mb_model_heights=True)
+                # including extra height of buckets gives the same (bucket_height=0)
+                # or a more positive (less negative) smb value;
+                # -1e-20 floating point precision
+                assert np.all(smb_monthly_4_mb_elev - smb_monthly_4[setting] >= -1e-20)
+                assert np.any(smb_monthly_4_mb_elev - smb_monthly_4[setting] > 0)
+
             if clim_res in ['daily']:
                 target_year_day = target_year_month
                 smb_daily_3_9[setting] = mb_mod.get_daily_mb(
@@ -1446,6 +1475,16 @@ class TestMassBalanceModels:
                     year=date_to_floatyear(y=target_year_day, m=9, d=5))
                 assert mb_mod.mb_buckets_year == date_to_floatyear(
                     y=target_year_day, m=9, d=6)
+
+                # test elevation feedback of mb_buckets heights for get_daily_mb
+                smb_daily_3_9_mb_elev = mb_mod_elev.get_daily_mb(
+                    heights=h,
+                    year=date_to_floatyear(y=target_year_day, m=9, d=3),
+                    include_mb_model_heights=True)
+                # including extra height of buckets gives the same (bucket_height=0)
+                # or a more positive (less negative) smb value
+                assert np.all(smb_daily_3_9_mb_elev - smb_daily_3_9[setting] >= -1e-20)
+                assert np.any(smb_daily_3_9_mb_elev - smb_daily_3_9[setting] > 0)
 
             mb_buckets = mb_mod.mb_buckets_stored
 
@@ -1757,7 +1796,7 @@ class TestMassBalanceModels:
             calibrate_param3='temp_bias',
             mb_model_class=massbalance.DailyTIModel)
 
-        df, mb_mod_claib = massbalance.mb_calibration_from_scalar_mb(
+        df, mb_mod_calib = massbalance.mb_calibration_from_scalar_mb(
             gdir, settings_filesuffix='_daily_sfc',
             observations_filesuffix='_daily_sfc',
             overwrite_gdir=True,
@@ -1793,12 +1832,12 @@ class TestMassBalanceModels:
         # by calling one of the last years, all previous values need to be
         # computed as well
         mb_mod_new.get_specific_mb(fls=[mb_mod_new.fl], year=2019)
-        assert mb_mod_claib.mb_buckets_year == mb_mod_new.mb_buckets_year
-        np.testing.assert_allclose(mb_mod_claib.mb_buckets_np,
+        assert mb_mod_calib.mb_buckets_year == mb_mod_new.mb_buckets_year
+        np.testing.assert_allclose(mb_mod_calib.mb_buckets_np,
                                    mb_mod_new.mb_buckets_np)
-        np.testing.assert_allclose(mb_mod_claib.climatic_mb.values,
+        np.testing.assert_allclose(mb_mod_calib.climatic_mb.values,
                                    mb_mod_new.climatic_mb.values)
-        np.testing.assert_allclose(mb_mod_claib.ice_mb.values,
+        np.testing.assert_allclose(mb_mod_calib.ice_mb.values,
                                    mb_mod_new.ice_mb.values)
 
         # now conduct two dynamic runs and compare
@@ -1806,8 +1845,10 @@ class TestMassBalanceModels:
                                     mb_model_class=massbalance.DailyTIModel,
                                     climate_input_filesuffix='_daily',
                                     ys=1980, ye=2020,
+                                    mb_elev_feedback='monthly',
                                     output_filesuffix='_daily')
         ds_daily = utils.compile_run_output(gdir, input_filesuffix='_daily')
+
         dyn_model = tasks.run_from_climate_data(
             gdir, settings_filesuffix='_daily_sfc',
             mb_model_class=partial(
@@ -1816,8 +1857,16 @@ class TestMassBalanceModels:
                 ys=mbdf.index[0]),
             climate_input_filesuffix='_daily',
             ys=1980, ye=2020,
+            store_model_geometry=True, store_fl_diagnostics=True,
+            store_monthly_step=True, mb_elev_feedback='monthly',
             output_filesuffix='_daily_sfc')
-        ds_daily_sfc = utils.compile_run_output(gdir, input_filesuffix='_daily_sfc')
+        ds_daily_sfc = utils.compile_run_output(gdir,
+                                                input_filesuffix='_daily_sfc')
+        with xr.open_dataset(
+                gdir.get_filepath('fl_diagnostics',
+                                  filesuffix='_daily_sfc'),
+                group=f'fl_0') as ds_fl_sfc:
+            ds_fl_sfc = ds_fl_sfc.load()
 
         if do_plot:
             ds_daily.volume.plot(label='DailyTIModel')
@@ -1828,6 +1877,108 @@ class TestMassBalanceModels:
         # including surface tracking we expect slower retreat as more energy is
         # needed to melt the input mass
         assert ds_daily.volume[-1] < ds_daily_sfc.volume[-1]
+
+        # test for include mb_model_heights in dynamics
+        dyn_model_elev = tasks.run_from_climate_data(
+            gdir, settings_filesuffix='_daily_sfc',
+            mb_model_class=partial(
+                massbalance.SfcTypeTIModel,
+                mb_model_class=massbalance.DailyTIModel,
+                ys=mbdf.index[0]),
+            climate_input_filesuffix='_daily',
+            ys=1980, ye=2020,
+            mb_elev_feedback='monthly',
+            output_filesuffix='_daily_sfc_mb_elev',
+            include_mb_model_heights=True,
+        )
+        ds_daily_sfc_elev = utils.compile_run_output(
+            gdir, input_filesuffix='_daily_sfc_mb_elev')
+        # test that including elevation feedback from mb_bucktes leads to larger
+        # overall volume
+        assert np.all(ds_daily_sfc_elev.volume - ds_daily_sfc.volume >= 0.)
+        assert np.any(ds_daily_sfc_elev.volume - ds_daily_sfc.volume > 0.)
+
+        # test firn outputs
+        dyn_model_firn = tasks.run_from_climate_data(
+            gdir, settings_filesuffix='_daily_sfc',
+            mb_model_class=partial(
+                massbalance.SfcTypeTIModel,
+                mb_model_class=massbalance.DailyTIModel,
+                ys=mbdf.index[0]),
+            climate_input_filesuffix='_daily',
+            ys=1980, ye=2020,
+            store_model_geometry=True, store_fl_diagnostics=True,
+            store_monthly_step=True, mb_elev_feedback='monthly',
+            output_filesuffix='_daily_sfc_firn_output',
+            include_firn_outputs=True,
+        )
+        ds_daily_sfc_firn = utils.compile_run_output(
+            gdir, input_filesuffix='_daily_sfc_firn_output')
+        with xr.open_dataset(
+                gdir.get_filepath('fl_diagnostics',
+                                  filesuffix='_daily_sfc_firn_output'),
+                group=f'fl_0') as ds_fl_sfc_firn:
+            ds_fl_sfc_firn = ds_fl_sfc_firn.load()
+
+        # totals should be equal of ice + firn
+        # glacier totals
+        np.testing.assert_allclose(
+            ds_daily_sfc_firn.mass_ice_kg + ds_daily_sfc_firn.mass_firn_kg,
+            ds_daily_sfc_firn.mass_kg)
+        np.testing.assert_allclose(
+            ds_daily_sfc_firn.volume_ice + ds_daily_sfc_firn.volume_firn,
+            ds_daily_sfc_firn.volume)
+        # fl_diagnostics
+        np.testing.assert_allclose(
+            ds_fl_sfc_firn.mass_ice_kg + ds_fl_sfc_firn.mass_firn_kg,
+            ds_fl_sfc_firn.mass_kg)
+        np.testing.assert_allclose(
+            ds_fl_sfc_firn.volume_ice_m3 + ds_fl_sfc_firn.volume_firn_m3,
+            ds_fl_sfc_firn.volume_m3)
+        np.testing.assert_allclose(
+            ds_fl_sfc_firn.thickness_ice_m + ds_fl_sfc_firn.thickness_firn_m,
+            ds_fl_sfc_firn.thickness_m)
+
+        # check firn density always larger then fresh snow
+        snow_density = dyn_model_firn.mb_model.flowline_mb_models[0].snow_density
+        # glacier totals
+        assert np.all(
+            ds_daily_sfc_firn.mass_firn_kg / ds_daily_sfc_firn.volume_firn >=
+            snow_density)
+        # fl_diagnostics
+        fl_firn_density = ds_fl_sfc_firn.mass_firn_kg / ds_fl_sfc_firn.volume_firn_m3
+        assert np.all(
+            # deal with nan values
+            np.where(np.isnan(fl_firn_density), snow_density, fl_firn_density) >=
+            snow_density)
+
+        # check max firn density inside of a plausible range, it can be larger
+        # than ice density due to firn densification over time
+        max_firn_density = 2000
+        assert np.max(ds_daily_sfc_firn.mass_firn_kg /
+                      ds_daily_sfc_firn.volume_firn) < max_firn_density
+        assert np.max(np.where(np.isfinite(fl_firn_density),
+                               fl_firn_density, 0)) < max_firn_density
+
+        # check ice density always the same in dynamic model
+        # glacier totals
+        np.testing.assert_allclose(
+            ds_daily_sfc_firn.mass_ice_kg / ds_daily_sfc_firn.volume_ice,
+            dyn_model_firn.ice_density)
+        # fl_diagnostics
+        fl_ice_density = ds_fl_sfc_firn.mass_ice_kg / ds_fl_sfc_firn.volume_ice_m3
+        np.testing.assert_allclose(
+            # deal with nan values
+            np.where(np.isnan(fl_ice_density),
+                     dyn_model_firn.ice_density, fl_ice_density),
+            dyn_model_firn.ice_density)
+
+        # current implementation: if firn output is not included set the total
+        # to the ice values
+        np.testing.assert_allclose(ds_daily_sfc.volume,
+                                   ds_daily_sfc_firn.volume_ice)
+        np.testing.assert_allclose(ds_daily_sfc.mass_kg,
+                                   ds_daily_sfc_firn.mass_ice_kg)
 
         # test run_with_hydro, just testing if it runs without errors
         gdir.settings_filesuffix = '_daily'
@@ -3332,6 +3483,176 @@ def inversion_gdir(class_case_dir):
     gdir = GlacierDirectory(entity, base_dir=class_case_dir, reset=True)
     define_glacier_region(gdir)
     return gdir
+
+
+class TestLeapYears:
+    """Tests for leap-year-aware time conversion in FlowlineModel."""
+
+    def _make_model(self, y0, use_leap_years):
+        cfg.initialize()
+        fls = dummy_constant_bed()
+        mb = LinearMassBalance(2600., use_leap_years=use_leap_years)
+        glen_a = 2.4e-24
+        return FluxBasedModel(fls, mb_model=mb, y0=float(y0), glen_a=glen_a)
+
+    def test_yr_to_seconds_known_values(self):
+        """_yr_to_seconds must accumulate 366 days for leap years, 365 for others."""
+        model = self._make_model(1980, use_leap_years=True)
+        SEC = 86400
+        # 1980 is a leap year (366 d)
+        assert model._yr_to_seconds(1981.0) == 366 * SEC
+        # 1981 is not (365 d)
+        assert model._yr_to_seconds(1982.0) == (366 + 365) * SEC
+        # 1980–1984 spans two leap years (1980, 1984) and three normal ones
+        assert model._yr_to_seconds(1985.0) == (366 + 365 + 365 + 365 + 366) * SEC
+        # Fractional year: 0.5 through a 365-day year
+        assert model._yr_to_seconds(1981.5) == (366 + 0.5 * 365) * SEC
+
+    def test_round_trip(self):
+        """_seconds_to_yr must be the exact inverse of _yr_to_seconds."""
+        model = self._make_model(1980, use_leap_years=True)
+        # float_years_timeseries covers monthly steps over 5 years (1980–1984),
+        # including two leap years (1980, 1984) and the Feb-29 transitions.
+        for yr in utils.float_years_timeseries(1980., 1985.):
+            t = model._yr_to_seconds(yr)
+            np.testing.assert_allclose(model._seconds_to_yr(t), yr, atol=1e-9,
+                                       err_msg=f'Round-trip failed for yr={yr}')
+
+    def test_yr_property_after_run(self):
+        """After run_until(y1), self.yr must equal y1 and self.t the correct seconds."""
+        model = self._make_model(1980, use_leap_years=True)
+        model.run_until(1985.)
+        np.testing.assert_allclose(model.yr, 1985., atol=1e-9)
+        expected_t = (366 + 365 + 365 + 365 + 366) * 86400  # 1980–1984
+        np.testing.assert_allclose(model.t, expected_t, rtol=1e-9)
+
+    def test_no_leap_unchanged(self):
+        """With use_leap_years=False the old SEC_IN_YEAR behaviour must be preserved."""
+        model = self._make_model(1980, use_leap_years=False)
+        model.run_until(1985.)
+        np.testing.assert_allclose(model.t, 5 * SEC_IN_YEAR)
+        np.testing.assert_allclose(model.yr, 1985.)
+
+    def test_lookup_extension(self):
+        """_yr_to_seconds/_seconds_to_yr must work beyond the initial 100-year window."""
+        model = self._make_model(1980, use_leap_years=True)
+        yr_far = 2090.75  # 110 years past y0, beyond default 100-year window
+        t = model._yr_to_seconds(yr_far)
+        np.testing.assert_allclose(model._seconds_to_yr(t), yr_far, atol=1e-9)
+
+    def test_run_until_monthly_steps(self):
+        """Monthly time steps through a leap year must land on exact targets."""
+        model = self._make_model(1980, use_leap_years=True)
+        monthly_ts = utils.float_years_timeseries(1980., 1981.)
+        for yr in monthly_ts:
+            model.run_until(yr)
+            np.testing.assert_allclose(model.yr, yr, atol=1e-9,
+                                       err_msg=f'Missed target month at yr={yr}')
+
+    def test_calendar_attr(self, tmp_path):
+        """Output datasets must carry the correct calendar string."""
+        model = self._make_model(1980, use_leap_years=True)
+        ds_diag, _ = model.run_until_and_store(1985., geom_path=None)
+        assert ds_diag.attrs['calendar'] == '365/366-day (Gregorian, leap years)'
+
+        model2 = self._make_model(1980, use_leap_years=False)
+        ds_diag2, _ = model2.run_until_and_store(1985., geom_path=None)
+        assert ds_diag2.attrs['calendar'] == '365-day (no leap)'
+
+    def test_leap_years_with_monthly_ti_model(self, hef_gdir):
+        """Comprehensive test of leap-year handling with MonthlyTIModel.
+
+        Covers:
+        - _get_sec_in_year / _get_sec_in_month delegation in FlowlineModel
+        - February climatic_mb differnce: cmb_leap - cmb_noleap = -melt_f * tmelt_pd / rho
+        - get_annual_mb normalisation by sec_in_year
+        - MultipleFlowlineMassBalance.sec_in_year / sec_in_month delegation
+        """
+        from oggm.core.massbalance import MonthlyTIModel, MultipleFlowlineMassBalance
+
+        feb_1980 = utils.date_to_floatyear(1980, 2)  # 1980 is a leap year
+        feb_1981 = utils.date_to_floatyear(1981, 2)  # 1981 is not
+
+        mb_leap = MonthlyTIModel(hef_gdir, use_leap_years=True)
+        mb_noleap = MonthlyTIModel(hef_gdir, use_leap_years=False)
+
+        # --- 1. _get_sec_in_year / _get_sec_in_month ---
+        fls = dummy_constant_bed()
+        model_leap = FluxBasedModel(fls, mb_model=mb_leap, y0=1980.)
+        model_noleap = FluxBasedModel(dummy_constant_bed(), mb_model=mb_noleap, y0=1980.)
+
+        assert model_leap._get_sec_in_year(feb_1980) == 366 * 86400  # 1980 is leap
+        assert model_noleap._get_sec_in_year(feb_1980) == 365 * 86400
+        assert model_leap._get_sec_in_year(feb_1981) == 365 * 86400  # 1981 not leap
+        assert model_noleap._get_sec_in_year(feb_1981) == 365 * 86400  # identical
+
+        assert model_leap._get_sec_in_month(feb_1980) == 29 * 86400  # leap February
+        assert model_noleap._get_sec_in_month(feb_1980) == 28 * 86400
+        assert model_leap._get_sec_in_month(feb_1981) == 28 * 86400  # non-leap February
+        assert model_noleap._get_sec_in_month(feb_1981) == 28 * 86400  # identical
+
+        # --- 2. February climatic_mb ---
+        # climatic_mb = get_monthly_mb(heights, year) * sec_in_month
+        # For February in a leap year (N=29 days) vs non-leap (N=28 days):
+        #   cmb_leap   = (prcpsol - melt_f * 29 * tmelt_pd) / rho
+        #   cmb_noleap = (prcpsol - melt_f * 28 * tmelt_pd) / rho
+        #   difference = -melt_f * tmelt_pd / rho  (zero if no February melt)
+        heights = fls[0].surface_h
+        cmb_leap = (mb_leap.get_monthly_mb(heights, year=feb_1980)
+                    * mb_leap.sec_in_month(feb_1980))
+        cmb_noleap = (mb_noleap.get_monthly_mb(heights, year=feb_1980)
+                      * mb_noleap.sec_in_month(feb_1980))
+
+        _, tmelt_feb_leap, _, _ = mb_leap.get_monthly_climate(heights, year=feb_1980)
+        tmelt_per_day = tmelt_feb_leap / 29  # tmelt_feb_leap was scaled by 29 days
+        expected_diff = -mb_leap.melt_f * tmelt_per_day / mb_leap.ice_density
+        # test for some magnitude of expected_diff
+        assert np.any(np.abs(expected_diff) > 1e-2)
+        np.testing.assert_allclose(cmb_leap - cmb_noleap, expected_diff, rtol=1e-6)
+
+        # For a non-leap February both models must give the same climatic_mb
+        cmb_leap_1981 = (mb_leap.get_monthly_mb(heights, year=feb_1981)
+                         * mb_leap.sec_in_month(feb_1981))
+        cmb_noleap_1981 = (mb_noleap.get_monthly_mb(heights, year=feb_1981)
+                           * mb_noleap.sec_in_month(feb_1981))
+        np.testing.assert_allclose(cmb_leap_1981, cmb_noleap_1981)
+
+        # --- 3. get_annual_mb: sec_in_year normalisation ---
+        # the same "expected_diff" as above
+        mb_a_leap = mb_leap.get_annual_mb(heights, year=1980.)
+        mb_a_noleap = mb_noleap.get_annual_mb(heights, year=1980.)
+        np.testing.assert_allclose(
+            mb_a_leap * 366 * 86400 - mb_a_noleap * 365 * 86400,
+            expected_diff,
+            atol=1e-14,
+        )
+        # For a non-leap year the two models give identical annual MB
+        np.testing.assert_allclose(
+            mb_leap.get_annual_mb(heights, year=1981.),
+            mb_noleap.get_annual_mb(heights, year=1981.),
+        )
+
+        # --- 4. MultipleFlowlineMassBalance.sec_in_year / sec_in_month ---
+        mb_multi_leap = MultipleFlowlineMassBalance(
+            hef_gdir, mb_model_class=MonthlyTIModel,
+            use_leap_years=True, use_inversion_flowlines=True)
+        mb_multi_noleap = MultipleFlowlineMassBalance(
+            hef_gdir, mb_model_class=MonthlyTIModel,
+            use_leap_years=False, use_inversion_flowlines=True)
+
+        assert mb_multi_leap.sec_in_year(feb_1980) == 366 * 86400
+        assert mb_multi_noleap.sec_in_year(feb_1980) == 365 * 86400
+        assert mb_multi_leap.sec_in_month(feb_1980) == 29 * 86400
+        assert mb_multi_noleap.sec_in_month(feb_1980) == 28 * 86400
+
+        # Delegation must match the first inner flowline model
+        inner = mb_multi_leap.flowline_mb_models[0]
+        assert mb_multi_leap.sec_in_year(feb_1980) == inner.sec_in_year(feb_1980)
+        assert mb_multi_leap.sec_in_month(feb_1980) == inner.sec_in_month(feb_1980)
+
+        # use_leap_years is synced from inner models
+        assert mb_multi_leap.use_leap_years is True
+        assert mb_multi_noleap.use_leap_years is False
 
 
 class TestIdealisedInversion():

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -2009,7 +2009,7 @@ class TestMassBalanceModels:
             np.testing.assert_allclose(
                 continues_mb.flowline_mb_models[i].mb_buckets_np,
                 part2_mb.flowline_mb_models[i].mb_buckets_np,
-                rtol=5e-3)
+                rtol=1e-2)
 
     @pytest.mark.slow
     def test_sfc_type_mb_model_calib_dynamics(self, hef_gdir):

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -1446,11 +1446,13 @@ class TestClimate(unittest.TestCase):
         # Default is to calibrate melt_f
         reset_observation_file(gdir)
         mb_calibration_from_scalar_mb(gdir,
+                                      settings_filesuffix='_default',
                                       ref_mb=ref_mb,
                                       ref_mb_period=ref_period)
 
         h, w = gdir.get_inversion_flowline_hw()
-        mb_new = massbalance.MonthlyTIModel(gdir)
+        mb_new = massbalance.MonthlyTIModel(gdir,
+                                            settings_filesuffix='_default')
         mbdf['melt_mb'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
 
         # Check that results are all the same
@@ -1459,7 +1461,8 @@ class TestClimate(unittest.TestCase):
         np.testing.assert_allclose(1, mbdf[['ref_mb', 'melt_mb']].corr(),
                                    atol=0.35)
 
-        pdf = gdir.read_yml('settings')
+        pdf = gdir.read_settings(['temp_bias', 'melt_f', 'prcp_fac'],
+                                 filesuffix='_default')
         assert pdf['temp_bias'] == 0
         assert pdf['melt_f'] != cfg.PARAMS['melt_f']
         assert pdf['prcp_fac'] == cfg.PARAMS['prcp_fac']
@@ -1467,11 +1470,13 @@ class TestClimate(unittest.TestCase):
         # Let's calibrate on temp_bias
         reset_observation_file(gdir)
         mb_calibration_from_scalar_mb(gdir,
+                                      settings_filesuffix='_temp_bias',
                                       ref_mb=ref_mb,
                                       ref_mb_period=ref_period,
                                       calibrate_param1='temp_bias')
 
-        mb_new = massbalance.MonthlyTIModel(gdir)
+        mb_new = massbalance.MonthlyTIModel(gdir,
+                                            settings_filesuffix='_temp_bias')
         mbdf['temp_mb'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
 
         # Check that results are all the same
@@ -1480,7 +1485,8 @@ class TestClimate(unittest.TestCase):
         np.testing.assert_allclose(1, mbdf[['ref_mb', 'temp_mb']].corr(),
                                    atol=0.35)
 
-        pdf = gdir.read_yml('settings')
+        pdf = gdir.read_settings(['temp_bias', 'melt_f', 'prcp_fac'],
+                                 filesuffix='_temp_bias')
         assert pdf['temp_bias'] != 0
         assert pdf['melt_f'] == cfg.PARAMS['melt_f']
         assert pdf['prcp_fac'] == cfg.PARAMS['prcp_fac']
@@ -1488,11 +1494,13 @@ class TestClimate(unittest.TestCase):
         # Let's calibrate on precip
         reset_observation_file(gdir)
         mb_calibration_from_scalar_mb(gdir,
+                                      settings_filesuffix='_prcp_fac',
                                       ref_mb=ref_mb,
                                       ref_mb_period=ref_period,
                                       calibrate_param1='prcp_fac')
 
-        mb_new = massbalance.MonthlyTIModel(gdir)
+        mb_new = massbalance.MonthlyTIModel(gdir,
+                                            settings_filesuffix='_prcp_fac')
         mbdf['prcp_mb'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
 
         # Check that results are all the same
@@ -1501,7 +1509,8 @@ class TestClimate(unittest.TestCase):
         np.testing.assert_allclose(1, mbdf[['ref_mb', 'prcp_mb']].corr(),
                                    atol=0.35)
 
-        pdf = gdir.read_yml('settings')
+        pdf = gdir.read_settings(['temp_bias', 'melt_f', 'prcp_fac'],
+                                 filesuffix='_prcp_fac')
         assert pdf['temp_bias'] == 0
         assert pdf['melt_f'] == cfg.PARAMS['melt_f']
         assert pdf['prcp_fac'] != cfg.PARAMS['prcp_fac']
@@ -1519,11 +1528,13 @@ class TestClimate(unittest.TestCase):
                                           ref_mb_period=ref_period)
         reset_observation_file(gdir)
         mb_calibration_from_scalar_mb(gdir,
+                                      settings_filesuffix='_large_mb',
                                       ref_mb=ref_mb,
                                       ref_mb_period=ref_period,
                                       calibrate_param2='temp_bias')
 
-        mb_new = massbalance.MonthlyTIModel(gdir)
+        mb_new = massbalance.MonthlyTIModel(gdir,
+                                            settings_filesuffix='_large_mb')
         mbdf['melt_mb2'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
 
         # Check that results are all the same
@@ -1532,7 +1543,8 @@ class TestClimate(unittest.TestCase):
         np.testing.assert_allclose(1, mbdf[['ref_mb', 'melt_mb2']].corr(),
                                    atol=0.55)
 
-        pdf = gdir.read_yml('settings')
+        pdf = gdir.read_settings(['temp_bias', 'melt_f', 'prcp_fac'],
+                                 filesuffix='_large_mb')
         assert pdf['temp_bias'] < 0
         assert pdf['melt_f'] != cfg.PARAMS['melt_f']
         assert pdf['melt_f'] == cfg.PARAMS['melt_f_min']
@@ -1547,11 +1559,13 @@ class TestClimate(unittest.TestCase):
                                           ref_mb_period=ref_period)
         reset_observation_file(gdir)
         mb_calibration_from_scalar_mb(gdir,
+                                      settings_filesuffix='_small_mb',
                                       ref_mb=ref_mb,
                                       ref_mb_period=ref_period,
                                       calibrate_param2='temp_bias')
 
-        mb_new = massbalance.MonthlyTIModel(gdir)
+        mb_new = massbalance.MonthlyTIModel(gdir,
+                                            settings_filesuffix='_small_mb')
         mbdf['melt_mb2'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
 
         # Check that results are all the same
@@ -1560,7 +1574,8 @@ class TestClimate(unittest.TestCase):
         np.testing.assert_allclose(1, mbdf[['ref_mb', 'melt_mb2']].corr(),
                                    atol=0.5)
 
-        pdf = gdir.read_yml('settings')
+        pdf = gdir.read_settings(['temp_bias', 'melt_f', 'prcp_fac'],
+                                 filesuffix='_small_mb')
         assert pdf['temp_bias'] > 0
         assert pdf['melt_f'] != cfg.PARAMS['melt_f']
         assert pdf['melt_f'] == cfg.PARAMS['melt_f_max']
@@ -1577,12 +1592,14 @@ class TestClimate(unittest.TestCase):
                                           calibrate_param1='prcp_fac')
         reset_observation_file(gdir)
         mb_calibration_from_scalar_mb(gdir,
+                                      settings_filesuffix='_very_large',
                                       ref_mb=ref_mb,
                                       ref_mb_period=ref_period,
                                       calibrate_param1='prcp_fac',
                                       calibrate_param2='temp_bias')
 
-        mb_new = massbalance.MonthlyTIModel(gdir)
+        mb_new = massbalance.MonthlyTIModel(gdir,
+                                            settings_filesuffix='_very_large')
         mbdf['melt_mb2'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
 
         # Check that results are all the same
@@ -1591,7 +1608,8 @@ class TestClimate(unittest.TestCase):
         np.testing.assert_allclose(1, mbdf[['ref_mb', 'melt_mb2']].corr(),
                                    atol=0.45)
 
-        pdf = gdir.read_yml('settings')
+        pdf = gdir.read_settings(['temp_bias', 'melt_f', 'prcp_fac'],
+                                 filesuffix='_very_large')
         assert pdf['temp_bias'] < 0
         assert pdf['melt_f'] == cfg.PARAMS['melt_f']
         assert pdf['prcp_fac'] > cfg.PARAMS['prcp_fac']
@@ -1606,12 +1624,14 @@ class TestClimate(unittest.TestCase):
                                           calibrate_param1='prcp_fac')
         reset_observation_file(gdir)
         mb_calibration_from_scalar_mb(gdir,
+                                      settings_filesuffix='_very_small',
                                       ref_mb=ref_mb,
                                       ref_mb_period=ref_period,
                                       calibrate_param1='prcp_fac',
                                       calibrate_param2='temp_bias')
 
-        mb_new = massbalance.MonthlyTIModel(gdir)
+        mb_new = massbalance.MonthlyTIModel(gdir,
+                                            settings_filesuffix='_very_small')
         mbdf['melt_mb2'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
 
         # Check that results are all the same
@@ -1620,7 +1640,8 @@ class TestClimate(unittest.TestCase):
         np.testing.assert_allclose(1, mbdf[['ref_mb', 'melt_mb2']].corr(),
                                    atol=0.5)
 
-        pdf = gdir.read_yml('settings')
+        pdf = gdir.read_settings(['temp_bias', 'melt_f', 'prcp_fac'],
+                                 filesuffix='_very_small')
         assert pdf['temp_bias'] > 0
         assert pdf['melt_f'] == cfg.PARAMS['melt_f']
         assert pdf['prcp_fac'] < cfg.PARAMS['prcp_fac']
@@ -1644,13 +1665,15 @@ class TestClimate(unittest.TestCase):
 
         reset_observation_file(gdir)
         mb_calibration_from_scalar_mb(gdir,
+                                      settings_filesuffix='_extreme_small',
                                       ref_mb=ref_mb,
                                       ref_mb_period=ref_period,
                                       calibrate_param1='prcp_fac',
                                       calibrate_param2='temp_bias',
                                       calibrate_param3='melt_f')
 
-        mb_new = massbalance.MonthlyTIModel(gdir)
+        mb_new = massbalance.MonthlyTIModel(gdir,
+                                            settings_filesuffix='_extreme_small')
         mbdf['melt_mb3'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
 
         # Check that results are all the same
@@ -1659,7 +1682,8 @@ class TestClimate(unittest.TestCase):
         np.testing.assert_allclose(1, mbdf[['ref_mb', 'melt_mb3']].corr(),
                                    atol=0.5)
 
-        pdf = gdir.read_yml('settings')
+        pdf = gdir.read_settings(['temp_bias', 'melt_f', 'prcp_fac'],
+                                 filesuffix='_extreme_small')
         assert pdf['temp_bias'] == cfg.PARAMS['temp_bias_max']
         assert pdf['melt_f'] > cfg.PARAMS['melt_f']
         assert pdf['prcp_fac'] == cfg.PARAMS['prcp_fac_min']
@@ -1677,13 +1701,19 @@ class TestClimate(unittest.TestCase):
 
         # Matchable positive with less range
         ref_mb = 1000
-        gdir.settings['temp_bias_min'] = -0.5
-        gdir.settings['temp_bias_max'] = 0.5
-        gdir.settings['prcp_fac_min'] = 2
-        gdir.settings['prcp_fac_max'] = 3
+        gdir.create_new_settings(
+            filesuffix='_extreme_large',
+            data = {
+                'temp_bias_min': -0.5,
+                'temp_bias_max': 0.5,
+                'prcp_fac_min': 2,
+                'prcp_fac_max': 3,
+            }
+        )
         with pytest.raises(RuntimeError):
             reset_observation_file(gdir)
             mb_calibration_from_scalar_mb(gdir,
+                                          settings_filesuffix='_extreme_large',
                                           ref_mb=ref_mb,
                                           ref_mb_period=ref_period,
                                           calibrate_param1='prcp_fac')
@@ -1691,6 +1721,7 @@ class TestClimate(unittest.TestCase):
         with pytest.raises(RuntimeError):
             reset_observation_file(gdir)
             mb_calibration_from_scalar_mb(gdir,
+                                          settings_filesuffix='_extreme_large',
                                           ref_mb=ref_mb,
                                           ref_mb_period=ref_period,
                                           calibrate_param1='prcp_fac',
@@ -1698,13 +1729,15 @@ class TestClimate(unittest.TestCase):
 
         reset_observation_file(gdir)
         mb_calibration_from_scalar_mb(gdir,
+                                      settings_filesuffix='_extreme_large',
                                       ref_mb=ref_mb,
                                       ref_mb_period=ref_period,
                                       calibrate_param1='prcp_fac',
                                       calibrate_param2='temp_bias',
                                       calibrate_param3='melt_f')
 
-        mb_new = massbalance.MonthlyTIModel(gdir)
+        mb_new = massbalance.MonthlyTIModel(gdir,
+                                            settings_filesuffix='_extreme_large')
         mbdf['melt_mb3'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
 
         # Check that results are all the same
@@ -1713,23 +1746,35 @@ class TestClimate(unittest.TestCase):
         np.testing.assert_allclose(1, mbdf[['ref_mb', 'melt_mb3']].corr(),
                                    atol=0.5)
 
-        pdf = gdir.read_yml('settings')
-        assert pdf['temp_bias'] == gdir.settings['temp_bias_min']
+        pdf = gdir.read_settings(['temp_bias', 'melt_f', 'prcp_fac',
+                                  'temp_bias_min', 'prcp_fac_max'],
+                                 filesuffix='_extreme_large')
+        assert pdf['temp_bias'] == pdf['temp_bias_min']
         assert pdf['melt_f'] < cfg.PARAMS['melt_f']
-        assert pdf['prcp_fac'] == gdir.settings['prcp_fac_max']
+        assert pdf['prcp_fac'] == pdf['prcp_fac_max']
 
         # Test perturbate
-        massbalance.perturbate_mb_params(gdir, perturbation={'temp_bias': -1,
-                                                             'prcp_fac': 2})
-        pdf = gdir.read_yml('settings')
-        assert pdf['temp_bias'] == gdir.settings['temp_bias_min'] - 1
-        assert pdf['prcp_fac'] == gdir.settings['prcp_fac_max'] * 2
+        output_filesuffix = '_perturbed'
+        massbalance.perturbate_mb_params(gdir, input_filesuffix='_extreme_large',
+                                         perturbation={'temp_bias': -1,
+                                                       'prcp_fac': 2},
+                                         output_filesuffix=output_filesuffix)
+        pdf_in = gdir.read_settings(['temp_bias', 'prcp_fac'],
+                                    filesuffix='_extreme_large')
+        pdf_out = gdir.read_settings(['temp_bias', 'prcp_fac'],
+                                     filesuffix=output_filesuffix)
+        assert pdf_out['temp_bias'] == pdf_in['temp_bias'] - 1
+        assert pdf_out['prcp_fac'] == pdf_in['prcp_fac'] * 2
 
-        massbalance.perturbate_mb_params(gdir, reset_default=True)
-        pdf = gdir.read_yml('settings')
-        assert pdf['temp_bias'] == gdir.settings['temp_bias_min']
-        assert pdf['melt_f'] < cfg.PARAMS['melt_f']
-        assert pdf['prcp_fac'] == gdir.settings['prcp_fac_max']
+        massbalance.perturbate_mb_params(gdir, input_filesuffix=output_filesuffix,
+                                         reset_default=True,
+                                         output_filesuffix=output_filesuffix)
+
+        pdf_out = gdir.read_settings(['temp_bias', 'melt_f', 'prcp_fac'],
+                                     filesuffix=output_filesuffix)
+        assert pdf_out['temp_bias'] == pdf_in['temp_bias']
+        assert pdf_out['melt_f'] < cfg.PARAMS['melt_f']
+        assert pdf_out['prcp_fac'] == pdf_in['prcp_fac']
 
         # Test custom ref_mb_period, e.g. useful for using hydro years
 
@@ -1861,12 +1906,16 @@ class TestClimate(unittest.TestCase):
                                       ref_mb_period=ref_period,
                                       use_2d_mb=True)
         mb_calib_2d = gdir.read_yml('settings')
-        # the calibration results for the melt factor should be close to each other (+/- 5% are tolerated)
-        np.testing.assert_allclose(mb_calib_2d['melt_f'], mb_calib_1d['melt_f'], rtol=0.05)
+        # the calibration results for the melt factor should be close to each
+        # other (+/- 5% are tolerated)
+        np.testing.assert_allclose(mb_calib_2d['melt_f'],
+                                   mb_calib_1d['melt_f'], rtol=0.05)
 
+    @pytest.mark.slow
     def test_mb_calibration_to_rmsd(self):
 
-        from oggm.core.massbalance import mb_calibration_to_rmsd, mb_calibration_from_scalar_mb
+        from oggm.core.massbalance import (mb_calibration_to_rmsd,
+                                           mb_calibration_from_scalar_mb)
         from functools import partial
 
         mb_calibration_to_rmsd = partial(mb_calibration_to_rmsd,
@@ -1888,74 +1937,93 @@ class TestClimate(unittest.TestCase):
 
         # Firstly, calibrate just the melt_f
         # Default is to calibrate melt_f
-        mb_calibration_to_rmsd(gdir, ref_df=ref_mb)
+        mb_calibration_to_rmsd(gdir, settings_filesuffix='_default_rmsd',
+                               ref_df=ref_mb)
 
         h, w = gdir.get_inversion_flowline_hw()
-        mb_new = massbalance.MonthlyTIModel(gdir)
+        mb_new = massbalance.MonthlyTIModel(gdir,
+                                            settings_filesuffix='_default_rmsd')
         mbdf['melt_mb_rmsd'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
 
         # Calibrate just prcp_fac
         mb_calibration_to_rmsd(gdir,
+                               settings_filesuffix='_pf_rmsd',
                                ref_df=ref_mb,
                                calibrate_params=('prcp_fac',))
 
         h, w = gdir.get_inversion_flowline_hw()
-        mb_new = massbalance.MonthlyTIModel(gdir)
+        mb_new = massbalance.MonthlyTIModel(gdir,
+                                            settings_filesuffix='_pf_rmsd')
         mbdf['prcp_fac_mb_rmsd'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
 
         # Calibrate just temp_bias
         mb_calibration_to_rmsd(gdir,
+                               settings_filesuffix='_tb_rmsd',
                                ref_df=ref_mb,
                                calibrate_params=('temp_bias',))
 
         h, w = gdir.get_inversion_flowline_hw()
-        mb_new = massbalance.MonthlyTIModel(gdir)
+        mb_new = massbalance.MonthlyTIModel(gdir,
+                                            settings_filesuffix='_tb_rmsd')
         mbdf['temp_bias_mb_rmsd'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
 
         # Calibrate melt_f and prcp_fac
         mb_calibration_to_rmsd(gdir,
+                               settings_filesuffix='_melt_pr_rmsd',
                                ref_df=ref_mb,
                                calibrate_params=('melt_f', 'prcp_fac',))
 
         h, w = gdir.get_inversion_flowline_hw()
-        mb_new = massbalance.MonthlyTIModel(gdir)
+        mb_new = massbalance.MonthlyTIModel(gdir,
+                                            settings_filesuffix='_melt_pr_rmsd')
         mbdf['mf_pf_mb_rmsd'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
 
         # Calibrate melt_f and temp_bias
         mb_calibration_to_rmsd(gdir,
+                               settings_filesuffix='_melt_tp_rmsd',
                                ref_df=ref_mb,
                                calibrate_params=('melt_f', 'temp_bias',))
 
         h, w = gdir.get_inversion_flowline_hw()
-        mb_new = massbalance.MonthlyTIModel(gdir)
+        mb_new = massbalance.MonthlyTIModel(gdir,
+                                            settings_filesuffix='_melt_tp_rmsd')
         mbdf['mf_tb_mb_rmsd'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
 
         # Calibrate prcp_fac and temp_bias
         mb_calibration_to_rmsd(gdir,
+                               settings_filesuffix='_pr_tp_rmsd',
                                ref_df=ref_mb,
                                calibrate_params=('prcp_fac', 'temp_bias',))
 
         h, w = gdir.get_inversion_flowline_hw()
-        mb_new = massbalance.MonthlyTIModel(gdir)
+        mb_new = massbalance.MonthlyTIModel(gdir,
+                                            settings_filesuffix='_pr_tp_rmsd')
         mbdf['pf_tb_mb_rmsd'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
 
         # Calibrate all parameters together
         mb_calibration_to_rmsd(gdir,
+                               settings_filesuffix='_all_rmsd',
                                ref_df=ref_mb,
-                               calibrate_params=('melt_f', 'prcp_fac', 'temp_bias',))
+                               calibrate_params=('melt_f', 'prcp_fac',
+                                                 'temp_bias',))
 
         h, w = gdir.get_inversion_flowline_hw()
-        mb_new = massbalance.MonthlyTIModel(gdir)
+        mb_new = massbalance.MonthlyTIModel(gdir,
+                                            settings_filesuffix='_all_rmsd')
         mbdf['all_mb_rmsd'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
 
-        # Now check if the parameters are within the expected bounds, this can be done with our last run of calibration with rmsd
-        pdf = gdir.read_json('mb_calib')
+        # Now check if the parameters are within the expected bounds, this can
+        # be done with our last run of calibration with rmsd
+        pdf = gdir.read_settings(['temp_bias', 'melt_f', 'prcp_fac'],
+                                 filesuffix='_all_rmsd')
         assert cfg.PARAMS['melt_f_min'] <= pdf['melt_f'] <= cfg.PARAMS['melt_f_max']
         assert cfg.PARAMS['prcp_fac_min'] <= pdf['prcp_fac'] <= cfg.PARAMS['prcp_fac_max']
         assert cfg.PARAMS['temp_bias_min'] <= pdf['temp_bias'] <= cfg.PARAMS['temp_bias_max']
 
-        # Check that the mean mass balance results are all similar to the observed - TODO: What is classed as "similar" here?
-        # We are minimising the RMSD here, so the mean will not match exactly, but should be relatively close
+        # Check that the mean mass balance results are all similar to the
+        # observed - TODO: What is classed as "similar" here?
+        # We are minimising the RMSD here, so the mean will not match exactly,
+        # but should be relatively close
         np.testing.assert_allclose(ref_mb.mean(), mbdf['melt_mb_rmsd'].mean(), atol=100)
         np.testing.assert_allclose(ref_mb.mean(), mbdf['prcp_fac_mb_rmsd'].mean(), atol=100)
         np.testing.assert_allclose(ref_mb.mean(), mbdf['temp_bias_mb_rmsd'].mean(), atol=100)
@@ -1995,41 +2063,51 @@ class TestClimate(unittest.TestCase):
         ref_mb = mbdf.ANNUAL_BALANCE
         ref_period = f'{mbdf.index[0]}-01-01_{mbdf.index[-1] + 1}-01-01'
 
-        # Now calibrate to just the prcp_fac
+        # Now calibrate to just the melt_f
         mb_calibration_from_scalar_mb(gdir,
+                                      settings_filesuffix='_melt_scalar',
                                       ref_mb=ref_mb.mean(),
-                                      ref_period=ref_period)
+                                      ref_mb_period=ref_period)
         h, w = gdir.get_inversion_flowline_hw()
-        mb_new = massbalance.MonthlyTIModel(gdir)
+        mb_new = massbalance.MonthlyTIModel(gdir,
+                                            settings_filesuffix='_melt_scalar')
         mbdf['melt_mb_scalar'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
 
         # Default is to calibrate prcp_fac
         mb_calibration_from_scalar_mb(gdir,
+                                      settings_filesuffix='_pr_scalar',
                                       ref_mb=ref_mb.mean(),
-                                      ref_period=ref_period,
+                                      ref_mb_period=ref_period,
                                       calibrate_param1='prcp_fac')
 
         h, w = gdir.get_inversion_flowline_hw()
-        mb_new = massbalance.MonthlyTIModel(gdir)
+        mb_new = massbalance.MonthlyTIModel(gdir,
+                                            settings_filesuffix='_pr_scalar')
         mbdf['prcp_fac_mb_scalar'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
 
         # Default is to calibrate temp_bias
         mb_calibration_from_scalar_mb(gdir,
+                                      settings_filesuffix='_tp_scalar',
                                       ref_mb=ref_mb.mean(),
-                                      ref_period=ref_period,
+                                      ref_mb_period=ref_period,
                                       calibrate_param1='temp_bias')
 
         h, w = gdir.get_inversion_flowline_hw()
-        mb_new = massbalance.MonthlyTIModel(gdir)
+        mb_new = massbalance.MonthlyTIModel(gdir,
+                                            settings_filesuffix='_tp_scalar')
         mbdf['temp_bias_mb_scalar'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
 
-        # Since we are now calibrating to rmsd rather than the mean, let's check that the RMSD has been reduced between the
-        # RMSD calibration technique vs the scalar calibration technique
+        # Since we are now calibrating to rmsd rather than the mean, let's check
+        # that the RMSD has been reduced between the RMSD calibration technique
+        # vs the scalar calibration technique
 
-        # Unless the calibration for one parameter fails (which it wont in this case), for scalar it is equivalent
-        # to just test this to having one parameter calibrated, since it will only ever calibrate one parameter at a time
+        # Unless the calibration for one parameter fails (which it wont in this
+        # case), for scalar it is equivalent to just test this to having one
+        # parameter calibrated, since it will only ever calibrate one parameter
+        # at a time
 
-        # Check that RMSD has been reduced for calibrating melt_f, compare to scalar for when melt_f is calibrated
+        # Check that RMSD has been reduced for calibrating melt_f, compare to
+        # scalar for when melt_f is calibrated
         # Just melt_f
         np.testing.assert_array_less(utils.rmsd(mbdf['melt_mb_rmsd'], mbdf['ref_mb']),
                                      utils.rmsd(mbdf['melt_mb_scalar'], mbdf['ref_mb']))
@@ -2060,72 +2138,88 @@ class TestClimate(unittest.TestCase):
         np.testing.assert_array_less(utils.rmsd(mbdf['temp_bias_mb_rmsd'], mbdf['ref_mb']),
                                      utils.rmsd(mbdf['temp_bias_mb_scalar'], mbdf['ref_mb']))
 
-
-        # Now check that the order of parameters added into the  calibration does not affact the result
+        # Now check that the order of parameters added into the  calibration
+        # does not affact the result
 
         # Calibrate with parameters inserted in all possible permutations
         # mf, pf, tb
-        mb_calibration_to_rmsd(gdir, ref_df=ref_mb,
+        mb_calibration_to_rmsd(gdir,
+                               settings_filesuffix='_mf_pf_tb',
+                               ref_df=ref_mb,
                                calibrate_params=('melt_f', 'prcp_fac', 'temp_bias'),)
 
         h, w = gdir.get_inversion_flowline_hw()
-        mb_new = massbalance.MonthlyTIModel(gdir)
+        mb_new = massbalance.MonthlyTIModel(gdir,
+                                            settings_filesuffix='_mf_pf_tb')
         mbdf['perm1'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
 
         # mf, tb, pf
         mb_calibration_to_rmsd(gdir,
+                               settings_filesuffix='_mf_tb_pf',
                                ref_df=ref_mb,
                                calibrate_params=('melt_f', 'temp_bias', 'prcp_fac',))
 
         h, w = gdir.get_inversion_flowline_hw()
-        mb_new = massbalance.MonthlyTIModel(gdir)
+        mb_new = massbalance.MonthlyTIModel(gdir,
+                                            settings_filesuffix='_mf_tb_pf')
         mbdf['perm2'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
 
         # pf, mf, tb
         mb_calibration_to_rmsd(gdir,
+                               settings_filesuffix='_pf_mf_tb',
                                ref_df=ref_mb,
                                calibrate_params=('prcp_fac', 'melt_f', 'temp_bias',))
 
         h, w = gdir.get_inversion_flowline_hw()
-        mb_new = massbalance.MonthlyTIModel(gdir)
+        mb_new = massbalance.MonthlyTIModel(gdir,
+                                            settings_filesuffix='_pf_mf_tb')
         mbdf['perm3'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
 
         # pf, tb, mf
         mb_calibration_to_rmsd(gdir,
+                               settings_filesuffix='_pf_tb_mf',
                                ref_df=ref_mb,
                                calibrate_params=('prcp_fac', 'temp_bias', 'melt_f',))
 
         h, w = gdir.get_inversion_flowline_hw()
-        mb_new = massbalance.MonthlyTIModel(gdir)
+        mb_new = massbalance.MonthlyTIModel(gdir,
+                                            settings_filesuffix='_pf_tb_mf')
         mbdf['perm4'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
 
         # tb, mf, pf
         mb_calibration_to_rmsd(gdir,
+                               settings_filesuffix='_tb_mf_pf',
                                ref_df=ref_mb,
                                calibrate_params=('temp_bias', 'melt_f', 'prcp_fac',))
 
         h, w = gdir.get_inversion_flowline_hw()
-        mb_new = massbalance.MonthlyTIModel(gdir)
+        mb_new = massbalance.MonthlyTIModel(gdir,
+                                            settings_filesuffix='_tb_mf_pf')
         mbdf['perm5'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
 
         # tb, pf, mf
         mb_calibration_to_rmsd(gdir,
+                               settings_filesuffix='_tb_pf_mf',
                                ref_df=ref_mb,
                                calibrate_params=('temp_bias', 'prcp_fac', 'melt_f',))
 
         h, w = gdir.get_inversion_flowline_hw()
-        mb_new = massbalance.MonthlyTIModel(gdir)
+        mb_new = massbalance.MonthlyTIModel(gdir,
+                                            settings_filesuffix='_tb_pf_mf')
         mbdf['perm6'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
 
-        # Check that all permutations of parameters gather the same results for differential evolution
-        # Differential evolution is stochastic and so may differ slighly (hence atol=0.1 here, to allow for 5%)
+        # Check that all permutations of parameters gather the same results for
+        # differential evolution
+        # Differential evolution is stochastic and so may differ slighly (hence
+        # atol=0.1 here, to allow for 5%)
         np.testing.assert_allclose(mbdf['perm1'].values, mbdf['perm2'].values, atol=0.1)
         np.testing.assert_allclose(mbdf['perm2'].values, mbdf['perm3'].values, atol=0.1)
         np.testing.assert_allclose(mbdf['perm3'].values, mbdf['perm4'].values, atol=0.1)
         np.testing.assert_allclose(mbdf['perm4'].values, mbdf['perm5'].values, atol=0.1)
         np.testing.assert_allclose(mbdf['perm5'].values, mbdf['perm6'].values, atol=0.1)
 
-        # Now check what happens when we input unrealistic values, lets make an invalid boundary condition
+        # Now check what happens when we input unrealistic values, lets make an
+        # invalid boundary condition
         # This will force differential evolution to fail
 
         with pytest.raises(RuntimeError):
@@ -2149,7 +2243,7 @@ class TestClimate(unittest.TestCase):
                                    temp_bias_min=-np.inf,
                                    temp_bias_max=np.inf, )
 
-        # Test for an acceptibly small bias
+        # Test for an acceptably small bias
         np.testing.assert_allclose(0, (mbdf['melt_mb_rmsd'] - mbdf['ref_mb']).mean(), atol=100)
         np.testing.assert_allclose(0, (mbdf['prcp_fac_mb_rmsd'] - mbdf['ref_mb']).mean(), atol=100)
         np.testing.assert_allclose(0, (mbdf['temp_bias_mb_rmsd'] - mbdf['ref_mb']).mean(), atol=100)
@@ -2469,18 +2563,18 @@ class TestInversion(unittest.TestCase):
         df = pd.read_hdf(utils.get_demo_file('rgi62_itmix_df.h5'))
 
         # Works with Series
-        out = workflow.calibrate_inversion_from_volume(gdir,
-                                                       vol_ref_m3=df['vol_itmix_m3'])
-
         df = df.loc[gdir.rgi_id]
+        out = workflow.calibrate_inversion_from_volume_entity_task(
+            gdir, ref_volume_m3=df['vol_itmix_m3'])
+
         np.testing.assert_allclose(df.vol_itmix_m3,
                                    out['vol_oggm_m3'],
                                    rtol=0.01)
         assert out['fs'] == 0
 
         # Works with float
-        out = workflow.calibrate_inversion_from_volume(gdir,
-                                                       vol_ref_m3=df.vol_itmix_m3)
+        out = workflow.calibrate_inversion_from_volume_entity_task(
+            gdir, ref_volume_m3=df.vol_itmix_m3)
 
         np.testing.assert_allclose(df.vol_itmix_m3,
                                    out['vol_oggm_m3'],
@@ -2490,10 +2584,10 @@ class TestInversion(unittest.TestCase):
         # test user provided volume is working
         delta_volume_m3 = 100000000
         user_provided_volume_m3 = df.vol_itmix_m3 - delta_volume_m3
-        out = workflow.calibrate_inversion_from_volume(
+        out = workflow.calibrate_inversion_from_volume_entity_task(
               gdir,
               apply_fs_on_mismatch=True,
-              vol_ref_m3=user_provided_volume_m3)
+              ref_volume_m3=user_provided_volume_m3)
         np.testing.assert_allclose(user_provided_volume_m3,
                                    out['vol_oggm_m3'],
                                    rtol=0.01)

--- a/oggm/tests/test_shop.py
+++ b/oggm/tests/test_shop.py
@@ -335,7 +335,7 @@ class Test_w5e5:
             # (also ISIMIP3b) and all glaciers in this notebook:
             # https://nbviewer.org/urls/cluster.klima.uni-bremen.de/~oggm/
             # climate/notebooks/flatten_glacier_gridpoint_tests.ipynb
-            if d == ['GSWP3_W5E5', 'GSWP3_W5E5_daily']:
+            if d in ['GSWP3_W5E5', 'GSWP3_W5E5_daily']:
                 res = 0.5
                 with xr.open_dataset(w5e5.get_gswp3_w5e5_file(d, 'inv')) as dinv:
                     dinv = dinv.load()

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -185,8 +185,8 @@ class TestFuncs(object):
             utils.float_years_timeseries(1)
 
         # test daily timeseries
-        time = pd.date_range('1/1/1800', periods=365.25 * 299, freq='D')
         myr = utils.float_years_timeseries(1800, 2099, daily=True)
+        time = pd.date_range('1/1/1800', periods=len(myr), freq='D')
         y, m, d = utils.floatyear_to_date(myr, return_day=True)
         np.testing.assert_array_equal(y, time.year)
         np.testing.assert_array_equal(m, time.month)

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -122,6 +122,16 @@ class TestFuncs(object):
         assert m == 2
         assert d == 29
 
+        # test correct floor behaviour, this is very close to 1981.09.01
+        y, m, d = utils.floatyear_to_date(1981.6657534246575, return_day=True)
+        assert y == 1981
+        assert m == 8
+        assert d == 31
+        y, m, d = utils.floatyear_to_date(1981.6657534246576, return_day=True)
+        assert y == 1981
+        assert m == 9
+        assert d == 1
+
     def test_date_to_floatyear(self):
 
         r = utils.date_to_floatyear(0, 1)
@@ -236,6 +246,62 @@ class TestFuncs(object):
 
         ok = (years == y2) & (months == m2) & (days == d2)
         assert sum(~ok) == 0
+
+    def test_get_time_functions(self):
+        """Test scalar and array behavior of get_{days,seconds}_of_{year,month}."""
+        from oggm.utils._funcs import (get_days_of_year, get_seconds_of_year,
+                                       get_days_of_month, get_seconds_of_month)
+
+        # --- scalar input must return int ---
+        # no-leap: always 365
+        assert get_days_of_year(1980.0) == 365
+        assert isinstance(get_days_of_year(1980.0), int)
+        # leap-year aware: 1980 and 1984 are leap, 1981–1983 are not
+        assert get_days_of_year(1980.0, use_leap_years=True) == 366
+        assert isinstance(get_days_of_year(1980.0, use_leap_years=True), int)
+        assert get_days_of_year(1981.0, use_leap_years=True) == 365
+        assert get_days_of_year(1984.0, use_leap_years=True) == 366
+
+        assert get_seconds_of_year(1980.0) == 365 * 86400
+        assert get_seconds_of_year(1980.0, use_leap_years=True) == 366 * 86400
+        assert get_seconds_of_year(1981.0, use_leap_years=True) == 365 * 86400
+
+        # February: 29 days in a leap year, 28 otherwise
+        feb_1980 = utils.date_to_floatyear(1980, 2)
+        feb_1981 = utils.date_to_floatyear(1981, 2)
+        assert get_days_of_month(feb_1980, use_leap_years=True) == 29
+        assert get_days_of_month(feb_1981, use_leap_years=True) == 28
+        assert get_days_of_month(feb_1980, use_leap_years=False) == 28
+        assert isinstance(get_days_of_month(feb_1980, use_leap_years=True), int)
+
+        assert get_seconds_of_month(feb_1980, use_leap_years=True) == 29 * 86400
+        assert get_seconds_of_month(feb_1981, use_leap_years=True) == 28 * 86400
+
+        # --- array input must return np.ndarray of int64 ---
+        years = np.array([1980., 1981., 1982., 1983., 1984.])
+
+        days = get_days_of_year(years, use_leap_years=True)
+        assert isinstance(days, np.ndarray)
+        np.testing.assert_array_equal(days, [366, 365, 365, 365, 366])
+
+        secs = get_seconds_of_year(years, use_leap_years=True)
+        assert isinstance(secs, np.ndarray)
+        np.testing.assert_array_equal(secs, days * 86400)
+
+        # no-leap array: all 365
+        days_noleap = get_days_of_year(years, use_leap_years=False)
+        assert isinstance(days_noleap, np.ndarray)
+        np.testing.assert_array_equal(days_noleap, np.full(5, 365))
+
+        # monthly array for 1980 (leap year): February must have 29 days
+        monthly = utils.float_years_timeseries(1980., 1981.)
+        days_per_month = get_days_of_month(monthly, use_leap_years=True)
+        assert isinstance(days_per_month, np.ndarray)
+        _, m = utils.floatyear_to_date(monthly)
+        np.testing.assert_array_equal(days_per_month[m == 2], [29])
+
+        secs_per_month = get_seconds_of_month(monthly, use_leap_years=True)
+        np.testing.assert_array_equal(secs_per_month, days_per_month * 86400)
 
     @pytest.mark.parametrize("d,w", [
         (np.arange(10), np.arange(10)),
@@ -812,7 +878,7 @@ class TestWorkflowUtils:
                              'snowfall_off_glacier', 'snowfall_on_glacier',
                              'melt_residual_off_glacier',
                              'melt_residual_on_glacier', 'model_mb',
-                             'residual_mb', 'snow_bucket']
+                             'residual_mb', 'snow_bucket', 'mass']
         for gi in range(10):
             allowed_data_vars += [f'terminus_thick_{gi}']
 
@@ -860,6 +926,7 @@ class TestWorkflowUtils:
                 ds.loc[{'rgi_id': gdirs[0].rgi_id}]['melt_on_glacier'].values))
             assert np.all(np.isnan(
                 ds.loc[{'rgi_id': gdirs[0].rgi_id}]['melt_on_glacier_monthly'].values))
+            assert 'mass_kg' in ds.data_vars
 
         check_result(ds_1)
 

--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -637,8 +637,7 @@ class TestGdirSettings:
         rgi_ids = ['RGI60-11.00897']
         gdirs = workflow.init_glacier_directories(
             rgi_ids, from_prepro_level=3, prepro_border=160,
-            prepro_base_url='https://cluster.klima.uni-bremen.de/~oggm/gdirs/'
-                            'oggm_v1.6/L3-L5_files/2023.1/elev_bands/W5E5/')
+            prepro_base_url=oggm.DEFAULT_BASE_URL)
         gdir = gdirs[0]
         mb_calib_cluster = gdirs[0].read_json('mb_calib')
 
@@ -655,6 +654,7 @@ class TestGdirSettings:
         settings_informed_threestep['use_temp_bias_from_file'] = True
         settings_informed_threestep['use_winter_prcp_fac'] = True
         settings_informed_threestep['baseline_climate'] = 'W5E5'
+        settings_informed_threestep['prcp_fac'] = None
 
         workflow.execute_entity_task(tasks.mb_calibration_from_hugonnet_mb,
                                      gdirs,
@@ -675,13 +675,17 @@ class TestGdirSettings:
                         atol=1e-3)
 
         # recalibration without overwrite_gdir should raise an error
+        prcp_fac_original = settings_informed_threestep['prcp_fac']
         with pytest.raises(InvalidWorkflowError):
+            settings_informed_threestep['prcp_fac'] = None
             workflow.execute_entity_task(tasks.mb_calibration_from_hugonnet_mb,
                                          gdirs,
                                          overwrite_gdir=False,
                                          informed_threestep=True,
                                          settings_filesuffix='_informed_threestep',
                                          )
+
+        settings_informed_threestep['prcp_fac'] = prcp_fac_original
 
         # test MassBalance settings during dynamic run
         custom_settings = ModelSettings(gdir,
@@ -937,8 +941,7 @@ class TestGdirObservations:
         rgi_ids = ['RGI60-11.00897']
         gdirs = workflow.init_glacier_directories(
             rgi_ids, from_prepro_level=3, prepro_border=160,
-            prepro_base_url='https://cluster.klima.uni-bremen.de/~oggm/gdirs/'
-                            'oggm_v1.6/L3-L5_files/2023.1/elev_bands/W5E5/')
+            prepro_base_url=oggm.DEFAULT_BASE_URL)
         gdir = gdirs[0]
         mb_calib_cluster = gdirs[0].read_json('mb_calib')
 
@@ -947,6 +950,7 @@ class TestGdirObservations:
         settings_informed_threestep['use_temp_bias_from_file'] = True
         settings_informed_threestep['use_winter_prcp_fac'] = True
         settings_informed_threestep['baseline_climate'] = 'W5E5'
+        settings_informed_threestep['prcp_fac'] = None
         assert 'ref_mb' not in gdir.observations
         workflow.execute_entity_task(tasks.mb_calibration_from_hugonnet_mb,
                                      gdirs,
@@ -976,6 +980,7 @@ class TestGdirObservations:
                                      hugonnet_adapted['err'] / 2)
         gdir.observations_filesuffix = '_hugonnet_adapted'
         gdir.observations['ref_mb'] = hugonnet_adapted
+        settings_informed_threestep['prcp_fac'] = None
         workflow.execute_entity_task(tasks.mb_calibration_from_hugonnet_mb,
                                      gdirs,
                                      overwrite_gdir=True,

--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -751,8 +751,7 @@ class TestGdirSettings:
         rgi_ids = ['RGI60-11.00897']
         gdirs = workflow.init_glacier_directories(
             rgi_ids, from_prepro_level=3, prepro_border=160,
-            prepro_base_url='https://cluster.klima.uni-bremen.de/~oggm/gdirs/'
-                            'oggm_v1.6/L3-L5_files/2023.1/elev_bands/W5E5/')
+            prepro_base_url=oggm.DEFAULT_BASE_URL)
         gdir = gdirs[0]
 
         # create a test settings file with a larger glen a parameter
@@ -823,8 +822,7 @@ class TestGdirSettings:
         rgi_ids = ['RGI60-11.00897']
         gdirs = workflow.init_glacier_directories(
             rgi_ids, from_prepro_level=3, prepro_border=160,
-            prepro_base_url='https://cluster.klima.uni-bremen.de/~oggm/gdirs/'
-                            'oggm_v1.6/L3-L5_files/2023.1/elev_bands/W5E5/')
+            prepro_base_url=oggm.DEFAULT_BASE_URL)
         gdir = gdirs[0]
 
         # for reference, perform an inversion with default paramters

--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import unittest
+from packaging.version import Version
 import pickle
 import pytest
 import json
@@ -632,6 +633,8 @@ def with_class_wd(request, test_dir, hef_gdir):
 @pytest.mark.usefixtures('with_class_wd')
 class TestGdirSettings:
 
+    @pytest.mark.skipif((Version(np.__version__) < Version('2.0')),
+                        reason='requires NumPy >= 2.0')
     @pytest.mark.slow
     def test_settings_massbalance(self):
         rgi_ids = ['RGI60-11.00897']
@@ -746,6 +749,8 @@ class TestGdirSettings:
         # Now it should be W5E5
         assert gdir.get_climate_info()['baseline_climate_source'] == 'ERA5'
 
+    @pytest.mark.skipif((Version(np.__version__) < Version('2.0')),
+                        reason='requires NumPy >= 2.0')
     @pytest.mark.slow
     def test_settings_dynamics(self):
         rgi_ids = ['RGI60-11.00897']
@@ -817,6 +822,8 @@ class TestGdirSettings:
 
         assert np.all(ds_orig_thick.length >= ds_larger_thick.length)
 
+    @pytest.mark.skipif((Version(np.__version__) < Version('2.0')),
+                        reason='requires NumPy >= 2.0')
     @pytest.mark.slow
     def test_settings_inversion(self):
         rgi_ids = ['RGI60-11.00897']
@@ -934,6 +941,8 @@ class TestGdirSettings:
 @pytest.mark.usefixtures('with_class_wd')
 class TestGdirObservations:
 
+    @pytest.mark.skipif((Version(np.__version__) < Version('2.0')),
+                        reason='requires NumPy >= 2.0')
     @pytest.mark.slow
     def test_observations_ref_mb(self):
         rgi_ids = ['RGI60-11.00897']

--- a/oggm/utils/_funcs.py
+++ b/oggm/utils/_funcs.py
@@ -66,6 +66,10 @@ _BASE_CUM_START = np.array([0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304,
                             334], dtype=np.int64)
 _BASE_CUM_END = np.array([31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334,
                           365], dtype=np.int64)
+_DAYS_IN_MONTH_NOLEAP = np.array([31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
+                                  dtype=np.int64)
+_DAYS_IN_MONTH_LEAP = np.array([31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
+                                dtype=np.int64)
 
 
 def parse_rgi_meta(version=None):
@@ -806,6 +810,14 @@ def floatyear_to_date(yr, return_day=False):
     x = f * N.astype(np.float64)
     doy_minus1 = np.rint(x).astype(np.int64)
     doy_minus1 = np.clip(doy_minus1, 0, N - 1)
+
+    # Ensure the candidate date does not exceed yr. np.rint can round up, making
+    # y + doy_minus1/N > yr. When that happens, step back one day.
+    candidate_fy = y.astype(np.float64) + doy_minus1.astype(np.float64) / N.astype(np.float64)
+    too_far = candidate_fy > yr
+    doy_minus1 = np.where(too_far, doy_minus1 - 1, doy_minus1)
+    doy_minus1 = np.clip(doy_minus1, 0, N - 1)
+
     doy = doy_minus1 + 1
 
     adj = doy - (leap & (doy > 59)).astype(np.int64)  # collapse leap past Feb
@@ -994,90 +1006,100 @@ def hydrodate_to_calendardate_cftime(
     return dates
 
 
-def get_days_of_year(year: float, use_leap_years: bool = False) -> int:
+def get_days_of_year(year, use_leap_years: bool = False):
     """Get the number of days of a given year.
 
     Parameters
     ----------
-    year : float or int
-        Year in floating year convention.
+    year : float or array_like
+        Year(s) in floating year convention.
     use_leap_years : bool
         Define if leap years should be returned.
 
     Returns
     -------
-    int
-        The number of days of a given year.
+    int or np.ndarray
+        The number of days of the given year(s). Returns a scalar int when
+        ``year`` is scalar, and an ``np.ndarray`` of int64 when it is array_like.
     """
-    if use_leap_years:
-        # use floatyear_to_date to avoid floating point mistakes (e.g. 1999.9999999)
-        yr_int = floatyear_to_date(year)[0]
-        return 366 if calendar.isleap(yr_int) else 365
-    else:
-        return 365
+    scalar = np.ndim(year) == 0
+    if not use_leap_years:
+        return 365 if scalar else np.full(np.asarray(year).shape, 365, dtype=np.int64)
+    yr_int = floatyear_to_date(np.asarray(year, dtype=np.float64))[0]
+    result = np.where(_is_leap_year_vec(yr_int), 366, 365).astype(np.int64)
+    return int(result) if scalar else result
 
 
-def get_seconds_of_year(year: float = None, use_leap_years: bool = False) -> int:
+def get_seconds_of_year(year=None, use_leap_years: bool = False):
     """Get the number of seconds in a year.
 
     Parameters
     ----------
-    year : float or int
-        Year in floating year convention.
+    year : float or array_like
+        Year(s) in floating year convention.
     use_leap_years : bool
         Define if leap years should be returned.
 
     Returns
     -------
-    int
-        The number of seconds in a year.
+    int or np.ndarray
+        The number of seconds in the given year(s). Returns a scalar int when
+        ``year`` is scalar, and an ``np.ndarray`` of int64 when it is array_like.
     """
-    if use_leap_years:
-        return SEC_IN_DAY * get_days_of_year(year, use_leap_years=use_leap_years)
-    else:
-        return SEC_IN_YEAR
+    if not use_leap_years:
+        scalar = np.ndim(year) == 0
+        return SEC_IN_YEAR if scalar else np.full(np.asarray(year).shape,
+                                                   SEC_IN_YEAR, dtype=np.int64)
+    return SEC_IN_DAY * get_days_of_year(year, use_leap_years=True)
 
 
-def get_days_of_month(year: float = None, use_leap_years: bool = False) -> int:
+def get_days_of_month(year=None, use_leap_years: bool = False):
     """Get the number of days in a month.
 
     Parameters
     ----------
-    year : float or int
-        Year in floating year convention.
+    year : float or array_like
+        Year(s) in floating year convention (encodes both year and month).
     use_leap_years : bool
         Define if leap years should be returned.
 
     Returns
     -------
-    int
-        The number of days in the current month.
+    int or np.ndarray
+        The number of days in the month of the given year(s). Returns a scalar
+        int when ``year`` is scalar, and an ``np.ndarray`` of int64 when it is
+        array_like.
     """
-    yr, mth = floatyear_to_date(year)
+    scalar = np.ndim(year) == 0
+    yr_int, mth = floatyear_to_date(np.asarray(year, dtype=np.float64))
+    mth_idx = np.asarray(mth, dtype=np.int64) - 1  # 0-indexed
     if use_leap_years:
-        return calendar.monthrange(yr, mth)[1]
+        result = np.where(_is_leap_year_vec(yr_int),
+                          _DAYS_IN_MONTH_LEAP[mth_idx],
+                          _DAYS_IN_MONTH_NOLEAP[mth_idx]).astype(np.int64)
     else:
-        return {1: 31, 2: 28, 3: 31, 4: 30, 5: 31, 6: 30, 7: 31, 8: 31, 9: 30,
-                10: 31, 11: 30, 12: 31}[mth]
+        result = _DAYS_IN_MONTH_NOLEAP[mth_idx]
+    return int(result) if scalar else result
 
 
-def get_seconds_of_month(year: float = None, use_leap_years: bool = False) -> int:
-    """Get the number of seconds in a year.
+def get_seconds_of_month(year=None, use_leap_years: bool = False):
+    """Get the number of seconds in a month.
 
     Parameters
     ----------
-    year : float or int
-        Year in floating year convention.
+    year : float or array_like
+        Year(s) in floating year convention (encodes both year and month).
     use_leap_years : bool
         Define if leap years should be returned.
 
     Returns
     -------
-    int
-        The number of seconds in the current month.
+    int or np.ndarray
+        The number of seconds in the month of the given year(s). Returns a
+        scalar int when ``year`` is scalar, and an ``np.ndarray`` of int64
+        when it is array_like.
     """
-    return SEC_IN_DAY * get_days_of_month(year=year,
-                                          use_leap_years=use_leap_years)
+    return SEC_IN_DAY * get_days_of_month(year=year, use_leap_years=use_leap_years)
 
 
 def float_years_timeseries(y0, y1=None, ny=None, include_last_year=False,

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -1155,7 +1155,9 @@ def compile_run_output(gdirs, path=True, input_filesuffix='',
                          # as it is a variable in gdirs v1.6 2023.1
                          'area_m2', 'area_m2_min_h', 'length_m', 'calving_m3',
                          'calving_rate_myr', 'off_area',
-                         'on_area', 'model_mb', 'is_fixed_geometry_spinup']
+                         'on_area', 'model_mb', 'is_fixed_geometry_spinup',
+                         'volume_ice_m3', 'volume_firn_m3', 'mass_kg',
+                         'mass_ice_kg', 'mass_firn_kg']
     for gi in range(10):
         allowed_data_vars += [f'terminus_thick_{gi}']
     # this hydro variables can be _monthly or _daily

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -4801,29 +4801,32 @@ class ModelSettings(YAMLFileObject):
         if key in self.data:
             return self.data[key]
 
-        if key in ['bias', 'melt_f', 'prcp_fac', 'temp_bias',
-                   'mb_global_params', 'baseline_climate_source']:
-            # this is for backwards compatibility when mb_calib files was used
-            try:
-                value = self.gdir.read_json('mb_calib')[key]
-                if self.add_default_values:
-                    self.set(key, value)
-                return value
-            except FileNotFoundError:
-                pass
+        # the following is for backwards compatibility
+        if self.data['parent_filesuffix'] == 'cfg.PARAMS':
+            if key in ['bias', 'melt_f', 'prcp_fac', 'temp_bias',
+                       'mb_global_params', 'baseline_climate_source']:
+                # this is for backwards compatibility when mb_calib files was used
+                try:
+                    value = self.gdir.read_json('mb_calib')[key]
+                    if self.add_default_values:
+                        self.set(key, value)
+                    return value
+                except FileNotFoundError:
+                    pass
 
-        if key in ['inversion_glen_a', 'inversion_fs', 'calving_water_level',
-                   ]:  # TODO: add calving variables
-            # this is for backwards compatibility when some parameters were
-            # stored in the diagnostics
-            try:
-                value = self.gdir.get_diagnostics()[key]
-                if self.add_default_values:
-                    self.set(key, value)
-                return value
-            except KeyError:
-                pass
+            if key in ['inversion_glen_a', 'inversion_fs', 'calving_water_level',
+                       ]:  # TODO: add calving variables
+                # this is for backwards compatibility when some parameters were
+                # stored in the diagnostics
+                try:
+                    value = self.gdir.get_diagnostics()[key]
+                    if self.add_default_values:
+                        self.set(key, value)
+                    return value
+                except KeyError:
+                    pass
 
+        # We try to get the parameter from the parent
         try:
             value = self.defaults[key]
             # optionally add key from defaults to the settings file

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -914,7 +914,7 @@ def invert_from_params(gdirs,
 
 
 @entity_task(log, writes=['inversion_output'])
-def calibrate_inversion_from_volume_entity_task(gdir, vol_ref_m3=None,
+def calibrate_inversion_from_volume_entity_task(gdir, ref_volume_m3=None,
                                                 fs=0, a_bounds=(0.1, 10),
                                                 apply_fs_on_mismatch=False,
                                                 error_on_mismatch=True,
@@ -930,7 +930,7 @@ def calibrate_inversion_from_volume_entity_task(gdir, vol_ref_m3=None,
     ----------
     gdir : :py:class:`oggm.GlacierDirectory`
         the glacier directory to process
-    vol_ref_m3 : float
+    ref_volume_m3 : float
         the reference volume in m3 to match. If float, take it,
         if pd.Series, select the glacier, if None, error.
     fs : float
@@ -953,12 +953,12 @@ def calibrate_inversion_from_volume_entity_task(gdir, vol_ref_m3=None,
     dict with the glacier volume and the calibrated parameters
     """
 
-    if vol_ref_m3 is None:
+    if ref_volume_m3 is None:
         raise InvalidParamsError('vol_ref_m3 must be provided (float or Series).')
 
-    if isinstance(vol_ref_m3, pd.Series):
+    if isinstance(ref_volume_m3, pd.Series):
         try:
-            vol_ref_m3 = vol_ref_m3.loc[gdir.rgi_id]
+            ref_volume_m3 = ref_volume_m3.loc[gdir.rgi_id]
         except KeyError:
             raise InvalidParamsError(f'vol_ref_m3 series has no entry '
                                      f'for {gdir.rgi_id}.')
@@ -983,7 +983,7 @@ def calibrate_inversion_from_volume_entity_task(gdir, vol_ref_m3=None,
         log.info(f'Volume calibration for {gdir.rgi_id} with '
                  f'A factor: {x} and fs: {fs}')
         vol = compute_vol(x)
-        return vol_ref_m3 - vol
+        return ref_volume_m3 - vol
 
     try:
         out_fac, r = optimization.brentq(to_minimize, *a_bounds,
@@ -1000,20 +1000,19 @@ def calibrate_inversion_from_volume_entity_task(gdir, vol_ref_m3=None,
         vol1 = compute_vol(a_bounds[0])
         vol2 = compute_vol(a_bounds[1])
         msg = (f'calibration from volume CAN\'T converge for {gdir.rgi_id} with fs={fs}.\n'
-               f'Bound values (m3):\nRef={vol_ref_m3:.0f} OGGM={vol1:.0f} for A factor {a_bounds[0]}\n'
-               f'Ref={vol_ref_m3:.0f} OGGM={vol2:.0f} for A factor {a_bounds[1]}')
-        if apply_fs_on_mismatch and fs == 0 and vol2 > vol_ref_m3:
-            return calibrate_inversion_from_volume(gdir,
-                                                   vol_ref_m3=vol_ref_m3,
-                                                   fs=5.7e-20, a_bounds=a_bounds,
-                                                   apply_fs_on_mismatch=False,
-                                                   error_on_mismatch=error_on_mismatch,
-                                                   filter_inversion_output=filter_inversion_output)
+               f'Bound values (m3):\nRef={ref_volume_m3:.0f} OGGM={vol1:.0f} for A factor {a_bounds[0]}\n'
+               f'Ref={ref_volume_m3:.0f} OGGM={vol2:.0f} for A factor {a_bounds[1]}')
+        if apply_fs_on_mismatch and fs == 0 and vol2 > ref_volume_m3:
+            return calibrate_inversion_from_volume_entity_task(
+                gdir, ref_volume_m3=ref_volume_m3,
+                fs=5.7e-20, a_bounds=a_bounds,
+                apply_fs_on_mismatch=False, error_on_mismatch=error_on_mismatch,
+                filter_inversion_output=filter_inversion_output)
         if error_on_mismatch:
             raise ValueError(msg)
 
-        out_fac = a_bounds[int(abs(vol_ref_m3 - vol1) >
-                               abs(vol_ref_m3 - vol2))]
+        out_fac = a_bounds[int(abs(ref_volume_m3 - vol1) >
+                               abs(ref_volume_m3 - vol2))]
         log.info(msg)
         log.info(f'We use A factor = {out_fac} and fs = {fs} and move on.')
 


### PR DESCRIPTION
In this PR I add support for `SfcTypeTIModel` and `DailyTIModel` within the dynamic module (no `run_with_hydro` included yet).

In particular, I adapted `FlowlineModel` to provide separate ice and firn outputs and to incorporate firn heights from `SfcTypeTIModel` in the elevation feedback of the mass-balance calculation (for this I added a very experimental firn densification model). Furthermore, I added an option in `run_from_climate_data` to store the final firn buckets of `SfcTypeTIModel` to a file, and to continue a run by loading the exact state from that file (useful for projection runs).

Here is a more detailed list of changes introduced in this PR:

- General changes:
  - renamed `rho` to `ice_density` everywhere to make it more explicit, now that `snow_density` is involved
  - added `mass` as a new potential diagnostic (especially interesting when incorporating firn output from `SfcTypeTIModel` with varying density)

- `SfcTypeModel`:
  - added experimental densification model: currently it assumes a linear relation between firn `melt_f` and `density`: both evolve following the same exponential function as described in Schuster et al. (2023). The fresh snow density is set to 300 kg m-3. **This is currently very experimental and not validated**.
  - with density we have new diagnostics `buckets_thickness_m` (for each bucket, useful for plotting density profiles for testing and validation later) and `columns_thickness_m` (the total thickness of all buckets of one column).
  - new kwarg `include_mb_model_heights` in `get_{annual,monthly,daily}_mb`: if `True`, we add the current bucket thickness on top of the provided heights to include the elevation feedback of the bucket heights as well
  - new methods `save_to_file` (saving the complete current state, including firn buckets) and `load_from_file` (returns an initialized `SfcTypeTIModel` at the same state as when it was saved). The same methods were also added to `MultipleFlowlineMassBalance` for supporting multiple flowlines. To save the actual state I introduced new `mb_diagnostics` files (if `MultipleFlowlineMassBalance` creates it, the dataset is organized with groups, similar to `fl_diagnostics`)

- `FlowlineModel`:
  - new diagnostic `mass` in kg and Mt: important when including firn output, because the density conversion between volume and mass is no longer fixed at 900 kg m-3 (see above under `SfcTypeModel`)
  - new kwarg `include_mb_model_heights`: includes snow bucket heights for elevation feedback (see above under `SfcTypeModel`)
  - new kwarg `include_firn_outputs`: if `True`, the output provided for `volume`, `mass`, and `thickness` is total = ice + firn. Firn outputs are available in glacier-integrated output and `fl_diagnostics`
  - added support for daily time resolution and leap years:
    - This means the actual number of days in each month is used. Previously, `SEC_IN_MONTH` was used for converting the model output from s-1 to month-1 (especially important for `DailyTIModel`).
    - It is debatable whether the added code complexity for leap year support is worth the small impact it has; I still added it for completeness. Leap years are used if the provided `mb_model` has `use_leap_years=True`, otherwise we use the old default `SEC_IN_YEAR` for yearly seconds. (months always use number of days per month to get to seconds in months, see bullet point above. Feb. always 28 days when `use_leap_years=False`)

- `run_from_climate_data`:
  - new kwarg `mb_diagnostics_filesuffix`: if provided, a `MultipleFlowlineMassBalance` is initialized by loading a past `mb_model` state (only supported for `SfcTypeTIModel` at the moment)
  - new kwarg `save_mb_diagnostics_filesuffix`: if provided, at the end of the run the final `mb_model` state is saved to an `mb_diagnostics` file for later use (only supported for `SfcTypeTIModel`)

- [x] Tests added/passed
- [ ] Fully documented
- [ ] Entry in `whats-new.rst` 
