### PR TITLE
Integration of SfcTypeTIModel in dynamic spinup workflow

### DIFF
--- a/oggm/core/dynamic_spinup.py
+++ b/oggm/core/dynamic_spinup.py
@@ -919,12 +919,13 @@ def run_dynamic_spinup(gdir, settings_filesuffix='',
     for spinup_period in spinup_periods_to_try:
         yr_spinup = target_yr - spinup_period
 
+        y0_spinup = (yr_spinup + target_yr) / 2
+        halfsize_spinup = target_yr - y0_spinup
+
         if not provided_mb_model_spinup:
             # define spinup MassBalance
             # spinup is running for 'target_yr - yr_spinup' years, using a
             # ConstantMassBalance
-            y0_spinup = (yr_spinup + target_yr) / 2
-            halfsize_spinup = target_yr - y0_spinup
             mb_model_spinup = MultipleFlowlineMassBalance(
                 gdir, settings_filesuffix=settings_filesuffix,
                 mb_model_class=ConstantMassBalance,

--- a/oggm/core/dynamic_spinup.py
+++ b/oggm/core/dynamic_spinup.py
@@ -1045,6 +1045,7 @@ def dynamic_melt_f_run_with_dynamic_spinup(
         store_model_geometry=True, store_fl_diagnostics=None,
         local_variables=None, set_local_variables=False, do_inversion=True,
         spinup_start_yr_max=None, add_fixed_geometry_spinup=True,
+        mb_model_class_apparent_mb=None,
         **kwargs):
     """
     This function is one option for a 'run_function' for the
@@ -1187,6 +1188,9 @@ def dynamic_melt_f_run_with_dynamic_spinup(
         fixed-geometry-spinup is added at the beginning so that the resulting
         model run always starts from ys.
         Default is True
+    mb_model_class_apparent_mb : py:class:`core.MassBalanceModel`
+        The mass balance model class which should be used to define the apparent
+        mb for the inversion.
     kwargs : dict
         kwargs to pass to the evolution_model instance
 
@@ -1278,6 +1282,7 @@ def dynamic_melt_f_run_with_dynamic_spinup(
             apparent_mb_from_any_mb(gdir,
                                     settings_filesuffix=settings_filesuffix,
                                     add_to_log_file=False,  # dont write to log
+                                    mb_model_class=mb_model_class_apparent_mb,
                                     )
             # do inversion with A calibration to current volume
             calibrate_inversion_from_volume(
@@ -1358,7 +1363,8 @@ def dynamic_melt_f_run_with_dynamic_spinup_fallback(
         first_guess_t_spinup=-2, t_spinup_max_step_length=2, maxiter=30,
         store_model_geometry=True, store_fl_diagnostics=None,
         do_inversion=True, spinup_start_yr_max=None,
-        add_fixed_geometry_spinup=True, **kwargs):
+        add_fixed_geometry_spinup=True, mb_model_class_apparent_mb=None,
+        **kwargs):
     """
     This is the fallback function corresponding to the function
     'dynamic_melt_f_run_with_dynamic_spinup', which are provided
@@ -1479,6 +1485,9 @@ def dynamic_melt_f_run_with_dynamic_spinup_fallback(
         fixed-geometry-spinup is added at the beginning so that the resulting
         model run always starts from ys.
         Default is True
+    mb_model_class_apparent_mb : py:class:`core.MassBalanceModel`
+        The mass balance model class which should be used to define the apparent
+        mb for the inversion.
     kwargs : dict
         kwargs to pass to the evolution_model instance
 
@@ -1502,6 +1511,7 @@ def dynamic_melt_f_run_with_dynamic_spinup_fallback(
             with utils.DisableLogger():
                 apparent_mb_from_any_mb(gdir,
                                         settings_filesuffix=settings_filesuffix,
+                                        mb_model_class=mb_model_class_apparent_mb,
                                         add_to_log_file=False)
                 calibrate_inversion_from_volume(
                     [gdir], settings_filesuffix=settings_filesuffix,

--- a/oggm/core/dynamic_spinup.py
+++ b/oggm/core/dynamic_spinup.py
@@ -2496,8 +2496,15 @@ def run_dynamic_melt_f_calibration(
 
                 # there where some successful runs so we return the one with the
                 # smallest mismatch of dmdtda
-                min_mismatch_index = np.argmin(np.abs(mismatch_dmdtda))
-                melt_f_best = np.array(melt_f_guesses)[min_mismatch_index]
+                try:
+                    min_mismatch_index = np.nanargmin(np.abs(mismatch_dmdtda))
+                    melt_f_best = np.array(melt_f_guesses)[min_mismatch_index]
+                except ValueError as e:
+                    if "All-NaN slice encountered" in str(e):
+                        # nothing worked, just provide initial melt_f again
+                        melt_f_best = melt_f_initial
+                    else:
+                        raise
 
                 # check if the first guess was the best guess
                 only_first_guess = False

--- a/oggm/core/dynamic_spinup.py
+++ b/oggm/core/dynamic_spinup.py
@@ -1599,6 +1599,7 @@ def dynamic_melt_f_run_with_dynamic_spinup_fallback(
             min_ys=yr_clim_min, ye=ye,
             output_filesuffix=output_filesuffix,
             climate_input_filesuffix=climate_input_filesuffix,
+            mb_model=mb_model_historical,
             store_model_geometry=store_model_geometry,
             store_fl_diagnostics=store_fl_diagnostics,
             init_model_fls=fls_init, evolution_model=evolution_model,

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -927,7 +927,11 @@ class FlowlineModel(object):
             return self._mb_model
 
     def _get_along_fl_thickness_firn_m(self, fl_id):
-        return self._get_fl_mb_model(fl_id).columns_thickness_m
+        fl_mb_model = self._get_fl_mb_model(fl_id)
+        if hasattr(fl_mb_model, 'columns_thickness_m'):
+            return fl_mb_model.columns_thickness_m
+        else:
+            return np.zeros(self.fls[fl_id].thick.shape)
 
     def _get_along_fl_volume_firn_m3(self, fl_id):
         # we assume the firn/snow is just a box on top without considering any

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -610,7 +610,7 @@ class FlowlineModel(object):
                  is_tidewater=False, is_lake_terminating=False,
                  mb_elev_feedback='annual', check_for_boundaries=None,
                  water_level=None, required_model_steps='monthly',
-                 include_mb_model_heights=False, include_firn_outputs=False, ):
+                 include_mb_model_heights=True, include_firn_outputs=False, ):
         """Create a new flowline model from the flowlines and a MB model.
 
         Parameters
@@ -659,7 +659,7 @@ class FlowlineModel(object):
             only annual updates are required. You may want to change this
             for optimisation reasons for models that don't require adaptive
             steps (for example the deltaH method).
-        include_mb_model_heights : bool, default False
+        include_mb_model_heights : bool, default True
             If True we add the snow/firn height of the current mb_model (if
             available) to include this in the elevation feedback of the mb
             calculation.

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -994,8 +994,12 @@ class FlowlineModel(object):
         return self.mass_ice_kg * 1e-9
 
     def _get_along_fl_mass_firn_kg(self, fl_id):
-        return (self._get_fl_mb_model(fl_id).columns_mass_kg_per_sqm *
-                self.fls[fl_id].bin_area_m2)
+        fl_mb_model = self._get_fl_mb_model(fl_id)
+        if hasattr(fl_mb_model, 'columns_mass_kg_per_sqm'):
+            return (fl_mb_model.columns_mass_kg_per_sqm *
+                    self.fls[fl_id].bin_area_m2)
+        else:
+            return np.zeros(self.fls[fl_id].thick.shape)
 
     @property
     def mass_firn_kg(self):

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -6,6 +6,7 @@ import os
 import inspect
 from datetime import date, timedelta
 import calendar
+from functools import partial
 # External libs
 import cftime
 import numpy as np
@@ -2951,7 +2952,12 @@ class ConstantMassBalance(MassBalanceModel):
         self.years = np.arange(y0-halfsize, y0+halfsize+1)
         self.hemisphere = gdir.hemisphere
 
-        if isinstance(mb_model_class, SfcTypeTIModel):
+        if isinstance(mb_model_class, partial):
+            mb_model_name = mb_model_class.func.__name__
+        else:
+            mb_model_name = mb_model_class.__name__
+
+        if mb_model_name in ['SfcTypeTIModel']:
             self.mbmod = mb_model_class(gdir=gdir, hbins=self.hbins, **kwargs)
         else:
             self.mbmod = mb_model_class(gdir=gdir, **kwargs)

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -2923,7 +2923,6 @@ class ConstantMassBalance(MassBalanceModel):
         """
 
         super().__init__()
-        self.mbmod = mb_model_class(gdir=gdir, **kwargs)
 
         if y0 is None:
             raise InvalidParamsError('Please set `y0` explicitly')
@@ -2951,6 +2950,11 @@ class ConstantMassBalance(MassBalanceModel):
         self.halfsize = halfsize
         self.years = np.arange(y0-halfsize, y0+halfsize+1)
         self.hemisphere = gdir.hemisphere
+
+        if isinstance(mb_model_class, SfcTypeTIModel):
+            self.mbmod = mb_model_class(gdir=gdir, hbins=self.hbins, **kwargs)
+        else:
+            self.mbmod = mb_model_class(gdir=gdir, **kwargs)
 
     @property
     def temp_bias(self):

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -5258,7 +5258,9 @@ def apparent_mb_from_any_mb(gdir, settings_filesuffix='',
                             output_filesuffix=None,
                             mb_model=None,
                             mb_model_class=MonthlyTIModel,
-                            mb_years=None):
+                            mb_years=None,
+                            include_mb_model_heights=True,
+                            ):
     """Compute apparent mb from an arbitrary mass balance profile.
 
     This searches for a mass balance residual to add to the mass balance
@@ -5296,6 +5298,10 @@ def apparent_mb_from_any_mb(gdir, settings_filesuffix='',
         between this range, excluding the last one.
         If None, the method will use all the years from the reference
         geodetic mass balance period ``gdir.settings['geodetic_mb_period']``.
+    include_mb_model_heights : bool, default True
+        If True we add the snow/firn height of the current mb_model (if
+        available) to include this in the elevation feedback of the mb
+        calculation.
     """
 
     if input_filesuffix is None:
@@ -5340,7 +5346,14 @@ def apparent_mb_from_any_mb(gdir, settings_filesuffix='',
         mbz = 0
         smb = 0
         for yr in mb_years:
-            amb = mb_model.get_annual_mb(fl.surface_h, fls=fls, fl_id=fl_id, year=yr)
+            # some models have a climatic and ice mb (e.g. SfcTIModel), for
+            # inversion we want ice; if not available it is ignored; Similarly
+            # some models include a bucket height, and we can add this height on
+            # top to the ice surface height
+            amb = mb_model.get_annual_mb(fl.surface_h, fls=fls, fl_id=fl_id, year=yr,
+                                         climatic_mb_or_ice_mb='ice_mb',
+                                         include_mb_model_heights=include_mb_model_heights
+                                         )
             amb *= mb_model.sec_in_year(year=yr) * rho
             mbz += amb
             smb += weighted_average_1d(amb, widths)

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -5257,7 +5257,7 @@ def apparent_mb_from_any_mb(gdir, settings_filesuffix='',
                             input_filesuffix='',
                             output_filesuffix=None,
                             mb_model=None,
-                            mb_model_class=MonthlyTIModel,
+                            mb_model_class=None,
                             mb_years=None,
                             include_mb_model_heights=True,
                             ):
@@ -5309,6 +5309,9 @@ def apparent_mb_from_any_mb(gdir, settings_filesuffix='',
 
     if output_filesuffix is None:
         output_filesuffix = settings_filesuffix
+
+    if mb_model_class is None:
+        mb_model_class = MonthlyTIModel
 
     # Do we have a calving glacier?
     cmb = calving_mb(gdir)

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -2374,6 +2374,68 @@ class TestMassBalanceModels:
             plot_runoff('_daily_hydro', 'DailyTIModel')
             plot_runoff('_daily_sfc_hydro', 'SfcTypeTIModel with DailyTIModel')
 
+        # test sfc_type model with dynamic melt_f calibration
+        kwargs_sfc_type = {
+            'mb_model_class': massbalance.MonthlyTIModel,
+            'climate_resolution': "monthly",
+            'aging_frequency': "monthly",
+            'ys': 1979,
+            'spinup_years': 6,
+            'use_previous_mbs': True,
+        }
+
+        # With the bucketsystem we need to know the number of grid points
+        MySfcTypeTIModel_inv = partial(
+            massbalance.SfcTypeTIModel,
+            use_main_fl_from='inversion_flowlines',
+            **kwargs_sfc_type,
+        )
+
+        MySfcTypeTIModel_dyn = partial(
+            massbalance.SfcTypeTIModel,
+            use_main_fl_from='model_flowlines',
+            **kwargs_sfc_type,
+        )
+        mb_model_historical = massbalance.MultipleFlowlineMassBalance(
+            gdir, settings_filesuffix='',
+            mb_model_class=MySfcTypeTIModel_dyn,
+            filename='climate_historical')
+        mb_model_spinup = massbalance.MultipleFlowlineMassBalance(
+            gdir, settings_filesuffix='',
+            mb_model_class=partial(
+                massbalance.ConstantMassBalance,
+                mb_model_class=MySfcTypeTIModel_dyn,
+                y0=2001, halfsize=10,
+            ),
+            filename='climate_historical')
+        dyn_models = workflow.execute_entity_task(
+            tasks.run_dynamic_melt_f_calibration,
+            gdir,
+            ys=1979,
+            ye=gdir.get_climate_info()['baseline_yr_1'] + 1,
+            ignore_errors=True,
+            ref_mb_err_scaling_factor=0.2,
+            maxiter=10,
+            kwargs_run_function={
+                'maxiter': 10,
+                'overwrite_observations': False,
+                'mb_model_historical': mb_model_historical,
+                'mb_model_spinup': mb_model_spinup,
+                'include_mb_model_heights': True,
+                'include_firn_outputs': True,
+                'mb_model_class_apparent_mb': MySfcTypeTIModel_inv,
+            },
+            output_filesuffix='_spinup_historical',
+        )
+        # if the above runs without an error it is fine, but still check a few
+        # things
+        assert isinstance(dyn_models[0].volume_m3, float)
+        assert gdir.get_diagnostics()['used_spinup_option'] in [
+            'dynamic melt_f calibration (full success)',
+            'dynamic melt_f calibration (part success)',
+            'dynamic spinup only',
+        ]
+
     def test_constant_mb_model(self, hef_gdir):
 
         rho = cfg.PARAMS['ice_density']

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -2108,6 +2108,7 @@ class TestMassBalanceModels:
             ys=1980, ye=2020,
             store_model_geometry=True, store_fl_diagnostics=True,
             store_monthly_step=True, mb_elev_feedback='monthly',
+            include_mb_model_heights=False,
             output_filesuffix='_daily_sfc')
         ds_daily_sfc = utils.compile_run_output(gdir,
                                                 input_filesuffix='_daily_sfc')
@@ -2159,7 +2160,7 @@ class TestMassBalanceModels:
             store_model_geometry=True, store_fl_diagnostics=True,
             store_monthly_step=True, mb_elev_feedback='monthly',
             output_filesuffix='_daily_sfc_firn_output',
-            include_firn_outputs=True,
+            include_firn_outputs=True, include_mb_model_heights=False,
         )
         ds_daily_sfc_firn = utils.compile_run_output(
             gdir, input_filesuffix='_daily_sfc_firn_output')


### PR DESCRIPTION
Here I add some small adaptations for a full support of `SfcTypeTIModel` in the dynamic spinup workflow. This includes:

- Support to use `SfcTypeTIModel` within `apparent_mb_from_any_mb` and `ConstantMassBalance`
- Using `SfcTypeTIModel` as `mb_historical` in `run_dynamic_spinup`
- Using a `ConstantMassBalance` with `SfcTypeTIModel` as `mb_spinup` in `run_dynamic_spinup`

I still should add at least one test for doing a dynamic spinup with a SfcTypeTIModel.

- [x] Tests added/passed
- [ ] Fully documented
- [ ] Entry in `whats-new.rst` 
