### PR TITLE
Try to use pytest-xdist for test suite

### DIFF
--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -30,13 +30,15 @@ fi
 
 $PIP install --upgrade coverage coveralls git+https://github.com/fmaussion/salem.git
 $PIP install -e .
+python -c "import xdist" 2>/dev/null || $PIP install pytest-xdist
+python -c "import ilock" 2>/dev/null || $PIP install ilock
 
 export COVERAGE_RCFILE="$PWD/.coveragerc"
 
 coverage erase
 
 coverage run --source=./oggm --parallel-mode --module \
-    pytest --verbose --mpl-results-path="/tmp/oggm-mpl-results/${MPL_OUTPUT_OGGM_SUBDIR/:/_}/${OGGM_TEST_ENV/:/_}" $OGGM_MPL --run-slow --run-test-env $OGGM_TEST_ENV oggm
+    pytest -n auto --verbose --mpl-results-path="/tmp/oggm-mpl-results/${MPL_OUTPUT_OGGM_SUBDIR/:/_}/${OGGM_TEST_ENV/:/_}" $OGGM_MPL --run-slow --run-test-env $OGGM_TEST_ENV oggm
 
 coverage combine
 coverage xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,8 @@ docs = [
 ]
 tests = [
     "pytest",
+    "pytest-xdist",
+    "ilock",
     "pytest-mpl-oggm>=0.180.1",
 ]
 


### PR DESCRIPTION
While trying to reduce the runtime of the test suite on GitHub Actions, I came across pytest-xdist. The idea is to distribute the tests across all available CPUs. On GitHub Actions you get two CPUs, meaning there is potential to halve the test run times.

However, for this to work, we need to use locking correctly for all files involved in the tests, which is not currently the case. This PR is meant to investigate whether we are able to make use of this.

@TimoRoth do you know anything about this, or do you have an idea how we can make this work?

- [ ] Tests added/passed
- [ ] Fully documented
- [ ] Entry in `whats-new.rst` 
