### PR TITLE
feat: drop hdf tables in favour of parquet

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -82,8 +82,9 @@ Breaking changes
   sign for that variable.
   By `Brandon Tober <https://github.com/btobers>`_
 - Support for reading and writing HDF files with pytables is deprecated. Files
-  should instead use parquet with ZSTD compression. Adds pyarrow as a
-  dependency (:pull:`1924`).
+  should instead use parquet with ZSTD compression. This adds ``pyarrow`` as a
+  core dependency and removes ``tables`` (pytables), which we are very glad to
+  see go as it was a recurrent source of installation pain (:pull:`1924`).
   By `Nicolas Gampierakis <https://github.com/gampnico>`_
 
 v1.6.3 (April 13, 2026)

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -19,6 +19,10 @@ Bug fixes
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
+- Support for reading and writing HDF files with pytables is deprecated. Files
+  should instead use parquet with ZSTD compression. Adds pyarrow as a
+  dependency (:pull:`1924`).
+  By `Nicolas Gampierakis <https://github.com/gampnico>`_
 
 v1.6.3 (April 13, 2026)
 -----------------------

--- a/oggm/shop/glathida.py
+++ b/oggm/shop/glathida.py
@@ -56,11 +56,16 @@ def glathida_to_gdir(gdir):
     base_url = GTD_BASE_URL.format(rgi_version)
     gtd_file = utils.file_downloader(base_url)
 
-    try:
-        df = pd.read_hdf(gtd_file, key=gdir.rgi_id)
-    except KeyError:
-        log.debug(f'({gdir.rgi_id}): no GlaThiDa data for this glacier')
-        return None
+    if str(gtd_file).endswith('.parquet'):
+        df = pd.read_parquet(gtd_file)
+        df = df[df['rgi_id'] == gdir.rgi_id].copy()
+        if df.empty:
+            log.debug(f'({gdir.rgi_id}): no GlaThiDa data for this glacier')
+            return None
+    else:
+        raise NotImplementedError(
+            "GlaThiDa data in HDF is no longer supported by OGGM."
+        )
 
     # OK - transform for later
     xx, yy = salem.transform_proj(salem.wgs84, gdir.grid.proj, df['longitude'], df['latitude'])

--- a/oggm/shop/glathida.py
+++ b/oggm/shop/glathida.py
@@ -19,7 +19,7 @@ from oggm import utils, cfg
 log = logging.getLogger(__name__)
 
 GTD_BASE_URL = ('https://cluster.klima.uni-bremen.de/~oggm/glathida/glathida-main/'
-                'data/glathida_2023-11-16_rgi_{}_per_id.h5')
+                'data/glathida_2023-11-16_rgi_{}_per_id.parquet')
 
 
 @utils.entity_task(log, writes=['glathida_data'])

--- a/oggm/tests/conftest.py
+++ b/oggm/tests/conftest.py
@@ -323,7 +323,7 @@ def hef_elev_gdir(hef_elev_gdir_base, class_case_dir):
                                  setup='all')
 
 
-@pytest.fixture(scope="class", autouse=True)
+@pytest.fixture(scope="session")
 def rgi62_itmix_df():
     """Provides a reference to the rgi62_itmix_df for the entire test session.
 

--- a/oggm/tests/conftest.py
+++ b/oggm/tests/conftest.py
@@ -189,6 +189,7 @@ def patch_download_url_allowlist():
         'cluster.klima.uni-bremen.de/~oggm/test_files/',
         'klima.uni-bremen.de/~oggm/climate/cru/cru_cl2.nc.zip',
         'klima.uni-bremen.de/~oggm/geodetic_ref_mb',
+        'klima.uni-bremen.de/~oggm/g2ti',
         'RGI2000-v7.0-regions.zip',
         base_extra_v14.format('L1'),
         base_extra_v14.format('L2'),
@@ -338,3 +339,15 @@ def hef_elev_gdir(hef_elev_gdir_base, class_case_dir):
     """
     return tasks.copy_to_basedir(hef_elev_gdir_base, base_dir=class_case_dir,
                                  setup='all')
+
+
+@pytest.fixture(scope="class", autouse=True)
+def rgi62_itmix_df():
+    """Provides a reference to the rgi62_itmix_df for the entire test session.
+
+    Named after the current git revision.
+    As a session-scoped fixture, this will only be created once and
+    then injected to each test that depends on it.
+    """
+    dl_path = "https://cluster.klima.uni-bremen.de/~oggm/g2ti/rgi62_itmix_df_v20260617.parquet"
+    return utils.file_downloader(dl_path)

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -178,7 +178,7 @@ class TestInitPresentDayFlowline:
                                         filesuffix='_consensus')[0]
 
         # check that resulting flowline has the same volume as observation
-        cdf = pd.read_hdf(utils.get_demo_file('rgi62_itmix_df.h5'))
+        cdf = pd.read_parquet(utils.get_demo_file('rgi62_itmix_df.parquet'))
         ref_vol = cdf.loc[gdir.rgi_id].vol_itmix_m3
         np.testing.assert_allclose(fl_consensus.volume_m3, ref_vol)
 

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -20,7 +20,7 @@ from oggm import utils, workflow, tasks, cfg
 from oggm.core import climate, inversion, centerlines
 from oggm.shop import gcm_climate, bedtopo
 from oggm.cfg import SEC_IN_YEAR, SEC_IN_MONTH
-from oggm.utils import get_demo_file
+from oggm.utils import get_demo_file, file_downloader
 from oggm.exceptions import InvalidParamsError, InvalidWorkflowError
 
 from oggm.tests.funcs import get_test_dir
@@ -154,8 +154,9 @@ class TestInitPresentDayFlowline:
         with pytest.raises(InvalidParamsError):
             init_present_time_glacier(gdir)
 
-    def test_init_present_time_glacier_obs_thick(self, hef_elev_gdir,
-                                                 monkeypatch):
+    def test_init_present_time_glacier_obs_thick(
+        self, hef_elev_gdir, rgi62_itmix_df, monkeypatch
+    ):
 
         gdir = hef_elev_gdir
 
@@ -178,7 +179,7 @@ class TestInitPresentDayFlowline:
                                         filesuffix='_consensus')[0]
 
         # check that resulting flowline has the same volume as observation
-        cdf = pd.read_parquet(utils.get_demo_file('rgi62_itmix_df.parquet'))
+        cdf = pd.read_parquet(rgi62_itmix_df, engine='pyarrow')
         ref_vol = cdf.loc[gdir.rgi_id].vol_itmix_m3
         np.testing.assert_allclose(fl_consensus.volume_m3, ref_vol)
 

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -2338,7 +2338,7 @@ class TestInversion(unittest.TestCase):
         dfo = workflow.invert_from_params(gdir, params_df=dfi)
         np.testing.assert_allclose(df.vol_itmix_m3, dfo.vol_oggm_m3, rtol=0.01)
 
-        df = pd.read_hdf(utils.get_demo_file('rgi62_itmix_df.h5'))
+        df = pd.read_parquet(utils.get_demo_file('rgi62_itmix_df.parquet'))
 
         # Works with Series
         out = workflow.calibrate_inversion_from_volume(gdir,

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -2196,7 +2196,7 @@ class TestInversion(unittest.TestCase):
 
         dfo = workflow.invert_from_params(gdir, params_df=dfi)
         np.testing.assert_allclose(df.vol_itmix_m3, dfo.vol_oggm_m3, rtol=0.01)
-        
+
         dl_path = "https://cluster.klima.uni-bremen.de/~oggm/g2ti/rgi62_itmix_df_v20260617.parquet"
         df = pd.read_parquet(utils.file_downloader(dl_path))
 

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -2196,8 +2196,9 @@ class TestInversion(unittest.TestCase):
 
         dfo = workflow.invert_from_params(gdir, params_df=dfi)
         np.testing.assert_allclose(df.vol_itmix_m3, dfo.vol_oggm_m3, rtol=0.01)
-
-        df = pd.read_parquet(utils.get_demo_file('rgi62_itmix_df.parquet'))
+        
+        dl_path = "https://cluster.klima.uni-bremen.de/~oggm/g2ti/rgi62_itmix_df_v20260617.parquet"
+        df = pd.read_parquet(utils.file_downloader(dl_path))
 
         # Works with Series
         out = workflow.calibrate_inversion_from_volume(gdir,

--- a/oggm/tests/test_shop.py
+++ b/oggm/tests/test_shop.py
@@ -728,7 +728,7 @@ class Test_climate_datasets:
 
 class Test_bedtopo:
 
-    def test_add_consensus(self, class_case_dir, monkeypatch):
+    def test_add_consensus(self, class_case_dir, rgi62_itmix_df, monkeypatch):
 
         # Init
         cfg.initialize()
@@ -771,7 +771,7 @@ class Test_bedtopo:
         assert utils.rmsd(ref, mine) < 2
 
         # Check vol
-        cdf = pd.read_parquet(utils.get_demo_file('rgi62_itmix_df.parquet'))
+        cdf = pd.read_parquet(rgi62_itmix_df, engine='pyarrow')
         ref_vol = cdf.loc[gdir.rgi_id].vol_itmix_m3
         my_vol = mine.sum() * gdir.grid.dx**2
         np.testing.assert_allclose(my_vol, ref_vol)

--- a/oggm/tests/test_shop.py
+++ b/oggm/tests/test_shop.py
@@ -821,7 +821,7 @@ class Test_Glathida:
 
         # use our files
         base_url = ('https://cluster.klima.uni-bremen.de/~oggm/test_files/'
-                    'glathida/glathida_2023-11-16_rgi_{}.h5')
+                    'glathida/glathida_2023-11-16_rgi_{}.parquet')
         monkeypatch.setattr(glathida, 'GTD_BASE_URL', base_url)
 
         df = glathida.glathida_to_gdir(gdir)

--- a/oggm/tests/test_shop.py
+++ b/oggm/tests/test_shop.py
@@ -771,7 +771,7 @@ class Test_bedtopo:
         assert utils.rmsd(ref, mine) < 2
 
         # Check vol
-        cdf = pd.read_hdf(utils.get_demo_file('rgi62_itmix_df.h5'))
+        cdf = pd.read_parquet(utils.get_demo_file('rgi62_itmix_df.parquet'))
         ref_vol = cdf.loc[gdir.rgi_id].vol_itmix_m3
         my_vol = mine.sum() * gdir.grid.dx**2
         np.testing.assert_allclose(my_vol, ref_vol)

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -2378,6 +2378,7 @@ class TestFakeDownloads(unittest.TestCase):
 
 
 class TestDataFiles(unittest.TestCase):
+    # TODO: Refactor to pytest
 
     def setUp(self):
         self.dldir = os.path.join(get_test_dir(), 'tmp_download')
@@ -2454,6 +2455,30 @@ class TestDataFiles(unittest.TestCase):
         # Raise error if nothing to extract
         with pytest.raises(InvalidParamsError):
             utils.file_extractor(tmp_file)
+
+    def test_get_dataframe_from_file(self):
+        wd = cfg.PATHS["working_dir"]
+        df_orig = pd.DataFrame({"a": [1, 2, 3], "b": [4.0, 5.0, 6.0]})
+
+        csv_path = os.path.join(wd, "test.csv")
+        df_orig.to_csv(csv_path, index=False)
+        df = _downloads.get_dataframe_from_file(csv_path)
+        pd.testing.assert_frame_equal(df, df_orig)
+
+        # TODO: Remove once HDF files are no longer available on oggm-sample-data
+        hdf_path = os.path.join(wd, "test.hdf")
+        df_orig.to_hdf(hdf_path, key="df")
+        with pytest.warns(DeprecationWarning, match="hdf"):
+            df = _downloads.get_dataframe_from_file(hdf_path)
+        pd.testing.assert_frame_equal(df, df_orig)
+
+        parquet_path = os.path.join(wd, "test.parquet")
+        df_orig.to_parquet(parquet_path, engine="pyarrow", index=False)
+        df = _downloads.get_dataframe_from_file(parquet_path)
+        pd.testing.assert_frame_equal(df, df_orig)
+
+        with pytest.raises(NotImplementedError):
+            _downloads.get_dataframe_from_file(os.path.join(wd, "test.nc"))
 
     def test_srtmzone(self):
 
@@ -3085,6 +3110,6 @@ class TestELAComputation(unittest.TestCase):
 
         fpath = os.path.join(cfg.PATHS['working_dir'], 'ELA.csv')
         ela1 = pd.read_csv(fpath, index_col=0)
-        ela2 = pd.read_hdf(fpath.replace('.csv', '.hdf'))
+        ela2 = pd.read_parquet(fpath.replace('.csv', '.parquet'))
 
         assert_allclose(ela1, ela2, rtol=1e-3)

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -520,7 +520,7 @@ class TestWorkflowTools(unittest.TestCase):
         assert len(df.loc[df['dmdtda'].isnull()]) == 0
 
         base_url = 'https://cluster.klima.uni-bremen.de/~oggm/geodetic_ref_mb/'
-        file_name = 'hugonnet_2021_ds_rgi60_pergla_rates_10_20_worldwide_filled.hdf'
+        file_name = 'hugonnet_2021_ds_rgi60_pergla_rates_10_20_worldwide_filled.parquet'
         file_path = utils.file_downloader(base_url + file_name)
 
         assert file_path in cfg.DATA
@@ -2546,13 +2546,6 @@ class TestDataFiles(unittest.TestCase):
         df = _downloads.get_dataframe_from_file(csv_path)
         pd.testing.assert_frame_equal(df, df_orig)
 
-        # TODO: Remove once HDF files are no longer available on oggm-sample-data
-        hdf_path = os.path.join(wd, "test.hdf")
-        df_orig.to_hdf(hdf_path, key="df")
-        with pytest.warns(DeprecationWarning, match="hdf"):
-            df = _downloads.get_dataframe_from_file(hdf_path)
-        pd.testing.assert_frame_equal(df, df_orig)
-
         parquet_path = os.path.join(wd, "test.parquet")
         df_orig.to_parquet(parquet_path, engine="pyarrow", index=False)
         df = _downloads.get_dataframe_from_file(parquet_path)
@@ -2560,6 +2553,16 @@ class TestDataFiles(unittest.TestCase):
 
         with pytest.raises(NotImplementedError):
             _downloads.get_dataframe_from_file(os.path.join(wd, "test.nc"))
+
+        # TODO: Remove once HDF files are no longer available on oggm-sample-data
+        # Kept last as importorskip aborts the rest of the test when pytables
+        # (an optional dependency) is not installed.
+        pytest.importorskip("tables")
+        hdf_path = os.path.join(wd, "test.hdf")
+        df_orig.to_hdf(hdf_path, key="df")
+        with pytest.warns(DeprecationWarning, match="hdf"):
+            df = _downloads.get_dataframe_from_file(hdf_path)
+        pd.testing.assert_frame_equal(df, df_orig)
 
     def test_srtmzone(self):
 

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -69,8 +69,8 @@ logger = logging.getLogger('.'.join(__name__.split('.')[:-1]))
 # Github repository and commit hash/branch name/tag name on that repository
 # The given commit will be downloaded from github and used as source for
 # all sample data
-SAMPLE_DATA_GH_REPO = 'OGGM/oggm-sample-data/tree/feat-ON-44-convert-csv-to-parquet'
-SAMPLE_DATA_COMMIT = '8af40f89620c6bd72f3485a777a018dcacb99d94'
+SAMPLE_DATA_GH_REPO = 'gampnico/oggm-sample-data'
+SAMPLE_DATA_COMMIT = 'f34067916f4986287749d054da45fd19869765fb'
 
 # Recommended url for runs
 DEFAULT_BASE_URL = ('https://cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.6/'

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -1195,7 +1195,7 @@ def get_dataframe_from_file(file_path: Path | str, **kwargs) -> pd.DataFrame:
 
     if extension == ".csv":
         df = pd.read_csv(file_path, **kwargs)
-    elif extension == ".hdf":
+    elif extension in [".hdf", ".h5"]:
         warnings.warn(
             "Reading directly from hdf files will be removed in a future"
             "release and replaced with geoparquet.",

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -1200,7 +1200,7 @@ def get_dataframe_from_file(file_path: Path | str, **kwargs) -> pd.DataFrame:
             "Reading directly from hdf files will be removed in a future"
             "release and replaced with geoparquet.",
             DeprecationWarning,
-            stack_level=2,
+            stacklevel=2,
         )
         df = pd.read_hdf(file_path, **kwargs)
     elif extension == ".parquet":

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -25,6 +25,8 @@ import ftplib
 import ssl
 import tarfile
 import json
+import warnings
+from pathlib import Path
 
 # External libs
 import pandas as pd
@@ -67,7 +69,7 @@ logger = logging.getLogger('.'.join(__name__.split('.')[:-1]))
 # Github repository and commit hash/branch name/tag name on that repository
 # The given commit will be downloaded from github and used as source for
 # all sample data
-SAMPLE_DATA_GH_REPO = 'OGGM/oggm-sample-data'
+SAMPLE_DATA_GH_REPO = 'OGGM/oggm-sample-data/tree/feat-ON-44-convert-csv-to-parquet'
 SAMPLE_DATA_COMMIT = '8af40f89620c6bd72f3485a777a018dcacb99d94'
 
 # Recommended url for runs
@@ -1165,6 +1167,50 @@ def _get_prepro_gdir_unlocked(rgi_version, rgi_id, border, prepro_level,
     return tar_base
 
 
+def get_dataframe_from_file(file_path: Path | str, **kwargs) -> pd.DataFrame:
+    """Fetches a dataframe from a file.
+
+    Parameters
+    ----------
+    file_path : str or Path
+        Path to the file to read. Supports csv and parquet files, with
+        deprecation warning for hdf files.
+    **kwargs
+        Additional keyword arguments to pass to the pandas read function.
+
+    Returns
+    -------
+    pd.DataFrame
+        The dataframe read from the file.
+
+    Raises
+    ------
+    NotImplementedError
+        If the file extension is not supported.
+    DeprecationWarning
+        If reading from hdf files, a warning is raised that support will
+        be removed in a future release.
+    """
+    extension = Path(file_path).suffix.lower()
+
+    if extension == ".csv":
+        df = pd.read_csv(file_path, **kwargs)
+    elif extension == ".hdf":
+        warnings.warn(
+            "Reading directly from hdf files will be removed in a future"
+            "release and replaced with geoparquet.",
+            DeprecationWarning,
+            stack_level=2,
+        )
+        df = pd.read_hdf(file_path, **kwargs)
+    elif extension == ".parquet":
+        df = pd.read_parquet(file_path, engine="pyarrow", **kwargs)
+    else:
+        raise NotImplementedError(f"File type not supported: {extension}")
+
+    return df
+
+
 def get_geodetic_mb_dataframe(file_path=None, regional=False):
     """Fetches the reference geodetic dataframe for calibration.
 
@@ -1204,12 +1250,7 @@ def get_geodetic_mb_dataframe(file_path=None, regional=False):
         return cfg.DATA[file_path]
 
     # If not let's go
-    extension = os.path.splitext(file_path)[1]
-    if extension == '.csv':
-        df = pd.read_csv(file_path)
-    elif extension == '.hdf':
-        df = pd.read_hdf(file_path)
-
+    df = get_dataframe_from_file(file_path)
     # Check for missing data (old files)
     if len(df.loc[df['dmdtda'].isnull()]) > 0:
         raise InvalidParamsError('The reference file you are using has missing '
@@ -1270,11 +1311,7 @@ def get_temp_bias_dataframe(dataset, regional=False, rgi_version='62'):
         return cfg.DATA[file_path]
 
     # If not let's go
-    extension = os.path.splitext(file_path)[1]
-    if extension == '.csv':
-        df = pd.read_csv(file_path, index_col=0)
-    elif extension == '.hdf':
-        df = pd.read_hdf(file_path)
+    df = get_dataframe_from_file(file_path)
 
     cfg.DATA[file_path] = df
     return df

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -69,8 +69,8 @@ logger = logging.getLogger('.'.join(__name__.split('.')[:-1]))
 # Github repository and commit hash/branch name/tag name on that repository
 # The given commit will be downloaded from github and used as source for
 # all sample data
-SAMPLE_DATA_GH_REPO = 'gampnico/oggm-sample-data'
-SAMPLE_DATA_COMMIT = 'f34067916f4986287749d054da45fd19869765fb'
+SAMPLE_DATA_GH_REPO = 'OGGM/oggm-sample-data'
+SAMPLE_DATA_COMMIT = 'df58aaf6b55390ab831e4bd28815a9c3070f5235'
 
 # Recommended url for runs
 DEFAULT_BASE_URL = ('https://cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.6/'

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -1233,6 +1233,9 @@ def get_dataframe_from_file(file_path: Path | str, **kwargs) -> pd.DataFrame:
     ------
     NotImplementedError
         If the file extension is not supported.
+
+    Warns
+    -----
     DeprecationWarning
         If reading from hdf files, a warning is raised that support will
         be removed in a future release.
@@ -1243,7 +1246,7 @@ def get_dataframe_from_file(file_path: Path | str, **kwargs) -> pd.DataFrame:
         df = pd.read_csv(file_path, **kwargs)
     elif extension in [".hdf", ".h5"]:
         warnings.warn(
-            "Reading directly from hdf files will be removed in a future"
+            "Reading directly from hdf files will be removed in a future "
             "release and replaced with geoparquet.",
             DeprecationWarning,
             stacklevel=2,
@@ -1285,7 +1288,7 @@ def get_geodetic_mb_dataframe(file_path=None, regional=False):
             file_name = 'hugonnet_2021_regional_avg.csv'
             file_path = file_downloader(base_url + file_name)
         else:
-            file_name = 'hugonnet_2021_ds_rgi60_pergla_rates_10_20_worldwide_filled.hdf'
+            file_name = 'hugonnet_2021_ds_rgi60_pergla_rates_10_20_worldwide_filled.parquet'
             file_path = file_downloader(base_url + file_name)
 
     if file_path.startswith('http'):
@@ -1357,7 +1360,7 @@ def get_temp_bias_dataframe(dataset, regional=False, rgi_version='62'):
         return cfg.DATA[file_path]
 
     # If not let's go
-    df = get_dataframe_from_file(file_path)
+    df = get_dataframe_from_file(file_path, index_col=0)
 
     cfg.DATA[file_path] = df
     return df

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -1977,8 +1977,8 @@ def compile_fixed_geometry_mass_balance(gdirs, filesuffix='',
 
     """Compiles a table of specific mass balance timeseries for all glaciers.
 
-    The file is stored in a hdf file (not csv) per default. Use pd.read_hdf
-    to open it.
+    By default, the file is stored in a parquet file (not csv) per default.
+    Use ``pd.read_parquet`` to open it.
 
     Parameters
     ----------
@@ -1991,7 +1991,7 @@ def compile_fixed_geometry_mass_balance(gdirs, filesuffix='',
         Set to a path to store the file to your chosen location (file
         extension matters)
     csv : bool
-        Set to store the data in csv instead of hdf.
+        Set to store the data in csv instead of parquet.
     use_inversion_flowlines : bool
         whether to use the inversion flowlines or the model flowlines
     ys : int
@@ -2038,13 +2038,13 @@ def compile_fixed_geometry_mass_balance(gdirs, filesuffix='',
             if csv:
                 out.to_csv(fpath + '.csv')
             else:
-                out.to_hdf(fpath + '.hdf', key='df')
+                out.to_parquet(fpath + '.parquet', engine='pyarrow')
         else:
             ext = os.path.splitext(path)[-1]
             if ext.lower() == '.csv':
                 out.to_csv(path)
-            elif ext.lower() == '.hdf':
-                out.to_hdf(path, key='df')
+            elif ext.lower() == '.parquet':
+                out.to_parquet(path, engine='pyarrow')
     return out
 
 
@@ -2056,8 +2056,8 @@ def compile_ela(gdirs, filesuffix='', path=True, csv=False, ys=None, ye=None,
     """Compiles a table of ELA timeseries for all glaciers for a given years,
     using the mb_model_class (default MonthlyTIModel).
 
-    The file is stored in a hdf file (not csv) per default. Use pd.read_hdf
-    to open it.
+    By default, the file is stored in a parquet file (not csv). Use
+    ``pd.read_parquet`` to open it.
 
     Parameters
     ----------
@@ -2069,8 +2069,8 @@ def compile_ela(gdirs, filesuffix='', path=True, csv=False, ys=None, ye=None,
         Set to "True" in order  to store the info in the working directory
         Set to a path to store the file to your chosen location (file
         extension matters)
-    csv: bool
-        Set to store the data in csv instead of hdf.
+    csv : bool
+        Set to store the data in csv instead of parquet.
     ys : int
         start year
     ye : int
@@ -2118,13 +2118,13 @@ def compile_ela(gdirs, filesuffix='', path=True, csv=False, ys=None, ye=None,
             if csv:
                 out.to_csv(fpath + '.csv')
             else:
-                out.to_hdf(fpath + '.hdf', key='df')
+                out.to_parquet(fpath + '.parquet', engine='pyarrow')
         else:
             ext = os.path.splitext(path)[-1]
             if ext.lower() == '.csv':
                 out.to_csv(path)
-            elif ext.lower() == '.hdf':
-                out.to_hdf(path, key='df')
+            elif ext.lower() == '.parquet':
+                out.to_parquet(path, engine='pyarrow')
     return out
 
 

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -630,7 +630,7 @@ def calibrate_inversion_from_consensus(gdirs, ignore_missing=True,
     gdirs = utils.tolist(gdirs)
 
     # Get the ref data for the glaciers we have
-    df = pd.read_hdf(utils.get_demo_file('rgi62_itmix_df.h5'))
+    df = pd.read_parquet(utils.get_demo_file('rgi62_itmix_df.parquet'))
     rids = [gdir.rgi_id for gdir in gdirs]
 
     found_ids = df.index.intersection(rids)

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -630,7 +630,8 @@ def calibrate_inversion_from_consensus(gdirs, ignore_missing=True,
     gdirs = utils.tolist(gdirs)
 
     # Get the ref data for the glaciers we have
-    df = pd.read_parquet(utils.get_demo_file('rgi62_itmix_df.parquet'))
+    dl_path = "https://cluster.klima.uni-bremen.de/~oggm/g2ti/rgi62_itmix_df_v20260617.parquet"
+    df = pd.read_parquet(utils.file_downloader(dl_path))
     rids = [gdir.rgi_id for gdir in gdirs]
 
     found_ids = df.index.intersection(rids)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "scipy",
     "shapely",
     "xarray",
+    "pyarrow",
 ]
 
 [project.optional-dependencies]
@@ -62,7 +63,6 @@ full = [
     "scikit-learn",
     "seaborn",
     "tables",
-    "pyarrow",
 ]
 docs = [
     "numpydoc",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,6 @@ full = [
     "scikit-image",
     "scikit-learn",
     "seaborn",
-    "tables",
 ]
 docs = [
     "numpydoc",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ full = [
     "scikit-learn",
     "seaborn",
     "tables",
+    "pyarrow",
 ]
 docs = [
     "numpydoc",


### PR DESCRIPTION
<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->

- Defaults to reading and writing parquet rather than HDF.
- The default compression standard for parquet should be ZSTD. It provides a better balance between file size and speed compared to the default snappy.
- Adds pyarrow as a dependency.

- [x] replace H5 instances in shop (e.g. Glathilda)

Closes #1857.

- [x] Tests added/passed
- [x] Fully documented
- [x] Entry in `whats-new.rst` 
