### PR TITLE
refactor: modify glacier bundle limit

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -12,6 +12,12 @@ Enhancements
 - `run_prepro_levels` now allows to set a custom climate data processing
   module and custom geodetic data file to create glacier directories (:pull:`1910`).
   By `Fabien Maussion <https://github.com/fmaussion>`_
+- Supports bundling glaciers in sets other than 1000. The new default for
+  `base_dir_to_tar` is 100. Downloading from existing base URLs will still use
+  the 1k bundles, but new URLs will use bundles of 100 by default which should
+  be faster. `robust_tar_extract` will handle different bundle sizes
+  automatically. (:pull:`1925`).
+  By `Nicolas Gampierakis <https://github.com/gampnico>`_
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -17,11 +17,13 @@ Enhancements
   the initially defined spinup period (`spinup_period_initial`) and the minimum
   spinup period (`min_spinup_period`) fail (:pull:`1914`).
   By `Patrick Schmitt <https://github.com/pat-schmitt>`_
-- Supports bundling glaciers in sets other than 1000. The new default for
-  `base_dir_to_tar` is 100. Downloading from existing base URLs will still use
-  the 1k bundles, but new URLs will use bundles of 100 by default which should
-  be faster. `robust_tar_extract` will handle different bundle sizes
-  automatically. (:pull:`1925`).
+- `base_dir_to_tar` now groups glacier directories into bundles of 100 by
+  default (previously 1000); ``bundle_size`` accepts either 100 or 1000.
+  Smaller bundles make downloads more granular and faster while keeping the
+  number of files per directory manageable. Reading is fully backwards
+  compatible: existing base URLs keep serving the 1000-glacier bundles, while
+  newly created URLs use the 100-glacier bundles. Both RGI6 and RGI7 IDs are
+  supported (:pull:`1925`).
   By `Nicolas Gampierakis <https://github.com/gampnico>`_
 - Some tests have been refactored from unittest to pytest. (:pull:`1925`).
   By `Nicolas Gampierakis <https://github.com/gampnico>`_

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -18,6 +18,8 @@ Enhancements
   be faster. `robust_tar_extract` will handle different bundle sizes
   automatically. (:pull:`1925`).
   By `Nicolas Gampierakis <https://github.com/gampnico>`_
+- Some tests have been refactored from unittest to pytest. (:pull:`1925`).
+  By `Nicolas Gampierakis <https://github.com/gampnico>`_
 
 Bug fixes
 ~~~~~~~~~

--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -4,7 +4,7 @@ Type `$ oggm_prepro -h` for help
 
 """
 
-# External modules
+# Standard libraries
 import os
 import sys
 import shutil
@@ -13,6 +13,9 @@ import time
 import logging
 import json
 import importlib
+from pathlib import Path
+
+# External modules
 import pandas as pd
 import numpy as np
 import geopandas as gpd
@@ -328,13 +331,11 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
 
     if rgi_version is None:
         rgi_version = cfg.PARAMS['rgi_version']
-    output_base_dir = os.path.join(output_folder,
-                                   'RGI{}'.format(rgi_version),
-                                   'b_{:03d}'.format(border))
+    output_base_dir = Path(output_folder) / f'RGI{rgi_version}' / f'b_{border:03d}'
 
     # Add a package version file
     utils.mkdir(output_base_dir)
-    opath = os.path.join(output_base_dir, 'package_versions.txt')
+    opath = output_base_dir / 'package_versions.txt'
     with open(opath, 'w') as vfile:
         vfile.write(utils.show_versions(logger=log))
 
@@ -425,14 +426,14 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
         gdirs = workflow.init_glacier_directories(rgidf, reset=True, force=True)
 
         # Glacier stats
-        sum_dir = os.path.join(output_base_dir, 'L0', 'summary')
+        sum_dir = Path(output_base_dir) / 'L0' / 'summary'
         utils.mkdir(sum_dir)
-        opath = os.path.join(sum_dir, 'glacier_statistics_{}.csv'.format(rgi_reg))
+        opath = sum_dir / f'glacier_statistics_{rgi_reg}.csv'
         utils.compile_glacier_statistics(gdirs, path=opath)
 
         # L0 OK - compress all in output directory
         log.workflow('L0 done. Writing to tar...')
-        level_base_dir = os.path.join(output_base_dir, 'L0')
+        level_base_dir = Path(output_base_dir) / 'L0'
         workflow.execute_entity_task(utils.gdir_to_tar, gdirs, delete=False,
                                      base_dir=level_base_dir)
         utils.base_dir_to_tar(level_base_dir)
@@ -476,9 +477,9 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
                                          gdirs, source='ALL')
 
             # Glacier stats
-            sum_dir = os.path.join(output_base_dir, 'L1', 'summary')
+            sum_dir = Path(output_base_dir) / 'L1' / 'summary'
             utils.mkdir(sum_dir)
-            opath = os.path.join(sum_dir, 'glacier_statistics_{}.csv'.format(rgi_reg))
+            opath = sum_dir / f'glacier_statistics_{rgi_reg}.csv'
             utils.compile_glacier_statistics(gdirs, path=opath)
 
             # Add hypsometry files
@@ -495,7 +496,7 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
                                                  gdirs,
                                                  overwrite=False)
                     workflow.execute_entity_task(tasks.compute_hypsometry_attributes, gdirs)
-                    opath = os.path.join(sum_dir, f'hypsometry_{rgi_reg}_{dem_source}.csv')
+                    opath = sum_dir / f'hypsometry_{rgi_reg}_{dem_source}.csv'
                     utils.compile_glacier_hypsometry(gdirs, path=opath,
                                                      add_column=('dem_source', dem_source))
                     workflow.execute_entity_task(_move_hypsometry_to_dem_folder,
@@ -503,7 +504,7 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
 
             # L1 OK - compress all in output directory
             log.workflow('L1 done. Writing to tar...')
-            level_base_dir = os.path.join(output_base_dir, 'L1')
+            level_base_dir = Path(output_base_dir) / 'L1'
             workflow.execute_entity_task(utils.gdir_to_tar, gdirs, delete=False,
                                          base_dir=level_base_dir)
             utils.base_dir_to_tar(level_base_dir)
@@ -519,7 +520,7 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
                                      source=source)
 
         # Summaries
-        sum_dir = os.path.join(output_base_dir, 'L1', 'summary')
+        sum_dir = Path(output_base_dir) / 'L1' / 'summary'
         utils.mkdir(sum_dir)
 
         # Add hypsometry files
@@ -529,16 +530,16 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
                                          no_nunataks=True)
             workflow.execute_entity_task(tasks.rasterio_glacier_exterior_mask, gdirs)
             workflow.execute_entity_task(tasks.compute_hypsometry_attributes, gdirs)
-            opath = os.path.join(sum_dir, f'hypsometry_{rgi_reg}.csv')
+            opath = sum_dir / f'hypsometry_{rgi_reg}.csv'
             utils.compile_glacier_hypsometry(gdirs, path=opath)
 
         # Glacier stats
-        opath = os.path.join(sum_dir, 'glacier_statistics_{}.csv'.format(rgi_reg))
+        opath = sum_dir / f'glacier_statistics_{rgi_reg}.csv'
         utils.compile_glacier_statistics(gdirs, path=opath)
 
         # L1 OK - compress all in output directory
         log.workflow('L1 done. Writing to tar...')
-        level_base_dir = os.path.join(output_base_dir, 'L1')
+        level_base_dir = Path(output_base_dir) / 'L1'
         workflow.execute_entity_task(utils.gdir_to_tar, gdirs, delete=False,
                                      base_dir=level_base_dir)
         utils.base_dir_to_tar(level_base_dir)
@@ -653,63 +654,63 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
                          'downstream lines.')
 
         # Glacier stats
-        sum_dir = os.path.join(output_base_dir, 'L2', 'summary')
+        sum_dir = Path(output_base_dir) / 'L2' / 'summary'
         utils.mkdir(sum_dir)
-        opath = os.path.join(sum_dir, 'glacier_statistics_{}.csv'.format(rgi_reg))
+        opath = sum_dir / f'glacier_statistics_{rgi_reg}.csv'
         utils.compile_glacier_statistics(gdirs, path=opath)
 
         if add_itslive_velocity:
             from oggm.shop.its_live import compile_itslive_statistics
-            opath = os.path.join(sum_dir, 'itslive_statistics_{}.csv'.format(rgi_reg))
+            opath = sum_dir / f'itslive_statistics_{rgi_reg}.csv'
             compile_itslive_statistics(gdirs, path=opath)
         if add_millan_thickness or add_millan_velocity:
             from oggm.shop.millan22 import compile_millan_statistics
-            opath = os.path.join(sum_dir, 'millan_statistics_{}.csv'.format(rgi_reg))
+            opath = sum_dir / f'millan_statistics_{rgi_reg}.csv'
             compile_millan_statistics(gdirs, path=opath)
         if add_consensus_thickness:
             from oggm.shop.bedtopo import compile_consensus_statistics
-            opath = os.path.join(sum_dir, 'consensus_statistics_{}.csv'.format(rgi_reg))
+            opath = sum_dir / f'consensus_statistics_{rgi_reg}.csv'
             compile_consensus_statistics(gdirs, path=opath)
         if add_hugonnet_dhdt:
             from oggm.shop.hugonnet_maps import compile_hugonnet_statistics
-            opath = os.path.join(sum_dir, 'hugonnet_statistics_{}.csv'.format(rgi_reg))
+            opath = sum_dir / f'hugonnet_statistics_{rgi_reg}.csv'
             compile_hugonnet_statistics(gdirs, path=opath)
         if add_bedmachine:
             from oggm.shop.bedmachine import compile_bedmachine_statistics
-            opath = os.path.join(sum_dir, 'bedmachine_statistics_{}.csv'.format(rgi_reg))
+            opath = sum_dir / f'bedmachine_statistics_{rgi_reg}.csv'
             compile_bedmachine_statistics(gdirs, path=opath)
         if add_glathida:
             from oggm.shop.glathida import compile_glathida_statistics
-            opath = os.path.join(sum_dir, 'glathida_statistics_{}.csv'.format(rgi_reg))
+            opath = sum_dir / f'glathida_statistics_{rgi_reg}.csv'
             compile_glathida_statistics(gdirs, path=opath)
 
         # And for level 2: shapes
         if len(gdirs_cent) > 0:
-            opath = os.path.join(sum_dir, f'centerlines_{rgi_reg}.shp')
+            opath = sum_dir / f'centerlines_{rgi_reg}.shp'
             utils.write_centerlines_to_shape(gdirs_cent, to_tar=True,
                                              path=opath)
-            opath = os.path.join(sum_dir, f'centerlines_smoothed_{rgi_reg}.shp')
+            opath = sum_dir / f'centerlines_smoothed_{rgi_reg}.shp'
             utils.write_centerlines_to_shape(gdirs_cent, to_tar=True,
                                              ensure_exterior_match=True,
                                              simplify_line_before=0.75,
                                              corner_cutting=3,
                                              path=opath)
-            opath = os.path.join(sum_dir, f'flowlines_{rgi_reg}.shp')
+            opath = sum_dir / f'flowlines_{rgi_reg}.shp'
             utils.write_centerlines_to_shape(gdirs_cent, to_tar=True,
                                              flowlines_output=True,
                                              path=opath)
-            opath = os.path.join(sum_dir, f'geom_widths_{rgi_reg}.shp')
+            opath = sum_dir / f'geom_widths_{rgi_reg}.shp'
             utils.write_centerlines_to_shape(gdirs_cent, to_tar=True,
                                              geometrical_widths_output=True,
                                              path=opath)
-            opath = os.path.join(sum_dir, f'widths_{rgi_reg}.shp')
+            opath = sum_dir / f'widths_{rgi_reg}.shp'
             utils.write_centerlines_to_shape(gdirs_cent, to_tar=True,
                                              corrected_widths_output=True,
                                              path=opath)
 
         # L2 OK - compress all in output directory
         log.workflow('L2 done. Writing to tar...')
-        level_base_dir = os.path.join(output_base_dir, 'L2')
+        level_base_dir = Path(output_base_dir) / 'L2'
         workflow.execute_entity_task(utils.gdir_to_tar, gdirs, delete=False,
                                      base_dir=level_base_dir)
         utils.base_dir_to_tar(level_base_dir)
@@ -719,7 +720,7 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
 
     # L3 - Tasks
     if start_level <= 2:
-        sum_dir = os.path.join(output_base_dir, 'L3', 'summary')
+        sum_dir = Path(output_base_dir) / 'L3' / 'summary'
         utils.mkdir(sum_dir)
 
         # Climate
@@ -821,24 +822,24 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
                 log.workflow('L3: for map border values < 20, wont initialize glaciers '
                              'for the run.')
         # Glacier stats
-        opath = os.path.join(sum_dir, 'glacier_statistics_{}.csv'.format(rgi_reg))
+        opath = sum_dir / f'glacier_statistics_{rgi_reg}.csv'
         utils.compile_glacier_statistics(gdirs, path=opath)
 
         # Export thickness to GeoTIFF if requested
         if add_export_thickness_geotiff and add_distributed_thickness:
-            thickness_dir = os.path.join(sum_dir, 'distributed_thickness')
+            thickness_dir = sum_dir / 'distributed_thickness'
             utils.mkdir(thickness_dir)
             workflow.execute_entity_task(tasks.gridded_data_var_to_geotiff, gdirs,
                                          varname='distributed_thickness',
                                          output_folder=thickness_dir)
-        opath = os.path.join(sum_dir, 'climate_statistics_{}.csv'.format(rgi_reg))
+        opath = sum_dir / f'climate_statistics_{rgi_reg}.csv'
         utils.compile_climate_statistics(gdirs, path=opath)
-        opath = os.path.join(sum_dir, 'fixed_geometry_mass_balance_{}.csv'.format(rgi_reg))
+        opath = sum_dir / f'fixed_geometry_mass_balance_{rgi_reg}.csv'
         utils.compile_fixed_geometry_mass_balance(gdirs, path=opath)
 
         # L3 OK - compress all in output directory
         log.workflow('L3 done. Writing to tar...')
-        level_base_dir = os.path.join(output_base_dir, 'L3')
+        level_base_dir = Path(output_base_dir) / 'L3'
         workflow.execute_entity_task(utils.gdir_to_tar, gdirs, delete=False,
                                      base_dir=level_base_dir)
         utils.base_dir_to_tar(level_base_dir)
@@ -855,14 +856,14 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
 
     # L4 - Tasks (add historical runs (old default) and dynamic spinup runs)
     if start_level <= 3:
-        sum_dir = os.path.join(output_base_dir, 'L4', 'summary')
+        sum_dir = Path(output_base_dir) / 'L4' / 'summary'
         utils.mkdir(sum_dir)
 
         # Copy L3 files for consistency
         for bn in ['glacier_statistics', 'climate_statistics',
                    'fixed_geometry_mass_balance']:
             if start_level <= 2:
-                ipath = os.path.join(sum_dir_L3, bn + '_{}.csv'.format(rgi_reg))
+                ipath = sum_dir_L3 / f'{bn}_{rgi_reg}.csv'
             else:
                 ipath = file_downloader(os.path.join(
                     get_prepro_base_url(base_url=start_base_url,
@@ -870,7 +871,7 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
                                         prepro_level=start_level), 'summary',
                     bn + '_{}.csv'.format(rgi_reg)))
 
-            opath = os.path.join(sum_dir, bn + '_{}.csv'.format(rgi_reg))
+            opath = sum_dir / f'{bn}_{rgi_reg}.csv'
             shutil.copyfile(ipath, opath)
 
         # Get end date. The first gdir might have blown up, try some others
@@ -892,7 +893,7 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
                                      min_ys=y0, ye=ye,
                                      output_filesuffix='_historical')
         # Now compile the output
-        opath = os.path.join(sum_dir, f'historical_run_output_{rgi_reg}.nc')
+        opath = Path(sum_dir) / f'historical_run_output_{rgi_reg}.nc'
         utils.compile_run_output(gdirs, path=opath, input_filesuffix='_historical')
 
         # conduct dynamic spinup if wanted
@@ -919,20 +920,20 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
                                           },
                 output_filesuffix='_spinup_historical',)
             # Now compile the output
-            opath = os.path.join(sum_dir, f'spinup_historical_run_output_{rgi_reg}.nc')
+            opath = sum_dir / f'spinup_historical_run_output_{rgi_reg}.nc'
             utils.compile_run_output(gdirs, path=opath,
                                      input_filesuffix='_spinup_historical')
 
         # Glacier statistics we recompute here for error analysis
-        opath = os.path.join(sum_dir, 'glacier_statistics_{}.csv'.format(rgi_reg))
+        opath = sum_dir / f'glacier_statistics_{rgi_reg}.csv'
         utils.compile_glacier_statistics(gdirs, path=opath)
 
         # Add the extended files
-        pf = os.path.join(sum_dir, 'historical_run_output_{}.nc'.format(rgi_reg))
+        pf = sum_dir / f'historical_run_output_{rgi_reg}.nc'
         # We have copied the files above
-        mf = os.path.join(sum_dir, 'fixed_geometry_mass_balance_{}.csv'.format(rgi_reg))
-        sf = os.path.join(sum_dir, 'glacier_statistics_{}.csv'.format(rgi_reg))
-        opath = os.path.join(sum_dir, 'historical_run_output_extended_{}.nc'.format(rgi_reg))
+        mf = sum_dir / f'fixed_geometry_mass_balance_{rgi_reg}.csv'
+        sf = sum_dir / f'glacier_statistics_{rgi_reg}.csv'
+        opath = sum_dir / f'historical_run_output_extended_{rgi_reg}.nc'
         utils.extend_past_climate_run(past_run_file=pf,
                                       fixed_geometry_mb_file=mf,
                                       glacier_statistics_file=sf,
@@ -940,7 +941,7 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
 
         # L4 OK - compress all in output directory
         log.workflow('L4 done. Writing to tar...')
-        level_base_dir = os.path.join(output_base_dir, 'L4')
+        level_base_dir = Path(output_base_dir) / 'L4'
         workflow.execute_entity_task(utils.gdir_to_tar, gdirs, delete=False,
                                      base_dir=level_base_dir)
         utils.base_dir_to_tar(level_base_dir)
@@ -952,7 +953,7 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
             return
 
     # L5 - No tasks: make the dirs small
-    sum_dir = os.path.join(output_base_dir, 'L5', 'summary')
+    sum_dir = Path(output_base_dir) / 'L5' / 'summary'
     utils.mkdir(sum_dir)
 
     # Copy L4 files for consistency
@@ -965,27 +966,30 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
         files_suffixes.append('nc')
     for bn, suffix in zip(files_to_copy, files_suffixes):
         if start_level <= 3:
-            ipath = os.path.join(sum_dir_L4, bn + f'_{rgi_reg}.{suffix}')
+            ipath = sum_dir_L4 / f'{bn}_{rgi_reg}.{suffix}'
         else:
             ipath = file_downloader(os.path.join(
                 get_prepro_base_url(base_url=start_base_url,
                                     rgi_version=rgi_version, border=border,
                                     prepro_level=start_level), 'summary',
-                bn + f'_{rgi_reg}.{suffix}'))
-        opath = os.path.join(sum_dir, bn + f'_{rgi_reg}.{suffix}')
+                f'{bn}_{rgi_reg}.{suffix}'))
+        opath = sum_dir / f'{bn}_{rgi_reg}.{suffix}'
         shutil.copyfile(ipath, opath)
 
     # Copy mini data to new dir
-    mini_base_dir = os.path.join(working_dir, 'mini_perglacier',
-                                 'RGI{}'.format(rgi_version),
-                                 'b_{:03d}'.format(border))
+    mini_base_dir = (
+        Path(working_dir)
+        / 'mini_perglacier'
+        / f'RGI{rgi_version}'
+        / f'b_{border:03d}'
+    )
     mini_gdirs = workflow.execute_entity_task(tasks.copy_to_basedir, gdirs,
                                               base_dir=mini_base_dir,
                                               setup='run/spinup')
 
     # L5 OK - compress all in output directory
     log.workflow('L5 done. Writing to tar...')
-    level_base_dir = os.path.join(output_base_dir, 'L5')
+    level_base_dir = Path(output_base_dir) / 'L5'
     workflow.execute_entity_task(utils.gdir_to_tar, mini_gdirs, delete=False,
                                  base_dir=level_base_dir)
     utils.base_dir_to_tar(level_base_dir)

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -603,86 +603,96 @@ class TestWorkflowUtils:
         check_result(ds_2)
 
 
-class TestStartFromTar(unittest.TestCase):
+class TestStartFromTar:
 
-    def setUp(self):
-        # test directory
-        self.testdir = os.path.join(get_test_dir(), 'tmp_tar_tools')
+    @pytest.fixture(autouse=True)
+    def setup(self, tmpdir_factory):
 
+        working_dir = tmpdir_factory.mktemp("tmp_tar_tools")
         # Init
         cfg.initialize()
-        cfg.set_intersects_db(utils.get_demo_file('rgi_intersect_oetztal.shp'))
+        cfg.PATHS["working_dir"] = working_dir
+        cfg.set_intersects_db(utils.get_demo_file("rgi_intersect_oetztal.shp"))
 
         # Read in the RGI file
-        rgi_file = utils.get_demo_file('rgi_oetztal.shp')
+        rgi_file = utils.get_demo_file("rgi_oetztal.shp")
         rgidf = gpd.read_file(rgi_file)
-        rgidf = rgidf.loc[['_d0' not in d for d in rgidf.RGIId]].copy()
+        rgidf = rgidf.loc[["_d0" not in d for d in rgidf.RGIId]].copy()
         self.rgidf = rgidf.sample(4)
-        cfg.PATHS['dem_file'] = utils.get_demo_file('srtm_oetztal.tif')
-        cfg.PATHS['working_dir'] = self.testdir
-        self.clean_dir()
+        cfg.PATHS["dem_file"] = utils.get_demo_file("srtm_oetztal.tif")
+        utils.mkdir(working_dir, reset=True)
 
-    def tearDown(self):
-        self.rm_dir()
-
-    def rm_dir(self):
-        shutil.rmtree(self.testdir)
-
-    def clean_dir(self):
-        utils.mkdir(self.testdir, reset=True)
+    def test_setup(self):
+        assert hasattr(self, "rgidf")
+        assert len(self.rgidf) == 4
+        assert os.path.exists(cfg.PATHS["dem_file"])
+        assert os.path.exists(cfg.PATHS["working_dir"])
 
     @pytest.mark.slow
-    def test_to_and_from_tar(self):
+    @pytest.mark.parametrize("arg_bundle_size", [1000, 100])
+    def test_to_and_from_tar(self, arg_bundle_size):
 
         # Go - initialize working directories
         gdirs = workflow.init_glacier_directories(self.rgidf)
-        workflow.execute_entity_task([tasks.define_glacier_region, utils.gdir_to_tar],
-                                     gdirs)
+        workflow.execute_entity_task(
+            [tasks.define_glacier_region, utils.gdir_to_tar], gdirs
+        )
 
         # Test - reopen form tar
-        gdirs = workflow.init_glacier_directories(self.rgidf, from_tar=True,
-                                                  delete_tar=True)
+        gdirs = workflow.init_glacier_directories(
+            self.rgidf, from_tar=True, delete_tar=True
+        )
         for gdir in gdirs:
-            assert gdir.has_file('dem')
-            assert not os.path.exists(gdir.dir + '.tar.gz')
-        workflow.execute_entity_task([tasks.glacier_masks, utils.gdir_to_tar], gdirs)
+            assert gdir.has_file("dem")
+            assert not os.path.exists(gdir.dir + ".tar.gz")
+        workflow.execute_entity_task(
+            [tasks.glacier_masks, utils.gdir_to_tar], gdirs
+        )
 
         gdirs = workflow.init_glacier_directories(self.rgidf, from_tar=True)
         for gdir in gdirs:
-            assert gdir.has_file('gridded_data')
-            assert os.path.exists(gdir.dir + '.tar.gz')
+            assert gdir.has_file("gridded_data")
+            assert os.path.exists(gdir.dir + ".tar.gz")
 
     @pytest.mark.slow
-    def test_to_and_from_basedir_tar(self):
+    @pytest.mark.parametrize("arg_bundle_size", [1000, 100])
+    def test_to_and_from_basedir_tar(self, arg_bundle_size):
+
+        test_dir = cfg.PATHS["working_dir"]
 
         # Go - initialize working directories
         gdirs = workflow.init_glacier_directories(self.rgidf)
-        workflow.execute_entity_task([tasks.define_glacier_region, utils.gdir_to_tar],
-                                     gdirs)
+        workflow.execute_entity_task(
+            [tasks.define_glacier_region, utils.gdir_to_tar], gdirs
+        )
         # End - compress all
-        utils.base_dir_to_tar()
+        utils.base_dir_to_tar(bundle_size=arg_bundle_size)
 
-        # Test - reopen form tar
+        # Test - reopen from tar
         gdirs = workflow.init_glacier_directories(self.rgidf, from_tar=True)
 
         for gdir in gdirs:
-            assert gdir.has_file('dem')
-            assert not os.path.exists(gdir.dir + '.tar.gz')
-        workflow.execute_entity_task([tasks.glacier_masks, utils.gdir_to_tar], gdirs)
-        utils.base_dir_to_tar()
+            assert gdir.has_file("dem")
+            assert not os.path.exists(gdir.dir + ".tar.gz")
+        workflow.execute_entity_task(
+            [tasks.glacier_masks, utils.gdir_to_tar], gdirs
+        )
+        utils.base_dir_to_tar(bundle_size=arg_bundle_size)
 
-        tar_dir = os.path.join(self.testdir, 'new_dir')
-        shutil.copytree(os.path.join(cfg.PATHS['working_dir'],
-                                     'per_glacier'), tar_dir)
+        tar_dir = os.path.join(test_dir, "new_dir")
+        shutil.copytree(
+            os.path.join(cfg.PATHS["working_dir"], "per_glacier"), tar_dir
+        )
 
         gdirs = workflow.init_glacier_directories(self.rgidf, from_tar=tar_dir)
         for gdir in gdirs:
-            assert gdir.has_file('gridded_data')
+            assert gdir.has_file("gridded_data")
 
     @pytest.mark.slow
     def test_to_and_from_tar_new_dir(self):
 
-        base_dir = os.path.join(self.testdir, 'new_base_dir')
+        test_dir = cfg.PATHS["working_dir"]
+        base_dir = os.path.join(test_dir, "new_base_dir")
 
         # Go - initialize working directories
         gdirs = workflow.init_glacier_directories(self.rgidf)
@@ -706,7 +716,8 @@ class TestStartFromTar(unittest.TestCase):
 
     def test_to_and_from_tar_string(self):
 
-        base_dir = os.path.join(self.testdir, 'new_base_dir')
+        test_dir = cfg.PATHS["working_dir"]
+        base_dir = os.path.join(test_dir, "new_base_dir")
         utils.mkdir(base_dir, reset=True)
 
         # Go - initialize working directories
@@ -716,8 +727,8 @@ class TestStartFromTar(unittest.TestCase):
             (utils.gdir_to_tar, {"base_dir": base_dir, "delete": False})],
             gdirs)
 
-        # Test - reopen form tar after copy
-        new_base_dir = os.path.join(self.testdir, 'newer_base_dir')
+        # Test - reopen from tar after copy
+        new_base_dir = os.path.join(test_dir, "newer_base_dir")
         utils.mkdir(new_base_dir, reset=True)
         for p, gdir in zip(paths, gdirs):
             assert base_dir in p
@@ -728,29 +739,25 @@ class TestStartFromTar(unittest.TestCase):
             assert new_base_dir in new_gdir.base_dir
 
 
-class TestStartFromV14(unittest.TestCase):
+class TestStartFromV14:
 
-    def setUp(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, tmpdir_factory):
+
         # test directory
-        self.testdir = os.path.join(get_test_dir(), 'tmp_prepro_tools')
-        self.dldir = os.path.join(get_test_dir(), 'dl_cache')
+        working_dir = tmpdir_factory.mktemp("tmp_prepro_tools")
+        self.test_dir = working_dir
+        self.dl_dir = working_dir / "dl_cache"
 
         # Init
         cfg.initialize()
-        cfg.PATHS['dl_cache_dir'] = self.dldir
-        cfg.PATHS['working_dir'] = self.testdir
+        cfg.PATHS["dl_cache_dir"] = self.dl_dir
+        cfg.PATHS["working_dir"] = self.test_dir
         self.clean_dir()
 
-    def tearDown(self):
-        self.rm_dir()
-
-    def rm_dir(self):
-        shutil.rmtree(self.testdir)
-        shutil.rmtree(self.dldir)
-
     def clean_dir(self):
-        utils.mkdir(self.testdir, reset=True)
-        utils.mkdir(self.dldir, reset=True)
+        utils.mkdir(self.test_dir, reset=True)
+        utils.mkdir(self.dl_dir, reset=True)
 
     def test_start_from_level_1(self):
 

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -843,21 +843,18 @@ def _read_shp():
     return inter, rgidf
 
 
-class TestPreproCLI(unittest.TestCase):
+class TestPreproCLI:
 
-    def setUp(self):
-        from _pytest.monkeypatch import MonkeyPatch
-        self.monkeypatch = MonkeyPatch()
-        self.testdir = os.path.join(get_test_dir(), 'tmp_prepro_levs')
-        self.reset_dir()
-        self.on_mac = platform.system() == 'Darwin'
+    on_mac = platform.system() == "Darwin"
+
+    @pytest.fixture(autouse=True)
+    def setup(self, tmpdir_factory):
+        self.testdir = tmpdir_factory.mktemp("tmp_prepro_levs")
+        utils.mkdir(self.testdir, reset=True)
 
     def tearDown(self):
         if os.path.exists(self.testdir):
             shutil.rmtree(self.testdir)
-
-    def reset_dir(self):
-        utils.mkdir(self.testdir, reset=True)
 
     def test_parse_args(self):
 
@@ -1733,9 +1730,9 @@ class TestPreproCLI(unittest.TestCase):
                               rgi_file=rgidf, intersects_file=inter,
                               start_level=2, max_level=4)
 
-    def test_source_run(self):
+    def test_source_run(self, monkeypatch):
 
-        self.monkeypatch.setattr(oggm.utils, 'DEM_SOURCES', ['USER'])
+        monkeypatch.setattr(oggm.utils, 'DEM_SOURCES', ['USER'])
 
         from oggm.cli.prepro_levels import run_prepro_levels
 

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -927,10 +927,6 @@ class TestPreproCLI:
         self.testdir = tmpdir_factory.mktemp("tmp_prepro_levs")
         utils.mkdir(self.testdir, reset=True)
 
-    def tearDown(self):
-        if os.path.exists(self.testdir):
-            shutil.rmtree(self.testdir)
-
     def test_parse_args(self):
 
         from oggm.cli import prepro_levels

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -883,6 +883,41 @@ def _read_shp():
     return inter, rgidf
 
 
+def test_get_prepro_gdir_bundle_cache(monkeypatch):
+    # On a legacy (1000-bundle) base_url, the first glacier probes the new
+    # 100-bundle url (404) then the old one; every subsequent glacier for the
+    # same url must skip the new-format probe.
+    from oggm.utils import _downloads
+
+    calls = []
+
+    def fake_file_downloader(www_path, **kwargs):
+        calls.append(www_path)
+        # legacy server: only the old 1000-glacier bundle exists
+        if www_path.endswith(".00.tar"):
+            return "/fake/RGI60-11.00.tar"
+        return None  # new-format url -> 404
+
+    monkeypatch.setattr(_downloads, "file_downloader", fake_file_downloader)
+    monkeypatch.setattr(_downloads, "_prepro_bundle_format", {})
+
+    base_url = "https://example.com/gdirs/"
+    kw = dict(rgi_version="62", border=80, prepro_level=2, base_url=base_url)
+    prefix = f"{base_url}RGI62/b_080/L2/RGI60-11/"
+
+    p1 = _downloads._get_prepro_gdir_unlocked(rgi_id="RGI60-11.00001", **kw)
+    p2 = _downloads._get_prepro_gdir_unlocked(rgi_id="RGI60-11.00002", **kw)
+
+    assert p1 == "/fake/RGI60-11.00.tar"
+    assert p2 == "/fake/RGI60-11.00.tar"
+    assert calls == [
+        f"{prefix}RGI60-11.000.tar",  # 1st glacier: new probe (404)
+        f"{prefix}RGI60-11.00.tar",   # 1st glacier: old fallback (hit)
+        f"{prefix}RGI60-11.00.tar",   # 2nd glacier: straight to old, no probe
+    ]
+    assert _downloads._prepro_bundle_format[f"{base_url}RGI62/b_080/L2/"] == "old"
+
+
 class TestPreproCLI:
 
     on_mac = platform.system() == "Darwin"

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -655,7 +655,7 @@ class TestStartFromTar:
             assert os.path.exists(gdir.dir + ".tar.gz")
 
     @pytest.mark.slow
-    @pytest.mark.parametrize("arg_bundle_size", [1000, 100])
+    @pytest.mark.parametrize("arg_bundle_size", [1000, 100, 10, 5])
     def test_to_and_from_basedir_tar(self, arg_bundle_size):
 
         test_dir = cfg.PATHS["working_dir"]
@@ -1755,8 +1755,14 @@ class TestPreproCLI(unittest.TestCase):
                           test_topofile=topof, dem_source='ALL')
 
         rid = rgidf.iloc[0].RGIId
-        tarf = os.path.join(odir, 'RGI61', 'b_020', 'L1',
-                            rid[:8], rid[:8] + '.00.tar')
+        tarf = os.path.join(
+            odir,
+            "RGI61",
+            "b_020",
+            "L1",
+            rid[:8],
+            rid[:8] + f".{rid[-5:-2]}.tar",  # bundle_size=100
+        )
         assert os.path.isfile(tarf)
 
         tarf = os.path.join(odir, 'RGI61', 'b_020', 'L1',

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -629,8 +629,7 @@ class TestStartFromTar:
         assert os.path.exists(cfg.PATHS["working_dir"])
 
     @pytest.mark.slow
-    @pytest.mark.parametrize("arg_bundle_size", [1000, 100])
-    def test_to_and_from_tar(self, arg_bundle_size):
+    def test_to_and_from_tar(self):
 
         # Go - initialize working directories
         gdirs = workflow.init_glacier_directories(self.rgidf)
@@ -655,7 +654,7 @@ class TestStartFromTar:
             assert os.path.exists(gdir.dir + ".tar.gz")
 
     @pytest.mark.slow
-    @pytest.mark.parametrize("arg_bundle_size", [1000, 100, 10, 5])
+    @pytest.mark.parametrize("arg_bundle_size", [1000, 100])
     def test_to_and_from_basedir_tar(self, arg_bundle_size):
 
         test_dir = cfg.PATHS["working_dir"]
@@ -687,6 +686,47 @@ class TestStartFromTar:
         gdirs = workflow.init_glacier_directories(self.rgidf, from_tar=tar_dir)
         for gdir in gdirs:
             assert gdir.has_file("gridded_data")
+
+    @pytest.mark.parametrize("bundle_size", [100, 1000])
+    @pytest.mark.parametrize("rgi_ids", [
+        ["RGI60-11.00001", "RGI60-11.00099", "RGI60-11.00100"],
+        ["RGI2000-v7.0-G-01-00001", "RGI2000-v7.0-G-01-00099",
+         "RGI2000-v7.0-G-01-00100"],
+    ], ids=["RGI6", "RGI7"])
+    def test_bundle_tar_roundtrip(self, bundle_size, rgi_ids):
+        # Path-level round-trip of base_dir_to_tar + robust_tar_extract for
+        # both RGI6 and RGI7 IDs and both bundle sizes. Uses synthetic glacier
+        # tars so it needs no glacier data and runs fast.
+        base_dir = os.path.join(cfg.PATHS["working_dir"], "per_glacier")
+
+        def make_fake_gdir_tar(rgi_id):
+            # mirror gdir_to_tar: <region>/<subregion>/<rgi_id>.tar.gz holding
+            # <rgi_id>/dummy.txt
+            gdir_dir = os.path.join(base_dir, rgi_id[:-6], rgi_id[:-3], rgi_id)
+            utils.mkdir(gdir_dir)
+            with open(os.path.join(gdir_dir, "dummy.txt"), "w") as f:
+                f.write(rgi_id)
+            with tarfile.open(gdir_dir + ".tar.gz", "w:gz") as tar:
+                tar.add(gdir_dir, arcname=rgi_id)
+            shutil.rmtree(gdir_dir)
+
+        for rid in rgi_ids:
+            make_fake_gdir_tar(rid)
+
+        utils.base_dir_to_tar(base_dir, bundle_size=bundle_size)
+
+        for rid in rgi_ids:
+            # the path GlacierDirectory(from_tar=True) constructs
+            from_tar = os.path.join(base_dir, rid[:-6], rid[:-3],
+                                    rid + ".tar.gz")
+            to_dir = os.path.join(cfg.PATHS["working_dir"], "extracted", rid)
+            utils.mkdir(os.path.dirname(to_dir))
+            utils.robust_tar_extract(from_tar, to_dir)
+            assert os.path.exists(os.path.join(to_dir, "dummy.txt"))
+
+    def test_base_dir_to_tar_bad_bundle_size(self):
+        with pytest.raises(utils.InvalidParamsError):
+            utils.base_dir_to_tar(cfg.PATHS["working_dir"], bundle_size=10)
 
     @pytest.mark.slow
     def test_to_and_from_tar_new_dir(self):

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -1148,21 +1148,45 @@ def get_prepro_base_url(base_url=None, rgi_version=None, border=None,
     return url
 
 
-def _get_prepro_gdir_unlocked(rgi_version, rgi_id, border, prepro_level,
-                              base_url=None):
+def _get_prepro_gdir_unlocked(
+    rgi_version: str,
+    rgi_id: str,
+    border: int,
+    prepro_level,
+    base_url: str = None,
+) -> str:
 
-    url = get_prepro_base_url(rgi_version=rgi_version, border=border,
-                              prepro_level=prepro_level, base_url=base_url)
+    url = get_prepro_base_url(
+        rgi_version=rgi_version,
+        border=border,
+        prepro_level=prepro_level,
+        base_url=base_url,
+    )
     if len(rgi_id) == 23:
         # RGI7
-        url += '{}/{}.tar'.format(rgi_id[:17], rgi_id[:20])
+        url += "{}/{}.tar".format(rgi_id[:17], rgi_id[:20])
+        tar_base = file_downloader(url)
+        if tar_base is None:
+            raise RuntimeError("Could not find file at " + url)
+        return tar_base
     else:
-        url += '{}/{}.tar'.format(rgi_id[:8], rgi_id[:11])
-    tar_base = file_downloader(url)
-    if tar_base is None:
-        raise RuntimeError('Could not find file at ' + url)
+        # TODO: add support for bundle sizes of 10 and 1
+        # try new 3-digit suffix first, fall back to old 2-digit suffix
+        # for legacy base_urls
+        new_bundle = rgi_id[:-6] + "." + rgi_id[-5:-2]  # e.g. RGI60-07.000
+        try:
+            tar_base = file_downloader(f"{url}{rgi_id[:8]}/{new_bundle}.tar")
+            if tar_base is not None:
+                return tar_base
+        except InvalidParamsError:
+            # if new format URL not in allowlist then fall back
+            pass
+        old_url = f"{url}{rgi_id[:8]}/{rgi_id[:11]}.tar"
+        tar_base = file_downloader(old_url)
+        if tar_base is None:
+            raise RuntimeError(f"Could not find file at {old_url}")
 
-    return tar_base
+        return tar_base
 
 
 def get_geodetic_mb_dataframe(file_path=None, regional=False):

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -1162,31 +1162,31 @@ def _get_prepro_gdir_unlocked(
         prepro_level=prepro_level,
         base_url=base_url,
     )
-    if len(rgi_id) == 23:
-        # RGI7
-        url += "{}/{}.tar".format(rgi_id[:17], rgi_id[:20])
-        tar_base = file_downloader(url)
-        if tar_base is None:
-            raise RuntimeError("Could not find file at " + url)
-        return tar_base
-    else:
-        # TODO: add support for bundle sizes of 10 and 1
-        # try new 3-digit suffix first, fall back to old 2-digit suffix
-        # for legacy base_urls
-        new_bundle = rgi_id[:-6] + "." + rgi_id[-5:-2]  # e.g. RGI60-07.000
-        try:
-            tar_base = file_downloader(f"{url}{rgi_id[:8]}/{new_bundle}.tar")
-            if tar_base is not None:
-                return tar_base
-        except InvalidParamsError:
-            # if new format URL not in allowlist then fall back
-            pass
-        old_url = f"{url}{rgi_id[:8]}/{rgi_id[:11]}.tar"
-        tar_base = file_downloader(old_url)
-        if tar_base is None:
-            raise RuntimeError(f"Could not find file at {old_url}")
+    # The region dir, the new 100-glacier bundle name and the old
+    # 1000-glacier bundle name can all be derived from the RGI ID with the
+    # same slices for both RGI6 (14 char IDs) and RGI7 (23 char IDs), since
+    # the glacier number is always the last 5 characters of the ID.
+    # TODO: add support for bundle sizes of 10 and 1
+    region = rgi_id[:-6]                      # RGI60-07 / RGI2000-v7.0-G-01
+    new_bundle = f"{region}.{rgi_id[-5:-2]}"  # 100-bundle, e.g. RGI60-07.000
+    old_bundle = rgi_id[:-3]                  # 1000-bundle, e.g. RGI60-07.00
 
-        return tar_base
+    # Try the new 100-glacier bundle first, fall back to the old 1000-glacier
+    # bundle for legacy base_urls.
+    try:
+        tar_base = file_downloader(f"{url}{region}/{new_bundle}.tar")
+        if tar_base is not None:
+            return tar_base
+    except InvalidParamsError:
+        # if the new format URL is not in the allowlist then fall back
+        pass
+
+    old_url = f"{url}{region}/{old_bundle}.tar"
+    tar_base = file_downloader(old_url)
+    if tar_base is None:
+        raise RuntimeError(f"Could not find file at {old_url}")
+
+    return tar_base
 
 
 def get_geodetic_mb_dataframe(file_path=None, regional=False):

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -109,6 +109,12 @@ tuple2int = partial(np.array, dtype=np.int64)
 
 lock = None
 
+# Cache of the resolved bundle layout per prepro url: maps a resolved prepro
+# url to "new" (100-glacier bundles) or "old" (1000-glacier bundles), so we
+# don't re-probe (and 404) the new-format url for every glacier of a legacy
+# dataset. Populated only on a confirmed download (see _get_prepro_gdir_unlocked).
+_prepro_bundle_format = {}
+
 
 def mkdir(path, reset=False):
     """Checks if directory exists and if not, create one.
@@ -1171,21 +1177,37 @@ def _get_prepro_gdir_unlocked(
     new_bundle = f"{region}.{rgi_id[-5:-2]}"  # 100-bundle, e.g. RGI60-07.000
     old_bundle = rgi_id[:-3]                  # 1000-bundle, e.g. RGI60-07.00
 
-    # Try the new 100-glacier bundle first, fall back to the old 1000-glacier
-    # bundle for legacy base_urls.
-    try:
-        tar_base = file_downloader(f"{url}{region}/{new_bundle}.tar")
-        if tar_base is not None:
-            return tar_base
-    except InvalidParamsError:
-        # if the new format URL is not in the allowlist then fall back
-        pass
+    # The bundle layout (100- vs 1000-glacier) is uniform across a published
+    # prepro dataset, so once we have confirmed it for this url we go straight
+    # to the right file instead of re-probing (and 404-ing) the new-format url
+    # for every glacier. We only cache on a confirmed download: a bare 404 on
+    # the new-format url is ambiguous (legacy dataset vs. a glacier that is
+    # simply missing), so caching it could wrongly downgrade sibling glaciers.
+    fmt = _prepro_bundle_format.get(url)
+    new_url = f"{url}{region}/{new_bundle}.tar"
 
+    # Try the new 100-glacier bundle first, unless we already know this dataset
+    # is legacy.
+    if fmt in (None, "new"):
+        try:
+            tar_base = file_downloader(new_url)
+        except InvalidParamsError:
+            # new format URL not in allowlist -> fall back to the old layout
+            tar_base = None
+        if tar_base is not None:
+            _prepro_bundle_format[url] = "new"
+            return tar_base
+        if fmt == "new":
+            # confirmed new-format dataset, so this glacier is simply missing
+            raise RuntimeError(f"Could not find file at {new_url}")
+
+    # Fall back to the old 1000-glacier bundle for legacy base_urls.
     old_url = f"{url}{region}/{old_bundle}.tar"
     tar_base = file_downloader(old_url)
     if tar_base is None:
         raise RuntimeError(f"Could not find file at {old_url}")
 
+    _prepro_bundle_format[url] = "old"
     return tar_base
 
 

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -4268,12 +4268,16 @@ def base_dir_to_tar(
         bundles = {}
         for dirpath, _, filenames in os.walk(base_dir):
             for fname in sorted(filenames):
+                # TODO: Would this be easier/faster with pathlib?
                 if not fname.endswith(".tar.gz"):
                     continue
                 rgi_id = fname[:-7]
                 # TODO: RGI7 has a different ID length
                 # check for RGI, e.g. `centerlines_11` is also 14 chars long
-                if (len(rgi_id) != 14) or "RGI" not in rgi_id:
+                if not (
+                    (len(rgi_id) == 14 and "RGI" in rgi_id)
+                    or (len(rgi_id) == 23 and "RGI" in rgi_id)
+                ):
                     continue
                 # TODO: or maybe:
                 # bundle_name = f"{rgi_id[:-6]}.{int(rgi_id[-5:-2]) // bundle_size:03d}"

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -2646,8 +2646,9 @@ def robust_tar_extract(
             # 100-glacier bundle: RGI60-11.006.tar in the region dir
             # TODO: Really ought to consider switching to pathlib!
             rgi_id = bname[:-7]  # strip .tar.gz
-            # TODO: Check support for RGI7 as ids have a different length
-            if len(rgi_id) == 14:
+            # The bundle name slices work for both RGI6 (14 char IDs) and
+            # RGI7 (23 char IDs).
+            if len(rgi_id) in (14, 23):
                 dirbname = f"{rgi_id[:-6]}.{rgi_id[-5:-2]}"  # e.g. RGI60-11.006
                 region_dir = os.path.dirname(os.path.dirname(from_tar))
                 base_tar = os.path.join(region_dir, dirbname + ".tar")
@@ -4247,10 +4248,12 @@ def base_dir_to_tar(
     delete : bool
         Delete the original directory tars afterwards (default)
     bundle_size : int, default 100
-        Groups individual glacier .tar.gz files (from gdir_to_tar)
-        into bundles using a name derived from each glacier's RGI ID,
-        e.g. RGI60-07.000 contains glaciers 00001-00099. Currently only
-        RGI6 IDs are supported, and RGI7 is silently skipped.
+        Size of the glacier bundles to create. Must be either 100 (the new
+        default, which makes for faster downloads) or 1000 (the legacy
+        layout). With 100, the individual glacier .tar.gz files (from
+        gdir_to_tar) are grouped into bundles named from each glacier's RGI
+        ID, e.g. RGI60-07.000 contains glaciers 00000-00099. Both RGI6 and
+        RGI7 IDs are supported.
     """
 
     if base_dir is None:
@@ -4258,35 +4261,37 @@ def base_dir_to_tar(
             raise ValueError("Need a valid PATHS['working_dir']!")
         base_dir = os.path.join(cfg.PATHS["working_dir"], "per_glacier")
 
-    # TODO: get index based on the number of tens in repackage_index, e.g. 100 -> 2, 1000 -> 3, etc.
-    # index = int(np.log10(bundle_size))
+    # The read side (robust_tar_extract, gdir_from_tar, _get_prepro_gdir)
+    # only knows how to locate 100- and 1000-glacier bundles, so reject
+    # anything else rather than silently producing unreadable bundles.
+    if bundle_size not in (100, 1000):
+        raise InvalidParamsError(
+            "bundle_size must be 100 or 1000, got {}".format(bundle_size)
+        )
 
-    if bundle_size != 1000:  # stick with the established default if 1000
-        # RGI60-01.000
-        # region_dir is derived from the walk so it's correct regardless
-        # of whether base_dir points to working_dir or per_glacier directly.
+    if bundle_size == 100:
+        # Group the glacier .tar.gz files into 100-glacier bundles named from
+        # the RGI ID, e.g. RGI60-07.000 holds glaciers 00000-00099. The slices
+        # below work for both RGI6 (14 char IDs) and RGI7 (23 char IDs).
+        # region_dir is derived from the walk so it's correct regardless of
+        # whether base_dir points to working_dir or per_glacier directly.
         bundles = {}
+        src_dirs = set()
         for dirpath, _, filenames in os.walk(base_dir):
             for fname in sorted(filenames):
-                # TODO: Would this be easier/faster with pathlib?
                 if not fname.endswith(".tar.gz"):
                     continue
                 rgi_id = fname[:-7]
-                # TODO: RGI7 has a different ID length
-                # check for RGI, e.g. `centerlines_11` is also 14 chars long
-                if not (
-                    (len(rgi_id) == 14 and "RGI" in rgi_id)
-                    or (len(rgi_id) == 23 and "RGI" in rgi_id)
-                ):
+                # check for a valid RGI ID, e.g. `centerlines_11` is also
+                # 14 chars long but is not an RGI ID
+                if not (len(rgi_id) in (14, 23) and "RGI" in rgi_id):
                     continue
-                # TODO: or maybe:
-                # bundle_name = f"{rgi_id[:-6]}.{int(rgi_id[-5:-2]) // bundle_size:03d}"
-                # this is quite brittle, non-standard filenames could slip through
                 bundle_name = f"{rgi_id[:-6]}.{rgi_id[-5:-2]}"
                 region_dir = os.path.dirname(dirpath)
                 if bundle_name not in bundles:
                     bundles[bundle_name] = (region_dir, [])
                 bundles[bundle_name][1].append(os.path.join(dirpath, fname))
+                src_dirs.add(dirpath)
 
         to_delete = []
         for bundle_name, (region_dir, tar_paths) in sorted(bundles.items()):
@@ -4305,6 +4310,12 @@ def base_dir_to_tar(
 
         for tp in to_delete:
             os.remove(tp)
+        if delete:
+            # Remove the now-empty subregion directories left behind, to match
+            # the 1000-bundle behavior which removes the source dirs.
+            for d in src_dirs:
+                if os.path.isdir(d) and not os.listdir(d):
+                    os.rmdir(d)
         return
 
     to_delete = []

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -945,7 +945,7 @@ class compile_to_netcdf(object):
     """
 
     def __init__(self, log):
-        """Decorator syntax: ``@compile_to_netcdf(log, n_tmp_files=1000)``
+        """Decorator syntax: ``@compile_to_netcdf(log, n_tmp_files=100)``
 
         Parameters
         ----------
@@ -963,7 +963,7 @@ class compile_to_netcdf(object):
         def _compile_to_netcdf(gdirs, input_filesuffix='',
                                output_filesuffix='',
                                path=True,
-                               tmp_file_size=1000,
+                               tmp_file_size=100,
                                **kwargs):
 
             if not output_filesuffix:
@@ -1827,7 +1827,7 @@ def _write_fl_diagnostics(gdir, input_filesuffix='', folder_map=None):
 @global_task(log)
 def compile_fl_diagnostics(gdirs, *,
                            path=True,
-                           group_size=1000,
+                           group_size=100,
                            input_filesuffix='',
                            compress=True,
                            delete_folders=False):
@@ -4202,7 +4202,7 @@ def gdir_to_tar(gdir, base_dir=None, delete=True):
 
 
 def base_dir_to_tar(base_dir=None, delete=True):
-    """Merge the directories into 1000 bundles as tar files.
+    """Merge the directories into 100 bundles as tar files.
 
     The tar file is located at the same location of the original directory.
 

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -797,22 +797,27 @@ def get_centerline_lonlat(gdir,
     return olist
 
 
-def _write_shape_to_disk(gdf, fpath, to_tar=False):
-    """Write a shapefile to disk with optional compression
+def _write_shape_to_disk(
+    gdf: gpd.GeoDataFrame, fpath: str | Path, to_tar: bool = False
+) -> None:
+    """Write a shapefile to disk with optional compression.
 
     Parameters
     ----------
     gdf : gpd.GeoDataFrame
-        the data to write
-    fpath : str
-        where to writ the file - should be ending in shp
-    to_tar : bool
-        put the files in a .tar file. If cfg.PARAMS['use_compression'],
-        also compress to .gz
+        The data to write
+    fpath : str or Path
+        Where to write the file - should end with .shp
+    to_tar : bool, default False
+        Put the files in a `.tar` file.
+        If `cfg.PARAMS['use_compression']`, also compress to .gz
     """
 
-    if '.shp' not in fpath:
-        raise ValueError('File ending should be .shp')
+    if isinstance(fpath, Path):
+        fpath = str(fpath)
+
+    if not fpath.endswith(".shp"):
+        raise ValueError("File ending should be .shp")
 
     with warnings.catch_warnings():
         warnings.filterwarnings('ignore', 'GeoSeries.notna', UserWarning)
@@ -900,9 +905,11 @@ def write_centerlines_to_shape(gdirs, *, path=True, to_tar=False,
     """
     from oggm.workflow import execute_entity_task
 
-    if path is True:
-        path = os.path.join(cfg.PATHS['working_dir'],
-                            'glacier_centerlines' + filesuffix + '.shp')
+    if isinstance(path, bool) and path:
+        path = os.path.join(
+            cfg.PATHS["working_dir"],
+            "glacier_centerlines" + filesuffix + ".shp",
+        )
 
     _to_crs = salem.check_crs(to_crs)
     if not _to_crs:
@@ -4264,13 +4271,13 @@ def base_dir_to_tar(
                 if not fname.endswith(".tar.gz"):
                     continue
                 rgi_id = fname[:-7]
-                if (
-                    len(rgi_id) != 14
-                ):  # RGI6 only, RGI7 has a different ID length
+                # TODO: RGI7 has a different ID length
+                # check for RGI, e.g. `centerlines_11` is also 14 chars long
+                if (len(rgi_id) != 14) or "RGI" not in rgi_id:
                     continue
                 # TODO: or maybe:
                 # bundle_name = f"{rgi_id[:-6]}.{int(rgi_id[-5:-2]) // bundle_size:03d}"
-                bundle_name = rgi_id[:-6] + "." + rgi_id[-5:-2]
+                # this is quite brittle, non-standard filenames could slip through
                 bundle_name = f"{rgi_id[:-6]}.{rgi_id[-5:-2]}"
                 region_dir = os.path.dirname(dirpath)
                 if bundle_name not in bundles:

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -25,6 +25,7 @@ import platform
 import struct
 import importlib
 import re as regexp
+from pathlib import Path
 
 # External libs
 import pandas as pd
@@ -2611,25 +2612,47 @@ def _robust_extract(to_dir, *args, **kwargs):
     _back_up_retry(func, FileExistsError)
 
 
-def robust_tar_extract(from_tar, to_dir, delete_tar=False):
-    """Extract a tar file - also checks for a "tar in tar" situation"""
+def robust_tar_extract(
+    from_tar: str, to_dir: str, delete_tar: bool = False
+) -> None:
+    """Extract a tar file - also checks for a "tar in tar" situation.
+
+    Parameters
+    ----------
+    from_tar : str
+        Path to the tar file to extract.
+    to_dir : str
+        Path to the directory where to extract the tar file.
+    delete_tar : bool, default False
+        Whether to delete the tar file after extraction.
+    """
 
     if os.path.isfile(from_tar):
-        _robust_extract(to_dir, from_tar, 'r')
+        _robust_extract(to_dir, from_tar, "r")
     else:
         # maybe a tar in tar
-        base_tar = os.path.dirname(from_tar) + '.tar'
-        if not os.path.isfile(base_tar):
-            raise FileNotFoundError('Could not find a tarfile with path: '
-                                    '{}'.format(from_tar))
-        if delete_tar:
-            raise InvalidParamsError('Cannot delete tar in tar.')
-        # Open the tar
         bname = os.path.basename(from_tar)
+        # 1000-glacier bundles: subregion dir is tarred
+        base_tar = os.path.dirname(from_tar) + ".tar"
         dirbname = os.path.basename(os.path.dirname(from_tar))
+        if not os.path.isfile(base_tar):
+            # 100-glacier bundle: RGI60-11.006.tar in the region dir
+            # TODO: Really ought to consider switching to pathlib!
+            rgi_id = bname[:-7]  # strip .tar.gz
+            # TODO: Check support for RGI7 as ids have a different length
+            if len(rgi_id) == 14:
+                dirbname = f"{rgi_id[:-6]}.{rgi_id[-5:-2]}"  # e.g. RGI60-11.006
+                region_dir = os.path.dirname(os.path.dirname(from_tar))
+                base_tar = os.path.join(region_dir, dirbname + ".tar")
+        if not os.path.isfile(base_tar):
+            raise FileNotFoundError(
+                f"Could not find a tarfile with path: {from_tar}"
+            )
+        if delete_tar:
+            raise InvalidParamsError("Cannot delete tar in tar.")
 
         def func():
-            with tarfile.open(base_tar, 'r') as tf:
+            with tarfile.open(base_tar, "r") as tf:
                 i_from_tar = tf.getmember(os.path.join(dirbname, bname))
                 with tf.extractfile(i_from_tar) as fileobj:
                     _robust_extract(to_dir, fileobj=fileobj)
@@ -4201,37 +4224,90 @@ def gdir_to_tar(gdir, base_dir=None, delete=True):
     return opath
 
 
-def base_dir_to_tar(base_dir=None, delete=True):
-    """Merge the directories into 100 bundles as tar files.
+def base_dir_to_tar(
+    base_dir: Path | str | None = None,
+    delete: bool = True,
+    bundle_size: int = 100,
+) -> None:
+    """Merge the directories into tar bundle files.
 
     The tar file is located at the same location of the original directory.
 
     Parameters
     ----------
-    base_dir : str
-        path to the basedir to parse (defaults to the working directory)
-    to_base_dir : str
-        path to the basedir where to write the directory (defaults to the
-        same location of the original directory)
+    base_dir : Path | str | None
+        Path to the basedir to parse (defaults to the working directory)
     delete : bool
-        delete the original directory tars afterwards (default)
+        Delete the original directory tars afterwards (default)
+    bundle_size : int, default 100
+        Groups individual glacier .tar.gz files (from gdir_to_tar)
+        into bundles using a name derived from each glacier's RGI ID,
+        e.g. RGI60-07.000 contains glaciers 00001-00099. Currently only
+        RGI6 IDs are supported, and RGI7 is silently skipped.
     """
 
     if base_dir is None:
-        if not cfg.PATHS.get('working_dir', None):
+        if not cfg.PATHS.get("working_dir", None):
             raise ValueError("Need a valid PATHS['working_dir']!")
-        base_dir = os.path.join(cfg.PATHS['working_dir'], 'per_glacier')
+        base_dir = os.path.join(cfg.PATHS["working_dir"], "per_glacier")
+
+    # TODO: get index based on the number of tens in repackage_index, e.g. 100 -> 2, 1000 -> 3, etc.
+    # index = int(np.log10(bundle_size))
+
+    if bundle_size != 1000:  # stick with the established default if 1000
+        # RGI60-01.000
+        # region_dir is derived from the walk so it's correct regardless
+        # of whether base_dir points to working_dir or per_glacier directly.
+        bundles = {}
+        for dirpath, _, filenames in os.walk(base_dir):
+            for fname in sorted(filenames):
+                if not fname.endswith(".tar.gz"):
+                    continue
+                rgi_id = fname[:-7]
+                if (
+                    len(rgi_id) != 14
+                ):  # RGI6 only, RGI7 has a different ID length
+                    continue
+                # TODO: or maybe:
+                # bundle_name = f"{rgi_id[:-6]}.{int(rgi_id[-5:-2]) // bundle_size:03d}"
+                bundle_name = rgi_id[:-6] + "." + rgi_id[-5:-2]
+                bundle_name = f"{rgi_id[:-6]}.{rgi_id[-5:-2]}"
+                region_dir = os.path.dirname(dirpath)
+                if bundle_name not in bundles:
+                    bundles[bundle_name] = (region_dir, [])
+                bundles[bundle_name][1].append(os.path.join(dirpath, fname))
+
+        to_delete = []
+        for bundle_name, (region_dir, tar_paths) in sorted(bundles.items()):
+            opath = os.path.join(region_dir, bundle_name + ".tar")
+            with tarfile.open(opath, "w") as tar:
+                for tp in sorted(tar_paths):
+                    # Store as bundle_name/file.tar.gz so robust_tar_extract
+                    # can locate the member via os.path.join(dirbname, bname)
+                    # Also ensures correct transfer between the download-cache
+                    tar.add(
+                        tp,
+                        arcname=os.path.join(bundle_name, os.path.basename(tp)),
+                    )
+            if delete:
+                to_delete.extend(tar_paths)
+
+        for tp in to_delete:
+            os.remove(tp)
+        return
 
     to_delete = []
     for dirname, subdirlist, filelist in os.walk(base_dir):
         # RGI60-01.00
         bname = os.path.basename(dirname)
         # second argument for RGI7 naming convention
-        if not ((len(bname) == 11 and bname[-3] == '.') or
-                (len(bname) == 20 and bname[-3] == '-')):
+        if not (
+            (len(bname) == 11 and bname[-3] == ".")
+            or (len(bname) == 20 and bname[-3] == "-")
+        ):
             continue
-        opath = dirname + '.tar'
-        with tarfile.open(opath, 'w') as tar:
+        opath = dirname + ".tar"
+        with tarfile.open(opath, "w") as tar:
             tar.add(dirname, arcname=os.path.basename(dirname))
         if delete:
             to_delete.append(dirname)

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -263,10 +263,13 @@ def gdir_from_tar(entity, from_tar):
     except AttributeError:
         rgi_id = entity
 
+    # The region dir, the new 100-glacier bundle name and the old
+    # 1000-glacier bundle name use the same slices for RGI6 and RGI7.
     # TODO: add support for bundle sizes of 10 and 1
-    new_bundle = rgi_id[:-6] + "." + rgi_id[-5:-2]
-    new_path = os.path.join(from_tar, rgi_id[:8], new_bundle + ".tar")
-    old_path = os.path.join(from_tar, rgi_id[:8], rgi_id[:11] + ".tar")
+    region = rgi_id[:-6]
+    new_bundle = f"{region}.{rgi_id[-5:-2]}"
+    new_path = os.path.join(from_tar, region, new_bundle + ".tar")
+    old_path = os.path.join(from_tar, region, rgi_id[:-3] + ".tar")
     if os.path.exists(new_path):
         from_tar = new_path
     elif os.path.exists(old_path):

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -263,10 +263,19 @@ def gdir_from_tar(entity, from_tar):
     except AttributeError:
         rgi_id = entity
 
-    from_tar = os.path.join(from_tar, '{}'.format(rgi_id[:8]),
-                            '{}.tar' .format(rgi_id[:11]))
-    assert os.path.exists(from_tar), 'tarfile does not exist'
-    from_tar = os.path.join(from_tar.replace('.tar', ''), rgi_id + '.tar.gz')
+    # TODO: add support for bundle sizes of 10 and 1
+    new_bundle = rgi_id[:-6] + "." + rgi_id[-5:-2]
+    new_path = os.path.join(from_tar, rgi_id[:8], new_bundle + ".tar")
+    old_path = os.path.join(from_tar, rgi_id[:8], rgi_id[:11] + ".tar")
+    if os.path.exists(new_path):
+        from_tar = new_path
+    elif os.path.exists(old_path):
+        from_tar = old_path
+    else:
+        raise FileNotFoundError(
+            "Cannot find bundle tar for {} in {}".format(rgi_id, from_tar)
+        )
+    from_tar = os.path.join(from_tar.replace(".tar", ""), rgi_id + ".tar.gz")
     return oggm.GlacierDirectory(entity, from_tar=from_tar)
 
 


### PR DESCRIPTION
<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->
Adds `bundle_size` argument to `base_dir_to_tar`, defaulting to 100.
Refactors `robust_tar_extract` and `gdir_from_tar` to be agnostic to bundle sizes, falling back to 1k bundles.
Refactors some tests into pytest-style.

Backwards compatible with existing `base_urls`, no breaking changes, and tested with the tutorial notebooks with both 1k and 100 glacier bundles for RGI6 & RGI7.

This means you can convert existing glacier directories like so:
```
gdirs = workflow.init_glacier_directories(rgi_ids, from_prepro_level=4, prepro_base_url=base_url)
workflow.execute_entity_task(utils.gdir_to_tar, gdirs, delete=True)
utils.base_dir_to_tar(WORKING_DIR, delete=True, bundle_size=100)
```
and upload the files. No need to regenerate the glacier directories.

Closes https://github.com/OGGM/oggm/issues/1902

- [x] Tests added/passed
- [x] Fully documented
- [x] Entry in `whats-new.rst` 
