### PR TITLE
use mass_kg for calculating dmdtda in dyanmic melt_f calibration

### DIFF
--- a/oggm/core/dynamic_spinup.py
+++ b/oggm/core/dynamic_spinup.py
@@ -1337,11 +1337,10 @@ def dynamic_melt_f_run_with_dynamic_spinup(
     with utils.DisableLogger():
         ds = utils.compile_run_output(gdir, input_filesuffix=output_filesuffix,
                                       path=False)
-    dmdtda_mdl = ((ds.volume.loc[yr1_ref_mb].values[0] -
-                   ds.volume.loc[yr0_ref_mb].values[0]) /
+    dmdtda_mdl = ((ds.mass_kg.loc[yr1_ref_mb].values[0] -
+                   ds.mass_kg.loc[yr0_ref_mb].values[0]) /
                   gdir.rgi_area_m2 /
-                  (yr1_ref_mb - yr0_ref_mb) *
-                  gdir.settings['ice_density'])
+                  (yr1_ref_mb - yr0_ref_mb))
 
     return model, dmdtda_mdl
 
@@ -1700,11 +1699,10 @@ def dynamic_melt_f_run(
     with utils.DisableLogger():
         ds = utils.compile_run_output(gdir, input_filesuffix=output_filesuffix,
                                       path=False)
-    dmdtda_mdl = ((ds.volume.loc[yr1_ref_mb].values[0] -
-                   ds.volume.loc[yr0_ref_mb].values[0]) /
+    dmdtda_mdl = ((ds.mass_kg.loc[yr1_ref_mb].values[0] -
+                   ds.mass_kg.loc[yr0_ref_mb].values[0]) /
                   gdir.rgi_area_m2 /
-                  (yr1_ref_mb - yr0_ref_mb) *
-                  gdir.settings['ice_density'])
+                  (yr1_ref_mb - yr0_ref_mb))
 
     return model, dmdtda_mdl
 

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -61,7 +61,7 @@ do_plot = False
 
 DOM_BORDER = 80
 
-ALL_DIAGS = ['volume', 'volume_bsl', 'volume_bwl', 'area', 'length',
+ALL_DIAGS = ['volume', 'volume_bsl', 'volume_bwl', 'area', 'length', 'mass',
              'calving', 'calving_rate', 'off_area', 'on_area', 'melt_off_glacier',
              'melt_on_glacier', 'liq_prcp_off_glacier', 'liq_prcp_on_glacier',
              'snowfall_off_glacier', 'snowfall_on_glacier', 'model_mb',


### PR DESCRIPTION
I changed the calculation of the modeled `dmdtda` in `run_dynamic_melt_f_calibration` to use the new diagnostic variable `mass_kg`.

The old implementation calculated the mass change by multiplying the volume change with the ice density (900 kg m³ by default). However, with the new `SfcTypeModel` we introduced snow/firn density which changes over time, and therefor assuming a constant (ice) density for the volume change does not hold anymore.

- [ ] Tests added/passed
- [ ] Fully documented
- [ ] Entry in `whats-new.rst` 
