### PR TITLE
fix variable name in prepare_for_inversion

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -21,6 +21,11 @@ Enhancements
 Bug fixes
 ~~~~~~~~~
 
+- Fixed a variable name bug in `prepare_for_inversion` where passing
+  `invert_with_trapezoid=False` did not disable trapezoidal bed shapes but
+  instead cleared the rectangular flag (:pull:`1931`).
+  By `Patrick Schmitt <https://github.com/pat-schmitt>`_
+
 Breaking changes
 ~~~~~~~~~~~~~~~~
 

--- a/oggm/core/inversion.py
+++ b/oggm/core/inversion.py
@@ -123,7 +123,7 @@ def prepare_for_inversion(gdir,
         if is_trapezoid is None:
             is_trapezoid = fl.is_rectangular * False
         if not invert_with_trapezoid:
-            is_rectangular[:] = False
+            is_trapezoid[:] = False
         if invert_all_trapezoid:
             is_trapezoid[:] = True
 

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -2494,6 +2494,70 @@ class TestIdealisedInversion():
         if do_plot:  # pragma: no cover
             self.simple_plot(model, inversion_gdir)
 
+    def test_prepare_for_inversion_shape_flags(self, inversion_gdir):
+        # The shape selection flags of prepare_for_inversion used to overwrite
+        # the rectangular flag in the trapezoid branch instead of the trapezoid
+        # one. The default code path (both flags True) hid the bug, hence this
+        # explicit check of all combinations - see GH #1931.
+        fls = dummy_constant_bed(map_dx=inversion_gdir.grid.dx)
+        mb = LinearMassBalance(2600.)
+
+        model = FluxBasedModel(fls, mb_model=mb, y0=0.)
+        model.run_until_equilibrium()
+
+        fls = []
+        for fl in model.fls:
+            pg = np.where((fl.thick > 0) & (fl.widths_m > 1))
+            line = shpg.LineString([fl.line.coords[int(p)] for p in pg[0]])
+            sh = fl.surface_h[pg]
+            flo = centerlines.Centerline(line, dx=fl.dx, surface_h=sh)
+            flo.widths = fl.widths[pg]
+            # a mix of rectangular, trapezoid and (the rest) parabolic sections
+            is_rect = np.zeros(flo.nx, dtype=bool)
+            is_trap = np.zeros(flo.nx, dtype=bool)
+            is_rect[::3] = True
+            is_trap[1::3] = True
+            flo.is_rectangular = is_rect
+            flo.is_trapezoid = is_trap
+            fls.append(flo)
+        inversion_gdir.write_pickle(copy.deepcopy(fls), 'inversion_flowlines')
+        massbalance.apparent_mb_from_linear_mb(inversion_gdir)
+
+        ref_rect = fls[0].is_rectangular.copy()
+        ref_trap = fls[0].is_trapezoid.copy()
+        assert ref_rect.any() and ref_trap.any()
+
+        # Default: both shapes are kept as is
+        inversion.prepare_for_inversion(inversion_gdir)
+        cl = inversion_gdir.read_pickle('inversion_input')[0]
+        np.testing.assert_array_equal(cl['is_rectangular'], ref_rect)
+        np.testing.assert_array_equal(cl['is_trapezoid'], ref_trap)
+
+        # No trapezoid: trapezoid flag is cleared, rectangular untouched
+        inversion.prepare_for_inversion(inversion_gdir,
+                                        invert_with_trapezoid=False)
+        cl = inversion_gdir.read_pickle('inversion_input')[0]
+        np.testing.assert_array_equal(cl['is_rectangular'], ref_rect)
+        assert not cl['is_trapezoid'].any()
+
+        # No rectangular: rectangular flag is cleared, trapezoid untouched
+        inversion.prepare_for_inversion(inversion_gdir,
+                                        invert_with_rectangular=False)
+        cl = inversion_gdir.read_pickle('inversion_input')[0]
+        assert not cl['is_rectangular'].any()
+        np.testing.assert_array_equal(cl['is_trapezoid'], ref_trap)
+
+        # Force all trapezoid / all rectangular
+        inversion.prepare_for_inversion(inversion_gdir,
+                                        invert_all_trapezoid=True)
+        cl = inversion_gdir.read_pickle('inversion_input')[0]
+        assert cl['is_trapezoid'].all()
+
+        inversion.prepare_for_inversion(inversion_gdir,
+                                        invert_all_rectangular=True)
+        cl = inversion_gdir.read_pickle('inversion_input')[0]
+        assert cl['is_rectangular'].all()
+
     def test_inversion_tributary(self, inversion_gdir):
 
         fls = dummy_width_bed_tributary(map_dx=inversion_gdir.grid.dx)


### PR DESCRIPTION
Found this wrong variable name after investigating a report on slack. 

- [x] Tests added/passed
- [ ] Fully documented
- [x] Entry in `whats-new.rst` 
