### PR TITLE
Add download timeout to prevent stalled transfers hanging forever

### DIFF
--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -47,6 +47,12 @@ auto_skip_task = False
 # 0 means no timeout, positive values give timeout threshold in seconds
 task_timeout = 0
 
+# Network timeout (in seconds) for file downloads. Guards against servers that
+# accept a connection but then stall mid-transfer (without a timeout the read
+# blocks indefinitely). Applies to connect and to each read; file_downloader
+# retries on timeout. 0 means no timeout (the old, unbounded behaviour).
+dl_timeout = 60
+
 # Use compression for the intermediate pickles? (might slow down I/O a bit)
 # Both the performance loss (0% ?) and the space gain (-10%) seem to be low
 use_compression = True

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -2376,6 +2376,62 @@ class TestFakeDownloads(unittest.TestCase):
         self.assertTrue('TDM1_DEM__30_N60W146_DEM.tif' in files)
         self.assertFalse('TDM1_DEM__30_N60W145_DEM.tif' in files)
 
+    def test_download_timeout_is_applied(self):
+        # issue #1906: oggm_urlretrieve must inject cfg.PARAMS['dl_timeout']
+        # when the caller passes no explicit timeout, so a stalled read can't
+        # hang forever. A 0 value disables it (legacy unbounded behaviour).
+        captured = {}
+
+        def fake_req(url, path, reporthook, auth=None, timeout=None):
+            captured['timeout'] = timeout
+            with open(path, 'w') as f:
+                f.write('hi')
+
+        self.reset_dir()
+        with FakeDownloadManager('_requests_urlretrieve', fake_req):
+            out = _downloads.oggm_urlretrieve(
+                'https://github.com/OGGM/timeout_test_a.txt',
+                cache_obj_name='timeout_test_a.txt')
+        assert out is not None
+        assert captured['timeout'] == cfg.PARAMS['dl_timeout']
+
+        old = cfg.PARAMS['dl_timeout']
+        cfg.PARAMS['dl_timeout'] = 0
+        try:
+            self.reset_dir()
+            with FakeDownloadManager('_requests_urlretrieve', fake_req):
+                _downloads.oggm_urlretrieve(
+                    'https://github.com/OGGM/timeout_test_b.txt',
+                    cache_obj_name='timeout_test_b.txt')
+        finally:
+            cfg.PARAMS['dl_timeout'] = old
+        assert captured['timeout'] is None
+
+    def test_download_readtimeout_retries(self):
+        # issue #1906: a ReadTimeout (server stalls mid-transfer) is not a
+        # ConnectionError, so file_downloader needs to retry it explicitly
+        # rather than let it propagate.
+        import requests
+
+        self.reset_dir()
+        target = os.path.join(self.dldir, 'ok.txt')
+        with open(target, 'w') as f:
+            f.write('ok')
+
+        calls = {'n': 0}
+
+        def flaky(url, *args, **kwargs):
+            calls['n'] += 1
+            if calls['n'] < 3:
+                raise requests.exceptions.ReadTimeout('stalled')
+            return target
+
+        with FakeDownloadManager('_progress_urlretrieve', flaky):
+            out = utils.file_downloader('https://github.com/OGGM/flaky.tar',
+                                        sleep_on_retry=0)
+        assert calls['n'] == 3
+        assert out == target
+
 
 class TestDataFiles(unittest.TestCase):
 

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -413,6 +413,11 @@ def oggm_urlretrieve(url, cache_obj_name=None, reset=False,
 
     _assert_url_in_allowlist(url)
 
+    if timeout is None:
+        # issue #1906: a server can accept the connection then stall mid-read;
+        # without a timeout the download hangs forever. 0 disables (legacy).
+        timeout = cfg.PARAMS.get('dl_timeout', 60) or None
+
     if cache_obj_name is None:
         cache_obj_name = _get_url_cache_name(url)
 
@@ -548,6 +553,16 @@ def file_downloader(www_path, retry_max=3, sleep_on_retry=5,
                             "The file might have changed or is corrupted. "
                             "File deleted. Re-downloading... %s/%s" %
                             (www_path, err.msg, retry_counter, retry_max))
+            continue
+        except requests.exceptions.ReadTimeout:
+            # issue #1906: the server accepted the connection then stalled
+            # mid-transfer. A ReadTimeout is not a ConnectionError, so it needs
+            # its own branch to be retried rather than propagated. (ConnectTimeout
+            # is a ConnectionError and is still handled by the branch below.)
+            logger.info("Downloading %s failed with ReadTimeout, "
+                        "retrying in %s seconds... %s/%s" %
+                        (www_path, sleep_on_retry, retry_counter, retry_max))
+            time.sleep(sleep_on_retry)
             continue
         except requests.ConnectionError as err:
             if err.args[0].__class__.__name__ == 'MaxRetryError':


### PR DESCRIPTION
File downloads used requests.get(stream=True, timeout=None), so a server that accepted a connection then stalled mid-transfer would block in ssl.read indefinitely (observed: a single CI download hanging ~60-80 min with the process otherwise idle). file_downloader's retry loop could not help, because a stalled connection never raises.

- New cfg param `dl_timeout` (default 60s; 0 = legacy unbounded). It is a per-read timeout, so it only trips on prolonged silence and does not affect slow-but-progressing downloads.
- oggm_urlretrieve injects it when the caller passes no timeout (covers the requests, classic urllib, and ftps backends).
- file_downloader now retries on requests.exceptions.ReadTimeout, which is a Timeout but not a ConnectionError and so was previously not retried.
- Tests in TestFakeDownloads: timeout is injected (and 0 disables it), and a ReadTimeout is retried then succeeds.