### PR TITLE
Add new filtered area diagnostic variable

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -9,6 +9,15 @@ v1.x (unreleased)
 Enhancements
 ~~~~~~~~~~~~
 
+- ``area_min_h`` is now a default diagnostic output variable: it is the
+  glacier area computed from grid points thicker than
+  ``cfg.PARAMS['min_ice_thick_for_area']`` (2 m), which avoids area spikes due
+  to interannual variability in snowfall. It is named ``area_min_h_m2`` in the
+  per-glacier ``model_diagnostics`` files and ``area_min_h`` in the compiled
+  output. This is the recommended area variable for most applications
+  (:pull:`XXXX`).
+  By `Fabien Maussion <https://github.com/fmaussion>`_ and
+  `Patrick Schmitt <https://github.com/pat-schmitt>`_
 - `run_prepro_levels` now allows to set a custom climate data processing
   module and custom geodetic data file to create glacier directories (:pull:`1910`).
   By `Fabien Maussion <https://github.com/fmaussion>`_
@@ -50,6 +59,19 @@ Bug fixes
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
+- Renamed ``cfg.PARAMS['dynamic_spinup_min_ice_thick']`` to
+  ``cfg.PARAMS['min_ice_thick_for_area']`` and the associated diagnostic output
+  variable ``area_m2_min_h`` to ``area_min_h_m2`` in the per-glacier
+  ``model_diagnostics`` files (units now consistently at the end of the name,
+  as for the other variables; in the compiled output the variable is named
+  ``area_min_h``, previously ``area_m2_min_h``). The
+  ``dynamic_spinup_min_ice_thick`` keyword of
+  ``FlowlineModel.run_until_and_store`` is renamed to ``min_ice_thick_for_area``
+  accordingly. Furthermore, the default of
+  ``cfg.PARAMS['min_ice_thick_for_length']`` was changed from 0 to 2 m, so that
+  ``length_m`` now also filters out length spikes due to climate variability
+  (set it back to 0 to recover the previous raw length) (:pull:`XXXX`).
+  By `Fabien Maussion <https://github.com/fmaussion>`_
 - Resolved inverted sign of flowline diagnostics flux divergence (:pull:`1815`).
   This is a breaking change because the OGGM output files have now an opposite
   sign for that variable.

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -15,7 +15,7 @@ Enhancements
   to interannual variability in snowfall. It is named ``area_min_h_m2`` in the
   per-glacier ``model_diagnostics`` files and ``area_min_h`` in the compiled
   output. This is the recommended area variable for most applications
-  (:pull:`XXXX`).
+  (:pull:`1940`).
   By `Fabien Maussion <https://github.com/fmaussion>`_ and
   `Patrick Schmitt <https://github.com/pat-schmitt>`_
 - `run_prepro_levels` now allows to set a custom climate data processing
@@ -67,10 +67,12 @@ Breaking changes
   ``area_min_h``, previously ``area_m2_min_h``). The
   ``dynamic_spinup_min_ice_thick`` keyword of
   ``FlowlineModel.run_until_and_store`` is renamed to ``min_ice_thick_for_area``
-  accordingly. Furthermore, the default of
+  accordingly. (:pull:`1940`).
+  By `Fabien Maussion <https://github.com/fmaussion>`_
+- Furthermore, the default of
   ``cfg.PARAMS['min_ice_thick_for_length']`` was changed from 0 to 2 m, so that
   ``length_m`` now also filters out length spikes due to climate variability
-  (set it back to 0 to recover the previous raw length) (:pull:`XXXX`).
+  (set it back to 0 to recover the previous raw length) (:pull:`1940`).
   By `Fabien Maussion <https://github.com/fmaussion>`_
 - Resolved inverted sign of flowline diagnostics flux divergence (:pull:`1815`).
   This is a breaking change because the OGGM output files have now an opposite

--- a/oggm/core/dynamic_spinup.py
+++ b/oggm/core/dynamic_spinup.py
@@ -143,7 +143,7 @@ def run_dynamic_spinup(gdir, init_model_filesuffix=None, init_model_yr=None,
         the forward model run. Therefore you could see quite fast changes
         (spikes) in the time-evolution (especially visible in length and area).
         If you set this value to 0 the filtering can be switched off.
-        Default is cfg.PARAMS['dynamic_spinup_min_ice_thick'].
+        Default is cfg.PARAMS['min_ice_thick_for_area'].
     first_guess_t_spinup : float
         The initial guess for the temperature bias for the spinup
         MassBalanceModel in °C.
@@ -236,7 +236,7 @@ def run_dynamic_spinup(gdir, init_model_filesuffix=None, init_model_yr=None,
     yr_min = gdir.get_climate_info()['baseline_yr_0']
 
     if min_ice_thickness is None:
-        min_ice_thickness = cfg.PARAMS['dynamic_spinup_min_ice_thick']
+        min_ice_thickness = cfg.PARAMS['min_ice_thick_for_area']
 
     # check provided maximum start year here, and change min_spinup_period
     if spinup_start_yr_max is not None:
@@ -448,7 +448,7 @@ def run_dynamic_spinup(gdir, init_model_filesuffix=None, init_model_yr=None,
                 geom_path=geom_path,
                 diag_path=diag_path,
                 fl_diag_path=fl_diag_path,
-                dynamic_spinup_min_ice_thick=min_ice_thickness,
+                min_ice_thick_for_area=min_ice_thickness,
                 fixed_geometry_spinup_yr=fixed_geometry_spinup_yr,
                 store_monthly_step=store_monthly_step,
             )
@@ -460,7 +460,7 @@ def run_dynamic_spinup(gdir, init_model_filesuffix=None, init_model_yr=None,
 
             if type(ds) == tuple:
                 ds = ds[0]
-            model_area_km2 = ds.area_m2_min_h.loc[target_yr].values * 1e-6
+            model_area_km2 = ds.area_min_h_m2.loc[target_yr].values * 1e-6
             model_volume_km3 = ds.volume_m3.loc[target_yr].values * 1e-9
         else:
             # only run to rgi date and extract values
@@ -1059,7 +1059,7 @@ def dynamic_melt_f_run_with_dynamic_spinup(
         the forward model run. Therefore you could see quite fast changes
         (spikes) in the time-evolution (especially visible in length and area).
         If you set this value to 0 the filtering can be switched off.
-        Default is cfg.PARAMS['dynamic_spinup_min_ice_thick'].
+        Default is cfg.PARAMS['min_ice_thick_for_area'].
     first_guess_t_spinup : float
         The initial guess for the temperature bias for the spinup
         MassBalanceModel in °C.
@@ -1359,7 +1359,7 @@ def dynamic_melt_f_run_with_dynamic_spinup_fallback(
         the forward model run. Therefore you could see quite fast changes
         (spikes) in the time-evolution (especially visible in length and area).
         If you set this value to 0 the filtering can be switched off.
-        Default is cfg.PARAMS['dynamic_spinup_min_ice_thick'].
+        Default is cfg.PARAMS['min_ice_thick_for_area'].
     first_guess_t_spinup : float
         The initial guess for the temperature bias for the spinup
         MassBalanceModel in °C.

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -927,7 +927,7 @@ class FlowlineModel(object):
                             store_monthly_step=None,
                             stop_criterion=None,
                             fixed_geometry_spinup_yr=None,
-                            dynamic_spinup_min_ice_thick=None,
+                            min_ice_thick_for_area=None,
                             ):
         """Runs the model and returns intermediate steps in xarray datasets.
 
@@ -979,13 +979,13 @@ class FlowlineModel(object):
             starting from the chosen year. The only output affected are the
             glacier wide diagnostic files - all other outputs are set
             to constants during "spinup"
-        dynamic_spinup_min_ice_thick : float or None
+        min_ice_thick_for_area : float or None
             if set to a float, additional variables are saved which are useful
             in combination with the dynamic spinup. In particular only grid
             points with a minimum ice thickness are considered for the total
             area or the total volume. This is useful to smooth out yearly
             fluctuations when matching to observations. The names of this new
-            variables include the suffix _min_h (e.g. 'area_m2_min_h')
+            variables include the suffix _min_h (e.g. 'area_min_h_m2')
 
         Returns
         -------
@@ -1107,16 +1107,16 @@ class FlowlineModel(object):
             diag_ds['area_m2'].attrs['description'] = 'Total glacier area'
             diag_ds['area_m2'].attrs['unit'] = 'm 2'
 
-        if dynamic_spinup_min_ice_thick is None:
-            dynamic_spinup_min_ice_thick = cfg.PARAMS['dynamic_spinup_min_ice_thick']
+        if min_ice_thick_for_area is None:
+            min_ice_thick_for_area = cfg.PARAMS['min_ice_thick_for_area']
 
         if 'area_min_h' in ovars:
-            # filled with a value if dynamic_spinup_min_ice_thick is not None
-            diag_ds['area_m2_min_h'] = ('time', np.zeros(nm) * np.nan)
-            diag_ds['area_m2_min_h'].attrs['description'] = \
-                f'Total glacier area of gridpoints with a minimum ice' \
-                f'thickness of {dynamic_spinup_min_ice_thick} m'
-            diag_ds['area_m2_min_h'].attrs['unit'] = 'm 2'
+            # filled with a value if min_ice_thick_for_area is not None
+            diag_ds['area_min_h_m2'] = ('time', np.zeros(nm) * np.nan)
+            diag_ds['area_min_h_m2'].attrs['description'] = \
+                f'Total glacier area of gridpoints with a minimum ice ' \
+                f'thickness of {min_ice_thick_for_area} m'
+            diag_ds['area_min_h_m2'].attrs['unit'] = 'm 2'
 
         if 'length' in ovars:
             diag_ds['length_m'] = ('time', np.zeros(nm) * np.nan)
@@ -1383,8 +1383,8 @@ class FlowlineModel(object):
             if 'volume_bwl' in ovars:
                 diag_ds['volume_bwl_m3'].data[i] = self.volume_bwl_m3
             if 'area_min_h' in ovars:
-                diag_ds['area_m2_min_h'].data[i] = np.sum([np.sum(
-                    fl.bin_area_m2[fl.thick > dynamic_spinup_min_ice_thick])
+                diag_ds['area_min_h_m2'].data[i] = np.sum([np.sum(
+                    fl.bin_area_m2[fl.thick > min_ice_thick_for_area])
                     for fl in self.fls])
             # Terminus thick is a bit more logic
             ti = None

--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -325,8 +325,16 @@ error_when_glacier_reaches_boundaries = True
 # Our defaults might not be the best for your use case. Here we provide
 # some options to the user.
 # This option sets an arbitrary limit on how thick (m) a glacier should be
-# to be defined as "glacier" (https://github.com/OGGM/oggm/issues/914)
-min_ice_thick_for_length = 0
+# to be defined as "glacier" (https://github.com/OGGM/oggm/issues/914).
+# Only grid points thicker than this threshold count towards the glacier
+# length ('length_m'). Like 'min_ice_thick_for_area' does for the area, a
+# non-zero value filters out length spikes due to climate variability (thin
+# ice flickering in and out at the terminus). Note that, unlike the area, the
+# length is not duplicated into a separate filtered variable: 'length_m' is
+# already the (optionally) filtered length, since length is a descriptive
+# quantity and not used to compute per-area quantities. Set this to 0 to
+# recover the raw, unfiltered length.
+min_ice_thick_for_length = 2
 # How to calculate the length of a glacier?
 # - 'naive' (the default) computes the length by summing the number of
 #   grid points with an ice thickness above min_ice_thick_for_length
@@ -344,12 +352,14 @@ glacier_length_method = naive
 # It's a good idea for operational runs.
 use_inversion_params_for_run = True
 
-### Dynamic spinup params
-# Defines the minimum ice thickness which is used during the dynamic spinup to
-# match area or volume. Only grid points with a larger thickness are considered
-# to the total area. This is needed to filter out area changes due to climate
-# variability around the rgi year (spikes).
-dynamic_spinup_min_ice_thick = 2.
+### Minimum ice thickness for area diagnostic
+# Defines the minimum ice thickness (m) used to compute the 'area_min_h_m2'
+# diagnostic: only grid points with a larger thickness are considered for the
+# total area. This is needed to filter out area changes due to climate
+# variability (spikes), for example around the rgi year. It is also the
+# threshold used during the dynamic spinup to match area or volume.
+# 'area_min_h_m2' is the recommended area variable for most applications.
+min_ice_thick_for_area = 2.
 
 ### Tidewater glaciers options
 
@@ -414,7 +424,7 @@ store_model_geometry = False
 #   melt_residual_off_glacier, melt_residual_on_glacier
 #   model_mb, residual_mb, snow_bucket,
 # You need to keep all variables in one line unfortunately
-store_diagnostic_variables =  volume, volume_bsl, volume_bwl, area, length, calving, calving_rate, off_area, on_area, melt_off_glacier, melt_on_glacier, liq_prcp_off_glacier, liq_prcp_on_glacier, snowfall_off_glacier, snowfall_on_glacier
+store_diagnostic_variables =  volume, volume_bsl, volume_bwl, area, area_min_h, length, calving, calving_rate, off_area, on_area, melt_off_glacier, melt_on_glacier, liq_prcp_off_glacier, liq_prcp_on_glacier, snowfall_off_glacier, snowfall_on_glacier
 
 # Whether to store the model flowline diagnostic files during operational runs
 # This can be useful for advanced diagnostics along the flowlines but is

--- a/oggm/tests/test_minimal.py
+++ b/oggm/tests/test_minimal.py
@@ -100,6 +100,8 @@ class TestSia2d(unittest.TestCase):
 
     def setUp(self):
         cfg.initialize_minimal()
+        # this idealised case compares length to the raw geometry
+        cfg.PARAMS['min_ice_thick_for_length'] = 0
 
     def tearDown(self):
         pass

--- a/oggm/tests/test_numerics.py
+++ b/oggm/tests/test_numerics.py
@@ -50,6 +50,8 @@ class TestIdealisedCases(unittest.TestCase):
     def setUp(self):
         N = 3
         cfg.initialize()
+        # these idealised cases compare length to the raw geometry
+        cfg.PARAMS['min_ice_thick_for_length'] = 0
         self.glen_a = 2.4e-24  # Modern style Glen parameter A
         self.aglen_old = (N + 2) * 1.9e-24 / 2.  # outdated value
         self.fd = 2. * self.glen_a / (N + 2.)  # equivalent to glen_a
@@ -1790,6 +1792,8 @@ class TestSia2d(unittest.TestCase):
 
     def setUp(self):
         cfg.initialize()
+        # this idealised case compares length to the raw geometry
+        cfg.PARAMS['min_ice_thick_for_length'] = 0
 
     def tearDown(self):
         pass

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -582,13 +582,13 @@ class TestWorkflowUtils:
                                         input_filesuffix=filesuffix)
 
         def check_result(ds):
-            assert 'area_m2_min_h' in ds.data_vars
+            assert 'area_min_h' in ds.data_vars
             assert 'melt_on_glacier' in ds.data_vars
             assert 'melt_on_glacier_monthly' in ds.data_vars
             assert ds_1['melt_on_glacier'].unit == 'kg yr-1'
             assert ds_1['melt_on_glacier_monthly'].unit == 'kg yr-1'
             assert np.all(np.isnan(
-                ds.loc[{'rgi_id': gdirs[0].rgi_id}]['area_m2_min_h'].values))
+                ds.loc[{'rgi_id': gdirs[0].rgi_id}]['area_min_h'].values))
             assert np.all(np.isnan(
                 ds.loc[{'rgi_id': gdirs[0].rgi_id}]['melt_on_glacier'].values))
             assert np.all(np.isnan(

--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -101,6 +101,9 @@ def up_to_climate(reset=False, use_mp=None, params_file=None):
     cfg.PARAMS['baseline_climate'] = 'CRU'
     cfg.PARAMS['evolution_model'] = 'FluxBased'
     cfg.PARAMS['downstream_line_shape'] = 'parabola'
+    # These tests compare the model length to the raw flowline geometry, so we
+    # switch off the length filtering (min_ice_thick_for_length default is 2)
+    cfg.PARAMS['min_ice_thick_for_length'] = 0
 
     # Go
     gdirs = workflow.init_glacier_directories(rgidf)

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -1140,7 +1140,7 @@ def compile_run_output(gdirs, path=True, input_filesuffix='',
     allowed_data_vars = ['volume_m3', 'volume_bsl_m3', 'volume_bwl_m3',
                          'volume_m3_min_h',  # only here for back compatibility
                          # as it is a variable in gdirs v1.6 2023.1
-                         'area_m2', 'area_m2_min_h', 'length_m', 'calving_m3',
+                         'area_m2', 'area_min_h_m2', 'length_m', 'calving_m3',
                          'calving_rate_myr', 'off_area',
                          'on_area', 'model_mb', 'is_fixed_geometry_spinup']
     for gi in range(10):
@@ -2426,7 +2426,7 @@ def extend_past_climate_run(past_run_file=None,
 
         # New vars
         for vn in ['volume', 'volume_m3_min_h', 'volume_bsl', 'volume_bwl',
-                   'area', 'area_m2_min_h', 'length', 'calving', 'calving_rate']:
+                   'area', 'area_min_h', 'length', 'calving', 'calving_rate']:
             if vn in ods.data_vars:
                 ods[vn + '_ext'] = ods[vn].copy(deep=True)
                 ods[vn + '_ext'].attrs['description'] += ' (extended with MB data)'


### PR DESCRIPTION
This is a branching out from https://github.com/OGGM/oggm/pull/1791 for separation of concerns.

This adds a new diagnostic output variable (`area_min_h`) which is useful for dynamic spinup and other applications where the spikes due to snowfall are not wanted (i.e.: most applications except perhaps SMB computations, although here as well I could see why SMB computed that way might be better - TBC).

This has implications for the spinup and possibly @pat-schmitt 's merge efforts
