### PR TITLE
Switch to Iceboost as new default volumes for the glaciers product

### DIFF
--- a/docs/_code/prepare_hef.py
+++ b/docs/_code/prepare_hef.py
@@ -43,8 +43,8 @@ tasks.mb_calibration_from_wgms_mb(gdir)
 tasks.apparent_mb_from_any_mb(gdir, mb_years=(1970, 2000))
 tasks.prepare_for_inversion(gdir)
 refv = 577852773  # From ITMIX
-df = workflow.calibrate_inversion_from_consensus(gdir, volume_m3_reference=refv)
-np.testing.assert_allclose(refv, df.vol_oggm_m3, rtol=0.01)
+out = workflow.calibrate_inversion_from_volume(gdir, vol_ref_m3=refv)
+np.testing.assert_allclose(refv, out['vol_oggm_m3'], rtol=0.01)
 
 cl = gdir.read_pickle('inversion_input')[-1]
 mbmod = massbalance.ConstantMassBalance(gdir, y0=1985)

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -17,7 +17,7 @@ Enhancements
   ``calibrate_inversion_from_consensus`` is deprecated but still available: it
   keeps calibrating against the Farinotti et al. (2019) consensus estimate.
   Note that the default reference for RGI6 ``run_prepro_levels`` inversions
-  changes accordingly from the consensus estimate to IceBoost v2 (:pull:`XXXX`).
+  changes accordingly from the consensus estimate to IceBoost v2 (:pull:`1942`).
   By `Fabien Maussion <https://github.com/fmaussion>`_
 - ``area_min_h`` is now a default diagnostic output variable: it is the
   glacier area computed from grid points thicker than

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -9,6 +9,16 @@ v1.x (unreleased)
 Enhancements
 ~~~~~~~~~~~~
 
+- New global task ``calibrate_inversion_from_ref_table`` generalises
+  ``calibrate_inversion_from_consensus`` to calibrate the ice thickness
+  inversion against an arbitrary reference volume table (given as a DataFrame,
+  a path or a URL). By default it now uses the IceBoost v2 products, with the
+  RGI6 or RGI7 table selected automatically from the glacier directories.
+  ``calibrate_inversion_from_consensus`` is deprecated but still available: it
+  keeps calibrating against the Farinotti et al. (2019) consensus estimate.
+  Note that the default reference for RGI6 ``run_prepro_levels`` inversions
+  changes accordingly from the consensus estimate to IceBoost v2 (:pull:`XXXX`).
+  By `Fabien Maussion <https://github.com/fmaussion>`_
 - ``area_min_h`` is now a default diagnostic output variable: it is the
   glacier area computed from grid points thicker than
   ``cfg.PARAMS['min_ice_thick_for_area']`` (2 m), which avoids area spikes due

--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -806,7 +806,7 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
                                              error_on_mismatch=False,
                                              filter_inversion_output=filter)
             else:
-                workflow.calibrate_inversion_from_consensus(gdirs,
+                workflow.calibrate_inversion_from_ref_table(gdirs,
                                                             apply_fs_on_mismatch=True,
                                                             error_on_mismatch=False,
                                                             filter_inversion_output=filter)

--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -806,18 +806,10 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
                     f"is supported, not '{inversion_volume_dataset}' (the "
                     "consensus estimate is only available for RGI62).")
 
-            if inversion_volume_dataset == 'consensus':
-                # Farinotti et al. (2019) consensus (ITMIX) estimate, parquet
-                dl_path = ("https://cluster.klima.uni-bremen.de/~oggm/g2ti/"
-                           "rgi62_itmix_df_v20260617.parquet")
-                ref_table = pd.read_parquet(utils.file_downloader(dl_path))
-            else:
-                # IceBoost v2, auto-selected by RGI version (62 / 70G / 70C)
-                ref_table = None
-
+            # 'iceboost'/'consensus' map directly to ref_table presets
             workflow.calibrate_inversion_from_ref_table(
                 gdirs,
-                ref_table=ref_table,
+                ref_table=inversion_volume_dataset,
                 apply_fs_on_mismatch=True,
                 error_on_mismatch=False,
                 filter_inversion_output=filter)

--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -807,8 +807,10 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
                     "consensus estimate is only available for RGI62).")
 
             if inversion_volume_dataset == 'consensus':
-                # Farinotti et al. (2019) consensus (ITMIX) estimate
-                ref_table = pd.read_hdf(utils.get_demo_file('rgi62_itmix_df.h5'))
+                # Farinotti et al. (2019) consensus (ITMIX) estimate, parquet
+                dl_path = ("https://cluster.klima.uni-bremen.de/~oggm/g2ti/"
+                           "rgi62_itmix_df_v20260617.parquet")
+                ref_table = pd.read_parquet(utils.file_downloader(dl_path))
             else:
                 # IceBoost v2, auto-selected by RGI version (62 / 70G / 70C)
                 ref_table = None

--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -105,6 +105,7 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
                       disable_mp=False, params_file=None,
                       elev_bands=False, centerlines=False,
                       override_params=None, skip_inversion=False,
+                      inversion_volume_dataset='iceboost',
                       mb_calibration_strategy='informed_threestep',
                       geodetic_mb_file_path=None,
                       select_source_from_dir=None, keep_dem_folders=False,
@@ -231,6 +232,13 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
     skip_inversion : bool
          do not run the inversion (level 3 files). This is a temporary
          workaround for workflows that wont run that far into level 3.
+    inversion_volume_dataset : str
+        which reference volume dataset to calibrate the ice thickness
+        inversion (Glen A) against. One of:
+        - 'iceboost' (default): the IceBoost v2 product, auto-selected by RGI
+          version. Supported for RGI62, RGI70G and RGI70C.
+        - 'consensus': the Farinotti et al. (2019) consensus (ITMIX) estimate.
+          Only supported for RGI62.
     logging_level : str
         the logging level to use (DEBUG, INFO, WARNING, WORKFLOW)
     override_params : dict
@@ -782,34 +790,35 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
         if not skip_inversion:
             workflow.execute_entity_task(tasks.apparent_mb_from_any_mb, gdirs)
 
-            # Inversion: we match the consensus
             filter = border >= 20
 
-            if rgi_version == '70G':
-                purl = ('https://cluster.klima.uni-bremen.de/~oggm/ref_mb_params/'
-                        'oggm_v1.6/inv_rgi7/rgi6_regional_inv_params_2025.1.csv')
-                params_df = pd.read_csv(utils.file_downloader(purl), index_col=0)
-                workflow.invert_from_params(gdirs,
-                                            params_df=params_df,
-                                            filter_inversion_output=filter)
-            elif rgi_version == '70C':
-                purl = ('https://cluster.klima.uni-bremen.de/~oggm/ref_mb_params/'
-                        'oggm_v1.6/inv_rgi7/rgi7c_glacier_inv_ref_2025.1.csv')
-                ref_vol_df = pd.read_csv(utils.file_downloader(purl), index_col=0)
-                # Small optim
-                ref_vol_df = ref_vol_df.loc[ref_vol_df.rgi_region == int(rgi_reg)]
-                ref_vol_df = ref_vol_df['inv_volume_km3'] * 1e9
-                workflow.execute_entity_task(workflow.calibrate_inversion_from_volume,
-                                             gdirs,
-                                             vol_ref_m3=ref_vol_df,
-                                             apply_fs_on_mismatch=True,
-                                             error_on_mismatch=False,
-                                             filter_inversion_output=filter)
+            # Inversion: calibrate Glen A to a reference volume dataset.
+            # Be explicit about which dataset is used for which RGI version.
+            if inversion_volume_dataset not in ('iceboost', 'consensus'):
+                raise InvalidParamsError(
+                    "inversion_volume_dataset must be 'iceboost' or "
+                    f"'consensus', not '{inversion_volume_dataset}'.")
+
+            if rgi_version in ('70G', '70C') and \
+                    inversion_volume_dataset != 'iceboost':
+                raise InvalidParamsError(
+                    f"For {rgi_version} only inversion_volume_dataset='iceboost' "
+                    f"is supported, not '{inversion_volume_dataset}' (the "
+                    "consensus estimate is only available for RGI62).")
+
+            if inversion_volume_dataset == 'consensus':
+                # Farinotti et al. (2019) consensus (ITMIX) estimate
+                ref_table = pd.read_hdf(utils.get_demo_file('rgi62_itmix_df.h5'))
             else:
-                workflow.calibrate_inversion_from_ref_table(gdirs,
-                                                            apply_fs_on_mismatch=True,
-                                                            error_on_mismatch=False,
-                                                            filter_inversion_output=filter)
+                # IceBoost v2, auto-selected by RGI version (62 / 70G / 70C)
+                ref_table = None
+
+            workflow.calibrate_inversion_from_ref_table(
+                gdirs,
+                ref_table=ref_table,
+                apply_fs_on_mismatch=True,
+                error_on_mismatch=False,
+                filter_inversion_output=filter)
 
             # Distribute thickness per altitude for gridded data
             if add_distributed_thickness:
@@ -1047,6 +1056,13 @@ def parse_args(args):
                         help='do not run the inversion (level 3 files). '
                              'this is a temporary workaround for workflows '
                              'that wont run that far into level 3.')
+    parser.add_argument('--inversion-volume-dataset', type=str,
+                        default='iceboost',
+                        choices=['iceboost', 'consensus'],
+                        help="reference volume dataset to calibrate the ice "
+                             "thickness inversion against. 'iceboost' (default, "
+                             "IceBoost v2, RGI62/RGI70G/RGI70C) or 'consensus' "
+                             "(Farinotti et al. 2019, RGI62 only).")
     parser.add_argument('--mb-calibration-strategy', type=str,
                         default='informed_threestep',
                         help='how to calibrate the massbalance. Currently one of '
@@ -1220,6 +1236,7 @@ def parse_args(args):
                 logging_level=args.logging_level,
                 elev_bands=args.elev_bands,
                 skip_inversion=args.skip_inversion,
+                inversion_volume_dataset=args.inversion_volume_dataset,
                 centerlines=args.centerlines,
                 select_source_from_dir=args.select_source_from_dir,
                 keep_dem_folders=args.keep_dem_folders,

--- a/oggm/core/dynamic_spinup.py
+++ b/oggm/core/dynamic_spinup.py
@@ -976,7 +976,7 @@ def dynamic_melt_f_run_with_dynamic_spinup(
     'dynamic_melt_f_run_with_dynamic_spinup_fallback'). This
     function defines a new melt_f in the glacier directory and conducts an
     inversion calibrating A to match '_vol_m3_ref' with this new melt_f
-    ('calibrate_inversion_from_consensus'). Afterwards a dynamic spinup is
+    ('calibrate_inversion_from_ref_table'). Afterwards a dynamic spinup is
     conducted to match 'minimise_for' (for more info look at docstring of
     'run_dynamic_spinup'). And in the end the geodetic mass balance of the
     current run is calculated (between the period [yr0_ref_mb, yr1_ref_mb]) and
@@ -1125,14 +1125,14 @@ def dynamic_melt_f_run_with_dynamic_spinup(
     if not isinstance(local_variables, dict):
         raise ValueError('You must provide a dict for local_variables!')
 
-    from oggm.workflow import calibrate_inversion_from_consensus
+    from oggm.workflow import calibrate_inversion_from_ref_table
 
     if set_local_variables:
         # clear the provided dictionary and set the first elements
         local_variables.clear()
         local_variables['t_spinup'] = [first_guess_t_spinup]
         # ATTENTION: it is assumed that the flowlines in gdir have the volume
-        # we want to match during calibrate_inversion_from_consensus when we
+        # we want to match during calibrate_inversion_from_ref_table when we
         # set_local_variables
         fls_ref = gdir.read_pickle('model_flowlines')
         local_variables['vol_m3_ref'] = np.sum([f.volume_m3 for f in fls_ref])
@@ -1187,7 +1187,7 @@ def dynamic_melt_f_run_with_dynamic_spinup(
                                     add_to_log_file=False,  # dont write to log
                                     )
             # do inversion with A calibration to current volume
-            calibrate_inversion_from_consensus(
+            calibrate_inversion_from_ref_table(
                 [gdir], apply_fs_on_mismatch=True, error_on_mismatch=False,
                 filter_inversion_output=True,
                 volume_m3_reference=local_variables['vol_m3_ref'],
@@ -1297,7 +1297,7 @@ def dynamic_melt_f_run_with_dynamic_spinup_fallback(
         end year of the run
     local_variables : dict
         Dict in which under the key 'vol_m3_ref' the volume which is used in
-        'calibrate_inversion_from_consensus'
+        'calibrate_inversion_from_ref_table'
     output_filesuffix : str
         For the output file.
         Default is ''
@@ -1406,13 +1406,13 @@ def dynamic_melt_f_run_with_dynamic_spinup_fallback(
     :py:class:`oggm.core.flowline.evolution_model`
         The final model after the run.
     """
-    from oggm.workflow import calibrate_inversion_from_consensus
+    from oggm.workflow import calibrate_inversion_from_ref_table
 
     evolution_model = decide_evolution_model(evolution_model)
 
     if local_variables is None:
         raise RuntimeError('Need the volume to do'
-                           'calibrate_inversion_from_consensus provided in '
+                           'calibrate_inversion_from_ref_table provided in '
                            'local_variables!')
 
     # revert gdir to original state if necessary
@@ -1422,7 +1422,7 @@ def dynamic_melt_f_run_with_dynamic_spinup_fallback(
             with utils.DisableLogger():
                 apparent_mb_from_any_mb(gdir,
                                         add_to_log_file=False)
-                calibrate_inversion_from_consensus(
+                calibrate_inversion_from_ref_table(
                     [gdir], apply_fs_on_mismatch=True, error_on_mismatch=False,
                     filter_inversion_output=True,
                     volume_m3_reference=local_variables['vol_m3_ref'],

--- a/oggm/global_tasks.py
+++ b/oggm/global_tasks.py
@@ -7,6 +7,7 @@ This module is simply a shortcut to the core functions
 from oggm.workflow import gis_prepro_tasks
 from oggm.workflow import climate_tasks
 from oggm.workflow import inversion_tasks
+from oggm.workflow import calibrate_inversion_from_ref_table
 from oggm.workflow import calibrate_inversion_from_consensus
 from oggm.workflow import merge_glacier_tasks
 from oggm.utils import get_ref_mb_glaciers

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -5441,7 +5441,8 @@ class TestMassRedis:
         tasks.mb_calibration_from_scalar_mb(gdir, ref_mb=ref_mb,
                                             ref_period='1953-01-01_2003-01-01')
         tasks.apparent_mb_from_any_mb(gdir, mb_years=[1953, 2003])
-        workflow.calibrate_inversion_from_consensus([gdir])
+        ref_table = pd.read_hdf(utils.get_demo_file('rgi62_itmix_df.h5'))
+        workflow.calibrate_inversion_from_ref_table([gdir], ref_table=ref_table)
         tasks.init_present_time_glacier(gdir)
 
         seed = 0

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -5409,7 +5409,7 @@ class TestHydro:
 
 class TestMassRedis:
 
-    def test_hef_retreat(self, class_case_dir):
+    def test_hef_retreat(self, class_case_dir, rgi62_itmix_df):
 
         import geopandas as gpd
 
@@ -5442,7 +5442,7 @@ class TestMassRedis:
         tasks.mb_calibration_from_scalar_mb(gdir, ref_mb=ref_mb,
                                             ref_period='1953-01-01_2003-01-01')
         tasks.apparent_mb_from_any_mb(gdir, mb_years=[1953, 2003])
-        ref_table = pd.read_hdf(utils.get_demo_file('rgi62_itmix_df.h5'))
+        ref_table = pd.read_parquet(rgi62_itmix_df, engine='pyarrow')
         workflow.calibrate_inversion_from_ref_table([gdir], ref_table=ref_table)
         tasks.init_present_time_glacier(gdir)
 

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -5566,7 +5566,7 @@ class TestHydro:
 
 class TestMassRedis:
 
-    def test_hef_retreat(self, class_case_dir, rgi62_itmix_df):
+    def test_hef_retreat(self, class_case_dir):
 
         import geopandas as gpd
 
@@ -5599,8 +5599,8 @@ class TestMassRedis:
         tasks.mb_calibration_from_scalar_mb(gdir, ref_mb=ref_mb,
                                             ref_period='1953-01-01_2003-01-01')
         tasks.apparent_mb_from_any_mb(gdir, mb_years=[1953, 2003])
-        ref_table = pd.read_parquet(rgi62_itmix_df, engine='pyarrow')
-        workflow.calibrate_inversion_from_ref_table([gdir], ref_table=ref_table)
+        workflow.calibrate_inversion_from_ref_table([gdir],
+                                                    ref_table='consensus')
         tasks.init_present_time_glacier(gdir)
 
         seed = 0

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -2160,9 +2160,7 @@ class TestInversion(unittest.TestCase):
         massbalance.mb_calibration_from_wgms_mb(gdir)
         massbalance.apparent_mb_from_any_mb(gdir, mb_years=(1953, 2002))
         inversion.prepare_for_inversion(gdir)
-        dl_path = ("https://cluster.klima.uni-bremen.de/~oggm/g2ti/"
-                   "rgi62_itmix_df_v20260617.parquet")
-        ref_table = pd.read_parquet(utils.file_downloader(dl_path))
+        ref_table = 'consensus'
         df = workflow.calibrate_inversion_from_ref_table(gdir,
                                                          ref_table=ref_table)
         np.testing.assert_allclose(df.vol_itmix_m3, df.vol_oggm_m3, rtol=0.01)

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -2301,23 +2301,28 @@ class TestInversion(unittest.TestCase):
         massbalance.mb_calibration_from_wgms_mb(gdir)
         massbalance.apparent_mb_from_any_mb(gdir, mb_years=(1953, 2002))
         inversion.prepare_for_inversion(gdir)
-        df = workflow.calibrate_inversion_from_consensus(gdir)
+        ref_table = pd.read_hdf(utils.get_demo_file('rgi62_itmix_df.h5'))
+        df = workflow.calibrate_inversion_from_ref_table(gdir,
+                                                         ref_table=ref_table)
         np.testing.assert_allclose(df.vol_itmix_m3, df.vol_oggm_m3, rtol=0.01)
         # Make it fail
         with pytest.raises(ValueError):
             a = (0.1, 3)
-            workflow.calibrate_inversion_from_consensus(gdir,
+            workflow.calibrate_inversion_from_ref_table(gdir,
+                                                        ref_table=ref_table,
                                                         a_bounds=a)
 
         a = (0.1, 5)
-        df = workflow.calibrate_inversion_from_consensus(gdir,
+        df = workflow.calibrate_inversion_from_ref_table(gdir,
+                                                         ref_table=ref_table,
                                                          a_bounds=a,
                                                          error_on_mismatch=False)
         np.testing.assert_allclose(df.vol_itmix_m3, df.vol_oggm_m3, rtol=0.08)
 
         # With fs it can work
         a = (0.1, 3)
-        df = workflow.calibrate_inversion_from_consensus(gdir,
+        df = workflow.calibrate_inversion_from_ref_table(gdir,
+                                                         ref_table=ref_table,
                                                          a_bounds=a,
                                                          apply_fs_on_mismatch=True)
         np.testing.assert_allclose(df.vol_itmix_m3, df.vol_oggm_m3, rtol=0.01)

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -2160,7 +2160,9 @@ class TestInversion(unittest.TestCase):
         massbalance.mb_calibration_from_wgms_mb(gdir)
         massbalance.apparent_mb_from_any_mb(gdir, mb_years=(1953, 2002))
         inversion.prepare_for_inversion(gdir)
-        ref_table = pd.read_hdf(utils.get_demo_file('rgi62_itmix_df.h5'))
+        dl_path = ("https://cluster.klima.uni-bremen.de/~oggm/g2ti/"
+                   "rgi62_itmix_df_v20260617.parquet")
+        ref_table = pd.read_parquet(utils.file_downloader(dl_path))
         df = workflow.calibrate_inversion_from_ref_table(gdir,
                                                          ref_table=ref_table)
         np.testing.assert_allclose(df.vol_itmix_m3, df.vol_oggm_m3, rtol=0.01)

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -1139,6 +1139,7 @@ class TestPreproCLI:
                           intersects_file=inter,
                           test_topofile=topof,
                           elev_bands=True,
+                          inversion_volume_dataset='consensus',
                           continue_on_error=False,
                           override_params={}
                           )
@@ -1297,6 +1298,7 @@ class TestPreproCLI:
                           test_topofile=topof,
                           elev_bands=True,
                           max_level=3,
+                          inversion_volume_dataset='consensus',
                           add_distributed_thickness=True,
                           add_export_thickness_geotiff=True,
                           continue_on_error=False,
@@ -1360,6 +1362,7 @@ class TestPreproCLI:
                           test_topofile=topof,
                           disable_mp=False,
                           centerlines=True,
+                          inversion_volume_dataset='consensus',
                           continue_on_error=False,
                           override_params={'geodetic_mb_period': ref_period,
                                            'baseline_climate': 'CRU',
@@ -1521,6 +1524,7 @@ class TestPreproCLI:
                               test_ids=['RGI60-11.00929'],
                               dynamic_spinup='area/dmdtda', rgi_file=rgidf,
                               intersects_file=inter,
+                              inversion_volume_dataset='consensus',
                               store_fl_diagnostics=True,
                               continue_on_error=False,
                               mb_calibration_strategy='melt_temp',
@@ -1680,6 +1684,7 @@ class TestPreproCLI:
                           override_params=params,
                           disable_mp=False,
                           mb_calibration_strategy='melt_temp',
+                          inversion_volume_dataset='consensus',
                           test_topofile=topof, elev_bands=True)
 
         df = pd.read_csv(os.path.join(odir, 'RGI61', 'b_020', 'L0', 'summary',
@@ -1774,6 +1779,7 @@ class TestPreproCLI:
                           start_level=1, start_base_url=base_url,
                           mb_calibration_strategy='melt_temp',
                           disable_mp=False,
+                          inversion_volume_dataset='consensus',
                           logging_level='INFO', max_level=5, elev_bands=True,
                           override_params={'geodetic_mb_period': ref_period,
                                            'baseline_climate': 'CRU',
@@ -1820,6 +1826,7 @@ class TestPreproCLI:
                           output_folder=odir, working_dir=wdir, is_test=True,
                           rgi_file=rgidf, intersects_file=inter,
                           logging_level='INFO',
+                          inversion_volume_dataset='consensus',
                           test_topofile=topof, dem_source='ALL')
 
         rid = rgidf.iloc[0].RGIId

--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -206,7 +206,9 @@ class TestFullRun(unittest.TestCase):
         # check if mini params file is used as expected
         assert cfg.PARAMS['lru_maxsize'] == 123
 
-        ref_table = pd.read_hdf(get_demo_file('rgi62_itmix_df.h5'))
+        dl_path = ("https://cluster.klima.uni-bremen.de/~oggm/g2ti/"
+                   "rgi62_itmix_df_v20260617.parquet")
+        ref_table = pd.read_parquet(utils.file_downloader(dl_path))
         df = workflow.calibrate_inversion_from_ref_table(gdirs,
                                                          ref_table=ref_table,
                                                          ignore_missing=True)

--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -206,9 +206,7 @@ class TestFullRun(unittest.TestCase):
         # check if mini params file is used as expected
         assert cfg.PARAMS['lru_maxsize'] == 123
 
-        dl_path = ("https://cluster.klima.uni-bremen.de/~oggm/g2ti/"
-                   "rgi62_itmix_df_v20260617.parquet")
-        ref_table = pd.read_parquet(utils.file_downloader(dl_path))
+        ref_table = 'consensus'
         df = workflow.calibrate_inversion_from_ref_table(gdirs,
                                                          ref_table=ref_table,
                                                          ignore_missing=True)

--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -5,6 +5,7 @@ import pickle
 import pytest
 import json
 import numpy as np
+import pandas as pd
 import xarray as xr
 from numpy.testing import assert_allclose
 import matplotlib.pyplot as plt
@@ -205,7 +206,9 @@ class TestFullRun(unittest.TestCase):
         # check if mini params file is used as expected
         assert cfg.PARAMS['lru_maxsize'] == 123
 
-        df = workflow.calibrate_inversion_from_consensus(gdirs,
+        ref_table = pd.read_hdf(get_demo_file('rgi62_itmix_df.h5'))
+        df = workflow.calibrate_inversion_from_ref_table(gdirs,
+                                                         ref_table=ref_table,
                                                          ignore_missing=True)
         df = df.dropna()
         np.testing.assert_allclose(df.vol_itmix_m3.sum(),
@@ -216,13 +219,18 @@ class TestFullRun(unittest.TestCase):
         # test user provided volume is working
         delta_volume_m3 = 100000000
         user_provided_volume_m3 = df.vol_itmix_m3.sum() - delta_volume_m3
-        df = workflow.calibrate_inversion_from_consensus(
-            gdirs, ignore_missing=True,
+        df = workflow.calibrate_inversion_from_ref_table(
+            gdirs, ref_table=ref_table, ignore_missing=True,
             volume_m3_reference=user_provided_volume_m3)
 
         np.testing.assert_allclose(user_provided_volume_m3,
                                    df.vol_oggm_m3.sum(),
                                    rtol=0.01)
+
+        # the deprecated alias still works and warns
+        with pytest.warns(FutureWarning, match='deprecated'):
+            workflow.calibrate_inversion_from_consensus(gdirs,
+                                                        ignore_missing=True)
 
     @pytest.mark.slow
     def test_shapefile_output(self):

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import shutil
+import warnings
 from collections.abc import Sequence
 # External libs
 import multiprocessing
@@ -27,6 +28,15 @@ except ImportError:
 
 # Module logger
 log = logging.getLogger(__name__)
+
+# Default reference volume tables ("IceBoost v2") used by
+# calibrate_inversion_from_ref_table, one file per RGI version
+ICEBOOST_V2_BASE_URL = ('https://cluster.klima.uni-bremen.de/~oggm/'
+                        'ice_thickness/iceboost_v2/')
+ICEBOOST_V2_FILES = {
+    '6': 'iceboostv2_compiled_rgi62_v20260701.hdf',
+    '7': 'iceboostv2_compiled_rgi70G_v20260701.hdf',
+}
 
 # Multiprocessing Pool
 _mp_manager = None
@@ -595,6 +605,215 @@ def inversion_tasks(gdirs, glen_a=None, fs=None, filter_inversion_output=True,
                                 add_to_log_file=add_to_log_file)
 
 
+def _resolve_ref_volume_table(gdirs, ref_table):
+    """Load and normalise a reference volume table.
+
+    Parameters
+    ----------
+    gdirs : list of :py:class:`oggm.GlacierDirectory` objects
+        used to pick the default table based on the RGI version
+    ref_table : None or pd.DataFrame or str
+        the reference table to use (see
+        :py:func:`calibrate_inversion_from_ref_table`)
+
+    Returns
+    -------
+    (df, ref_col) : the reference dataframe (indexed by RGI id) and the name
+        of the column holding the reference volume, in m3.
+    """
+    if ref_table is None:
+        # Pick the default IceBoost v2 table matching the RGI version
+        rgi_version = gdirs[0].rgi_version[0]
+        try:
+            fname = ICEBOOST_V2_FILES[rgi_version]
+        except KeyError:
+            raise InvalidParamsError(
+                'No default reference volume table available for RGI version '
+                '"{}". Provide one with the `ref_table` argument.'
+                ''.format(gdirs[0].rgi_version))
+        fpath = utils.file_downloader(ICEBOOST_V2_BASE_URL + fname)
+        df = pd.read_hdf(fpath)
+    elif isinstance(ref_table, pd.DataFrame):
+        df = ref_table.copy()
+    else:
+        # A local path or a URL to an hdf file
+        fpath = ref_table
+        if '://' in str(ref_table):
+            fpath = utils.file_downloader(ref_table)
+        df = pd.read_hdf(fpath)
+
+    # Normalise the reference volume to a column in m3
+    if 'vol_itmix_m3' in df.columns:
+        # Legacy consensus (ITMIX) table, already in m3
+        ref_col = 'vol_itmix_m3'
+    elif 'vol_km3' in df.columns:
+        # IceBoost tables store the volume in km3
+        ref_col = 'vol_ref_m3'
+        df[ref_col] = df['vol_km3'] * 1e9
+    else:
+        raise InvalidParamsError(
+            'The reference volume table must contain either a `vol_km3` or a '
+            '`vol_itmix_m3` column, but has: {}'.format(list(df.columns)))
+
+    return df, ref_col
+
+
+@global_task(log)
+def calibrate_inversion_from_ref_table(gdirs, ref_table=None,
+                                       ignore_missing=True,
+                                       fs=0, a_bounds=(0.1, 10),
+                                       apply_fs_on_mismatch=False,
+                                       error_on_mismatch=True,
+                                       filter_inversion_output=True,
+                                       volume_m3_reference=None,
+                                       add_to_log_file=True):
+    """Fit the total volume of the glaciers to a reference volume table.
+
+    This method finds the "best Glen A" to match all glaciers in gdirs with
+    a valid inverted volume.
+
+    Parameters
+    ----------
+    gdirs : list of :py:class:`oggm.GlacierDirectory` objects
+        the glacier directories to process
+    ref_table : None or pd.DataFrame or str
+        the reference volume table to calibrate against. It must be indexed
+        by RGI id and contain either a ``vol_km3`` column (volume in km3, as
+        in the IceBoost products) or a ``vol_itmix_m3`` column (volume in m3,
+        as in the Farinotti et al. (2019) consensus estimate). This can be
+        given as a pandas DataFrame, or as a path/URL to an hdf file. If None
+        (default), the IceBoost v2 table matching the RGI version of the
+        glaciers is downloaded and used.
+    ignore_missing : bool
+        set this to true to silence the error if some glaciers could not be
+        found in the reference table.
+    fs : float
+        invert with sliding (default: no)
+    a_bounds: tuple
+        factor to apply to default A
+    apply_fs_on_mismatch: false
+        on mismatch, try to apply an arbitrary value of fs (fs = 5.7e-20 from
+        Oerlemans) and try to optimize A again.
+    error_on_mismatch: bool
+        sometimes the given bounds do not allow to find a zero mismatch:
+        this will normally raise an error, but you can switch this off,
+        use the closest value instead and move on.
+    filter_inversion_output : bool
+        whether or not to apply terminus thickness filtering on the inversion
+        output (needs the downstream lines to work).
+    volume_m3_reference : float
+        Option to give an own total glacier volume to match to
+    add_to_log_file : bool
+        if the called entity tasks should write into log of gdir. Default True
+
+    Returns
+    -------
+    a dataframe with the individual glacier volumes
+    """
+
+    gdirs = utils.tolist(gdirs)
+    rids = [gdir.rgi_id for gdir in gdirs]
+
+    # A per-glacier reference table is only needed when matching individual
+    # volumes. When matching a single total volume (volume_m3_reference) and
+    # no table was explicitly provided, we skip loading/downloading it.
+    if volume_m3_reference is not None and ref_table is None:
+        df = pd.DataFrame(index=rids)
+        ref_col = None
+    else:
+        # Get the ref data for the glaciers we have
+        df, ref_col = _resolve_ref_volume_table(gdirs, ref_table)
+
+        found_ids = df.index.intersection(rids)
+        if not ignore_missing and (len(found_ids) != len(rids)):
+            raise InvalidWorkflowError('Could not find matching indices in the '
+                                       'reference table for all provided '
+                                       'glaciers. Set ignore_missing=True to '
+                                       'ignore this error.')
+
+        df = df.reindex(rids)
+
+    # Optimize the diff to ref
+    def_a = cfg.PARAMS['inversion_glen_a']
+
+    def compute_vol(x):
+        inversion_tasks(gdirs, glen_a=x*def_a, fs=fs,
+                        filter_inversion_output=filter_inversion_output,
+                        add_to_log_file=add_to_log_file)
+        odf = df.copy()
+        odf['oggm'] = execute_entity_task(tasks.get_inversion_volume, gdirs,
+                                          add_to_log_file=add_to_log_file)
+        # if the user provides a glacier volume all glaciers are considered,
+        # dropna() below excludes glaciers with no reference volume available
+        if volume_m3_reference is None:
+            return odf.dropna(subset=[ref_col, 'oggm'])
+        else:
+            return odf
+
+    def to_minimize(x):
+        log.workflow('Reference volume optimisation with '
+                     'A factor: {} and fs: {}'.format(x, fs))
+        odf = compute_vol(x)
+        if volume_m3_reference is None:
+            return odf[ref_col].sum() - odf.oggm.sum()
+        else:
+            return volume_m3_reference - odf.oggm.sum()
+
+    try:
+        out_fac, r = optimization.brentq(to_minimize, *a_bounds, rtol=1e-2,
+                                         full_output=True)
+        if r.converged:
+            log.workflow('calibrate_inversion_from_ref_table '
+                         'converged after {} iterations and fs={}. The '
+                         'resulting Glen A factor is {}.'
+                         ''.format(r.iterations, fs, out_fac))
+        else:
+            raise ValueError('Unexpected error in optimization.brentq')
+    except ValueError:
+        # Ok can't find an A. Log for debug:
+        odf1 = compute_vol(a_bounds[0]).sum() * 1e-9
+        odf2 = compute_vol(a_bounds[1]).sum() * 1e-9
+        if volume_m3_reference is None:
+            ref_vol_1 = odf1[ref_col]
+            ref_vol_2 = odf2[ref_col]
+        else:
+            ref_vol_1 = volume_m3_reference * 1e-9
+            ref_vol_2 = volume_m3_reference * 1e-9
+        msg = ('calibration from reference table CAN\'T converge with fs={}.\n'
+               'Bound values (km3):\nRef={:.3f} OGGM={:.3f} for A factor {}\n'
+               'Ref={:.3f} OGGM={:.3f} for A factor {}'
+               ''.format(fs,
+                         ref_vol_1, odf1.oggm, a_bounds[0],
+                         ref_vol_2, odf2.oggm, a_bounds[1]))
+        if apply_fs_on_mismatch and fs == 0 and odf2.oggm > ref_vol_2:
+            do_filter = filter_inversion_output
+            return calibrate_inversion_from_ref_table(gdirs,
+                                                      ref_table=ref_table,
+                                                      ignore_missing=ignore_missing,
+                                                      fs=5.7e-20, a_bounds=a_bounds,
+                                                      apply_fs_on_mismatch=False,
+                                                      error_on_mismatch=error_on_mismatch,
+                                                      volume_m3_reference=volume_m3_reference,
+                                                      filter_inversion_output=do_filter,
+                                                      add_to_log_file=add_to_log_file)
+        if error_on_mismatch:
+            raise ValueError(msg)
+
+        out_fac = a_bounds[int(abs(ref_vol_1 - odf1.oggm) >
+                               abs(ref_vol_2 - odf2.oggm))]
+        log.workflow(msg)
+        log.workflow('We use A factor = {} and fs = {} and move on.'
+                     ''.format(out_fac, fs))
+
+    # Compute the final volume with the correct A
+    inversion_tasks(gdirs, glen_a=out_fac*def_a, fs=fs,
+                    filter_inversion_output=filter_inversion_output,
+                    add_to_log_file=add_to_log_file)
+    df['vol_oggm_m3'] = execute_entity_task(tasks.get_inversion_volume, gdirs,
+                                            add_to_log_file=add_to_log_file)
+    return df
+
+
 @global_task(log)
 def calibrate_inversion_from_consensus(gdirs, ignore_missing=True,
                                        fs=0, a_bounds=(0.1, 10),
@@ -604,6 +823,12 @@ def calibrate_inversion_from_consensus(gdirs, ignore_missing=True,
                                        volume_m3_reference=None,
                                        add_to_log_file=True):
     """Fit the total volume of the glaciers to the 2019 consensus estimate.
+
+    .. deprecated::
+        Use :py:func:`calibrate_inversion_from_ref_table` instead, which
+        supports more recent reference volume products. This function is kept
+        for backwards compatibility and keeps calibrating against the
+        Farinotti et al. (2019) consensus estimate.
 
     This method finds the "best Glen A" to match all glaciers in gdirs with
     a valid inverted volume.
@@ -639,99 +864,27 @@ def calibrate_inversion_from_consensus(gdirs, ignore_missing=True,
     a dataframe with the individual glacier volumes
     """
 
-    gdirs = utils.tolist(gdirs)
+    warnings.warn('`calibrate_inversion_from_consensus` is deprecated. Use '
+                  '`calibrate_inversion_from_ref_table` instead, which '
+                  'supports more recent reference volume products. To keep '
+                  'calibrating against the Farinotti et al. (2019) consensus '
+                  'estimate, pass that table explicitly via `ref_table`.',
+                  FutureWarning)
 
-    # Get the ref data for the glaciers we have
-    df = pd.read_hdf(utils.get_demo_file('rgi62_itmix_df.h5'))
-    rids = [gdir.rgi_id for gdir in gdirs]
-
-    found_ids = df.index.intersection(rids)
-    if not ignore_missing and (len(found_ids) != len(rids)):
-        raise InvalidWorkflowError('Could not find matching indices in the '
-                                   'consensus estimate for all provided '
-                                   'glaciers. Set ignore_missing=True to '
-                                   'ignore this error.')
-
-    df = df.reindex(rids)
-
-    # Optimize the diff to ref
-    def_a = cfg.PARAMS['inversion_glen_a']
-
-    def compute_vol(x):
-        inversion_tasks(gdirs, glen_a=x*def_a, fs=fs,
-                        filter_inversion_output=filter_inversion_output,
-                        add_to_log_file=add_to_log_file)
-        odf = df.copy()
-        odf['oggm'] = execute_entity_task(tasks.get_inversion_volume, gdirs,
-                                          add_to_log_file=add_to_log_file)
-        # if the user provides a glacier volume all glaciers are considered,
-        # dropna() below exclude glaciers where no ITMIX volume is available
-        if volume_m3_reference is None:
-            return odf.dropna()
-        else:
-            return odf
-
-    def to_minimize(x):
-        log.workflow('Consensus estimate optimisation with '
-                     'A factor: {} and fs: {}'.format(x, fs))
-        odf = compute_vol(x)
-        if volume_m3_reference is None:
-            return odf.vol_itmix_m3.sum() - odf.oggm.sum()
-        else:
-            return volume_m3_reference - odf.oggm.sum()
-
-    try:
-        out_fac, r = optimization.brentq(to_minimize, *a_bounds, rtol=1e-2,
-                                         full_output=True)
-        if r.converged:
-            log.workflow('calibrate_inversion_from_consensus '
-                         'converged after {} iterations and fs={}. The '
-                         'resulting Glen A factor is {}.'
-                         ''.format(r.iterations, fs, out_fac))
-        else:
-            raise ValueError('Unexpected error in optimization.brentq')
-    except ValueError:
-        # Ok can't find an A. Log for debug:
-        odf1 = compute_vol(a_bounds[0]).sum() * 1e-9
-        odf2 = compute_vol(a_bounds[1]).sum() * 1e-9
-        if volume_m3_reference is None:
-            ref_vol_1 = odf1.vol_itmix_m3
-            ref_vol_2 = odf2.vol_itmix_m3
-        else:
-            ref_vol_1 = volume_m3_reference * 1e-9
-            ref_vol_2 = volume_m3_reference * 1e-9
-        msg = ('calibration from consensus estimate CAN\'T converge with fs={}.\n'
-               'Bound values (km3):\nRef={:.3f} OGGM={:.3f} for A factor {}\n'
-               'Ref={:.3f} OGGM={:.3f} for A factor {}'
-               ''.format(fs,
-                         ref_vol_1, odf1.oggm, a_bounds[0],
-                         ref_vol_2, odf2.oggm, a_bounds[1]))
-        if apply_fs_on_mismatch and fs == 0 and odf2.oggm > ref_vol_2:
-            do_filter = filter_inversion_output
-            return calibrate_inversion_from_consensus(gdirs,
-                                                      ignore_missing=ignore_missing,
-                                                      fs=5.7e-20, a_bounds=a_bounds,
-                                                      apply_fs_on_mismatch=False,
-                                                      error_on_mismatch=error_on_mismatch,
-                                                      volume_m3_reference=volume_m3_reference,
-                                                      filter_inversion_output=do_filter,
-                                                      add_to_log_file=add_to_log_file)
-        if error_on_mismatch:
-            raise ValueError(msg)
-
-        out_fac = a_bounds[int(abs(ref_vol_1 - odf1.oggm) >
-                               abs(ref_vol_2 - odf2.oggm))]
-        log.workflow(msg)
-        log.workflow('We use A factor = {} and fs = {} and move on.'
-                     ''.format(out_fac, fs))
-
-    # Compute the final volume with the correct A
-    inversion_tasks(gdirs, glen_a=out_fac*def_a, fs=fs,
-                    filter_inversion_output=filter_inversion_output,
-                    add_to_log_file=add_to_log_file)
-    df['vol_oggm_m3'] = execute_entity_task(tasks.get_inversion_volume, gdirs,
-                                            add_to_log_file=add_to_log_file)
-    return df
+    # Preserve the exact historical behaviour: the consensus (ITMIX) table
+    ref_table = pd.read_hdf(utils.get_demo_file('rgi62_itmix_df.h5'))
+    return calibrate_inversion_from_ref_table(
+        gdirs,
+        ref_table=ref_table,
+        ignore_missing=ignore_missing,
+        fs=fs,
+        a_bounds=a_bounds,
+        apply_fs_on_mismatch=apply_fs_on_mismatch,
+        error_on_mismatch=error_on_mismatch,
+        filter_inversion_output=filter_inversion_output,
+        volume_m3_reference=volume_m3_reference,
+        add_to_log_file=add_to_log_file,
+    )
 
 
 @global_task(log)
@@ -800,7 +953,7 @@ def calibrate_inversion_from_volume(gdir, vol_ref_m3=None,
                                     filter_inversion_output=True):
     """Fit the volume of a single glacier to a reference volume estimate.
 
-    This is the entity task version of calibrate_inversion_from_consensus.
+    This is the entity task version of calibrate_inversion_from_ref_table.
     It finds the "best Glen A" to match the reference volume for a single glacier.
 
     Parameters

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -882,8 +882,11 @@ def calibrate_inversion_from_consensus(gdirs, ignore_missing=True,
                   'estimate, pass that table explicitly via `ref_table`.',
                   FutureWarning)
 
-    # Preserve the exact historical behaviour: the consensus (ITMIX) table
-    ref_table = pd.read_hdf(utils.get_demo_file('rgi62_itmix_df.h5'))
+    # Preserve the historical behaviour: calibrate against the Farinotti
+    # et al. (2019) consensus (ITMIX) table, now served as parquet.
+    dl_path = ("https://cluster.klima.uni-bremen.de/~oggm/g2ti/"
+               "rgi62_itmix_df_v20260617.parquet")
+    ref_table = pd.read_parquet(utils.file_downloader(dl_path))
     return calibrate_inversion_from_ref_table(
         gdirs,
         ref_table=ref_table,

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -40,6 +40,10 @@ ICEBOOST_V2_FILES = {
     '7C': 'iceboostv2_compiled_rgi70C_v20260701.parquet',
 }
 
+# Farinotti et al. (2019) consensus (ITMIX) reference volume table (RGI6 only)
+CONSENSUS_REF_TABLE_URL = ('https://cluster.klima.uni-bremen.de/~oggm/g2ti/'
+                           'rgi62_itmix_df_v20260617.parquet')
+
 # Multiprocessing Pool
 _mp_manager = None
 _mp_pool = None
@@ -631,7 +635,12 @@ def _resolve_ref_volume_table(gdirs, ref_table):
         of the column holding the reference volume, in m3.
     """
     if ref_table is None:
-        # Pick the default IceBoost v2 table matching the RGI version.
+        ref_table = 'iceboost'
+
+    if isinstance(ref_table, pd.DataFrame):
+        df = ref_table.copy()
+    elif ref_table == 'iceboost':
+        # Pick the IceBoost v2 table matching the RGI version.
         # gdir.rgi_version is '6x' for RGI6 and '70G'/'70C' for RGI7.
         rgi_version = gdirs[0].rgi_version
         key = '6' if rgi_version[0] == '6' else rgi_version[0] + rgi_version[-1]
@@ -639,13 +648,15 @@ def _resolve_ref_volume_table(gdirs, ref_table):
             fname = ICEBOOST_V2_FILES[key]
         except KeyError:
             raise InvalidParamsError(
-                'No default reference volume table available for RGI version '
+                'No IceBoost reference volume table available for RGI version '
                 '"{}". Provide one with the `ref_table` argument.'
                 ''.format(rgi_version))
         fpath = utils.file_downloader(ICEBOOST_V2_BASE_URL + fname)
         df = _read_ref_table_file(fpath)
-    elif isinstance(ref_table, pd.DataFrame):
-        df = ref_table.copy()
+    elif ref_table == 'consensus':
+        # Farinotti et al. (2019) consensus (ITMIX) estimate (RGI6 only)
+        fpath = utils.file_downloader(CONSENSUS_REF_TABLE_URL)
+        df = _read_ref_table_file(fpath)
     else:
         # A local path or a URL to a parquet or hdf file
         fpath = ref_table
@@ -687,14 +698,18 @@ def calibrate_inversion_from_ref_table(gdirs, ref_table=None,
     ----------
     gdirs : list of :py:class:`oggm.GlacierDirectory` objects
         the glacier directories to process
-    ref_table : None or pd.DataFrame or str
-        the reference volume table to calibrate against. It must be indexed
-        by RGI id and contain either a ``vol_km3`` column (volume in km3, as
-        in the IceBoost products) or a ``vol_itmix_m3`` column (volume in m3,
-        as in the Farinotti et al. (2019) consensus estimate). This can be
-        given as a pandas DataFrame, or as a path/URL to a parquet or hdf
-        file. If None (default), the IceBoost v2 table matching the RGI
-        version of the glaciers is downloaded and used.
+    ref_table : None or str or pd.DataFrame
+        the reference volume table to calibrate against. One of:
+        - ``'iceboost'`` (the default, also selected when None): the IceBoost
+          v2 product matching the RGI version of the glaciers is downloaded
+          and used.
+        - ``'consensus'``: the Farinotti et al. (2019) consensus (ITMIX)
+          estimate (RGI6 only).
+        - a pandas DataFrame, or a path/URL to a parquet or hdf file: a custom
+          table, indexed by RGI id. It must contain either a ``vol_km3``
+          column (volume in km3, as in the IceBoost products, the recommended
+          format) or a ``vol_itmix_m3`` column (volume in m3, as in the
+          consensus estimate).
     ignore_missing : bool
         set this to true to silence the error if some glaciers could not be
         found in the reference table.
@@ -883,13 +898,10 @@ def calibrate_inversion_from_consensus(gdirs, ignore_missing=True,
                   FutureWarning)
 
     # Preserve the historical behaviour: calibrate against the Farinotti
-    # et al. (2019) consensus (ITMIX) table, now served as parquet.
-    dl_path = ("https://cluster.klima.uni-bremen.de/~oggm/g2ti/"
-               "rgi62_itmix_df_v20260617.parquet")
-    ref_table = pd.read_parquet(utils.file_downloader(dl_path))
+    # et al. (2019) consensus (ITMIX) table.
     return calibrate_inversion_from_ref_table(
         gdirs,
-        ref_table=ref_table,
+        ref_table='consensus',
         ignore_missing=ignore_missing,
         fs=fs,
         a_bounds=a_bounds,

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -30,12 +30,14 @@ except ImportError:
 log = logging.getLogger(__name__)
 
 # Default reference volume tables ("IceBoost v2") used by
-# calibrate_inversion_from_ref_table, one file per RGI version
+# calibrate_inversion_from_ref_table, one parquet file per RGI version /
+# subtype (RGI6, RGI7 glaciers '7G', RGI7 complexes '7C')
 ICEBOOST_V2_BASE_URL = ('https://cluster.klima.uni-bremen.de/~oggm/'
                         'ice_thickness/iceboost_v2/')
 ICEBOOST_V2_FILES = {
-    '6': 'iceboostv2_compiled_rgi62_v20260701.hdf',
-    '7': 'iceboostv2_compiled_rgi70G_v20260701.hdf',
+    '6': 'iceboostv2_compiled_rgi62_v20260701.parquet',
+    '7G': 'iceboostv2_compiled_rgi70G_v20260701.parquet',
+    '7C': 'iceboostv2_compiled_rgi70C_v20260701.parquet',
 }
 
 # Multiprocessing Pool
@@ -605,6 +607,13 @@ def inversion_tasks(gdirs, glen_a=None, fs=None, filter_inversion_output=True,
                                 add_to_log_file=add_to_log_file)
 
 
+def _read_ref_table_file(fpath):
+    """Read a reference volume table from a parquet or hdf file."""
+    if str(fpath).endswith('.parquet'):
+        return pd.read_parquet(fpath)
+    return pd.read_hdf(fpath)
+
+
 def _resolve_ref_volume_table(gdirs, ref_table):
     """Load and normalise a reference volume table.
 
@@ -622,25 +631,27 @@ def _resolve_ref_volume_table(gdirs, ref_table):
         of the column holding the reference volume, in m3.
     """
     if ref_table is None:
-        # Pick the default IceBoost v2 table matching the RGI version
-        rgi_version = gdirs[0].rgi_version[0]
+        # Pick the default IceBoost v2 table matching the RGI version.
+        # gdir.rgi_version is '6x' for RGI6 and '70G'/'70C' for RGI7.
+        rgi_version = gdirs[0].rgi_version
+        key = '6' if rgi_version[0] == '6' else rgi_version[0] + rgi_version[-1]
         try:
-            fname = ICEBOOST_V2_FILES[rgi_version]
+            fname = ICEBOOST_V2_FILES[key]
         except KeyError:
             raise InvalidParamsError(
                 'No default reference volume table available for RGI version '
                 '"{}". Provide one with the `ref_table` argument.'
-                ''.format(gdirs[0].rgi_version))
+                ''.format(rgi_version))
         fpath = utils.file_downloader(ICEBOOST_V2_BASE_URL + fname)
-        df = pd.read_hdf(fpath)
+        df = _read_ref_table_file(fpath)
     elif isinstance(ref_table, pd.DataFrame):
         df = ref_table.copy()
     else:
-        # A local path or a URL to an hdf file
+        # A local path or a URL to a parquet or hdf file
         fpath = ref_table
         if '://' in str(ref_table):
             fpath = utils.file_downloader(ref_table)
-        df = pd.read_hdf(fpath)
+        df = _read_ref_table_file(fpath)
 
     # Normalise the reference volume to a column in m3
     if 'vol_itmix_m3' in df.columns:
@@ -681,9 +692,9 @@ def calibrate_inversion_from_ref_table(gdirs, ref_table=None,
         by RGI id and contain either a ``vol_km3`` column (volume in km3, as
         in the IceBoost products) or a ``vol_itmix_m3`` column (volume in m3,
         as in the Farinotti et al. (2019) consensus estimate). This can be
-        given as a pandas DataFrame, or as a path/URL to an hdf file. If None
-        (default), the IceBoost v2 table matching the RGI version of the
-        glaciers is downloaded and used.
+        given as a pandas DataFrame, or as a path/URL to a parquet or hdf
+        file. If None (default), the IceBoost v2 table matching the RGI
+        version of the glaciers is downloaded and used.
     ignore_missing : bool
         set this to true to silence the error if some glaciers could not be
         found in the reference table.


### PR DESCRIPTION
This adds Iceboost v2 as another volume product we can match with OGGM. Previously we had only the Farinotti volumes. (we never added Millan's because of the issues with missing data and ambiguous ways to deal with this).

Iceboost is the new "default" as it's available for all RGI version (6, 7G, 7C) and is newer. The old way still is available and might be provided as an OGGM 1.7 prepro url as well