### PR TITLE
Integrating SfcTypeTIModel into run_prepro_levels

### DIFF
--- a/oggm/cfg.py
+++ b/oggm/cfg.py
@@ -254,11 +254,6 @@ BASENAMES['inversion_flowlines'] = ('inversion_flowlines.pkl', _doc)
 _doc = 'The historical monthly climate timeseries stored in a netCDF file.'
 BASENAMES['climate_historical'] = ('climate_historical.nc', _doc)
 
-# so far, this is only ERA5 or E5E5 daily and does not work with the default
-# OGGM mass balance module, only with sandbox
-_doc = 'The historical daily climate timeseries stored in a netCDF file.'
-BASENAMES['climate_historical_daily'] = ('climate_historical_daily.nc', _doc)
-
 _doc = "A dict containing the glacier's mass balance calibration parameters."
 BASENAMES['mb_calib'] = ('mb_calib.json', _doc)
 

--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -295,6 +295,7 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
     if mb_model_class == 'MonthlyTIModel':
         override_params['melt_f'] = 5.
         mb_model_class = MonthlyTIModel
+        store_mb_diagnostics = False
     elif mb_model_class == 'SfcTypeTIModel':
         # TODO: According to Schuster et al. (2023) Figure 1, the default melt_f
         # should be larger when including snow tacking (around 6. to 7.). If we
@@ -303,6 +304,7 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
         # MonthlyTIModel.
         override_params['melt_f'] = 5.
         mb_model_class = SfcTypeTIModel
+        store_mb_diagnostics = True
     else:
         raise NotImplementedError(f"Unknown mb_model: {mb_model_class}")
 
@@ -870,10 +872,12 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
 
         # conduct historical run before dynamic melt_f calibration
         # (for comparison to old default behavior)
-        workflow.execute_entity_task(tasks.run_from_climate_data, gdirs,
-                                     min_ys=y0, ye=ye,
-                                     mb_model_class=mb_model_class,
-                                     output_filesuffix='_historical')
+        workflow.execute_entity_task(
+            tasks.run_from_climate_data, gdirs,
+            min_ys=y0, ye=ye, mb_model_class=mb_model_class,
+            save_mb_diagnostics_filesuffix='_historical' if store_mb_diagnostics else None,
+            output_filesuffix='_historical'
+        )
         # Now compile the output
         opath = os.path.join(sum_dir, f'historical_run_output_{rgi_reg}.nc')
         utils.compile_run_output(gdirs, path=opath, input_filesuffix='_historical')
@@ -901,6 +905,8 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
                                           'spinup_periods_to_try':
                                               dynamic_spinup_periods_to_try
                                           },
+                save_mb_diagnostics_filesuffix=('_spinup_historical'
+                                                if store_mb_diagnostics else None),
                 output_filesuffix='_spinup_historical',)
             # Now compile the output
             opath = os.path.join(sum_dir, f'spinup_historical_run_output_{rgi_reg}.nc')

--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -20,6 +20,7 @@ import geopandas as gpd
 import oggm.cfg as cfg
 from oggm import utils, workflow, tasks, GlacierDirectory
 from oggm.core import gis
+from oggm.core.massbalance import MonthlyTIModel, SfcTypeTIModel
 from oggm.exceptions import InvalidParamsError, InvalidDEMError, InvalidWorkflowError
 
 # Module logger
@@ -101,6 +102,7 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
                       disable_mp=False, params_file=None,
                       elev_bands=False, centerlines=False,
                       override_params=None, skip_inversion=False,
+                      mb_model_class='MonthlyTIModel',
                       mb_calibration_strategy='informed_threestep',
                       select_source_from_dir=None, keep_dem_folders=False,
                       add_consensus_thickness=False, add_itslive_velocity=False,
@@ -154,6 +156,9 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
         compute all flowlines based on the Huss & Farinotti 2012 method.
     centerlines : bool
         compute all flowlines based on the OGGM centerline(s) method.
+    mb_model_class : str
+        The mb_model_class to use. Options are 'MonthlyTIModel' (default) and
+        'SfcTypeTIModel'.
     mb_calibration_strategy : str
         how to calibrate the massbalance. Currently one of:
         - 'informed_threestep' (default)
@@ -285,6 +290,21 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
     if centerlines:
         override_params['downstream_line_shape'] = 'parabola'
         override_params['evolution_model'] = 'FluxBased'
+
+    # define the default melt_f depending on the the used mb_model_class
+    if mb_model_class == 'MonthlyTIModel':
+        override_params['melt_f'] = 5.
+        mb_model_class = MonthlyTIModel
+    elif mb_model_class == 'SfcTypeTIModel':
+        # TODO: According to Schuster et al. (2023) Figure 1, the default melt_f
+        # should be larger when including snow tacking (around 6. to 7.). If we
+        # change this we also need to include this for the preparation of the
+        # three step calibration. Currently I stick to the same value as the
+        # MonthlyTIModel.
+        override_params['melt_f'] = 5.
+        mb_model_class = SfcTypeTIModel
+    else:
+        raise NotImplementedError(f"Unknown mb_model: {mb_model_class}")
 
     # Other things that make sense
     override_params['store_model_geometry'] = True
@@ -718,25 +738,29 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
             workflow.execute_entity_task(tasks.mb_calibration_from_hugonnet_mb,
                                          gdirs,
                                          informed_threestep=True,
+                                         mb_model_class=mb_model_class,
                                          use_regional_avg=use_regional_avg)
         elif mb_calibration_strategy == 'melt_temp':
             workflow.execute_entity_task(tasks.mb_calibration_from_hugonnet_mb,
                                          gdirs,
                                          calibrate_param1='melt_f',
                                          calibrate_param2='temp_bias',
+                                         mb_model_class=mb_model_class,
                                          use_regional_avg=use_regional_avg)
         elif mb_calibration_strategy == 'temp_melt':
             workflow.execute_entity_task(tasks.mb_calibration_from_hugonnet_mb,
                                          gdirs,
                                          calibrate_param1='temp_bias',
                                          calibrate_param2='melt_f',
+                                         mb_model_class=mb_model_class,
                                          use_regional_avg=use_regional_avg)
         else:
             raise InvalidParamsError('mb_calibration_strategy not understood: '
                                      f'{mb_calibration_strategy}')
 
         if not skip_inversion:
-            workflow.execute_entity_task(tasks.apparent_mb_from_any_mb, gdirs)
+            workflow.execute_entity_task(tasks.apparent_mb_from_any_mb, gdirs,
+                                         mb_model_class=mb_model_class,)
 
             # Inversion: we match the consensus
             filter = border >= 20
@@ -791,7 +815,8 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
         opath = os.path.join(sum_dir, 'climate_statistics_{}.csv'.format(rgi_reg))
         utils.compile_climate_statistics(gdirs, path=opath)
         opath = os.path.join(sum_dir, 'fixed_geometry_mass_balance_{}.csv'.format(rgi_reg))
-        utils.compile_fixed_geometry_mass_balance(gdirs, path=opath)
+        utils.compile_fixed_geometry_mass_balance(gdirs, path=opath,
+                                                  mb_model_class=mb_model_class)
 
         # L3 OK - compress all in output directory
         log.workflow('L3 done. Writing to tar...')
@@ -847,6 +872,7 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
         # (for comparison to old default behavior)
         workflow.execute_entity_task(tasks.run_from_climate_data, gdirs,
                                      min_ys=y0, ye=ye,
+                                     mb_model_class=mb_model_class,
                                      output_filesuffix='_historical')
         # Now compile the output
         opath = os.path.join(sum_dir, f'historical_run_output_{rgi_reg}.nc')
@@ -865,6 +891,7 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
                 ref_mb_err_scaling_factor=ref_mb_err_scaling_factor,
                 ys=dynamic_spinup_start_year, ye=ye,
                 melt_f_max=melt_f_max,
+                mb_model_class=mb_model_class,
                 kwargs_run_function={'minimise_for': minimise_for,
                                      'spinup_periods_to_try':
                                          dynamic_spinup_periods_to_try
@@ -1000,6 +1027,9 @@ def parse_args(args):
                         help='do not run the inversion (level 3 files). '
                              'this is a temporary workaround for workflows '
                              'that wont run that far into level 3.')
+    parser.add_argument('--mb-model-class', type=str, default='MonthlyTIModel',
+                        help='the mass balance model class to use. Options are '
+                             'MonthlyTIModel (default) or SfcTypeTIModel.')
     parser.add_argument('--mb-calibration-strategy', type=str,
                         default='informed_threestep',
                         help='how to calibrate the massbalance. Currently one of '
@@ -1174,6 +1204,7 @@ def parse_args(args):
                 ref_mb_err_scaling_factor=args.ref_mb_err_scaling_factor,
                 dynamic_spinup_start_year=args.dynamic_spinup_start_year,
                 dynamic_spinup_periods_to_try=args.dynamic_spinup_periods_to_try,
+                mb_model_class=args.mb_model_class,
                 mb_calibration_strategy=args.mb_calibration_strategy,
                 store_fl_diagnostics=args.store_fl_diagnostics,
                 override_params=args.override_params,

--- a/oggm/core/dynamic_spinup.py
+++ b/oggm/core/dynamic_spinup.py
@@ -5,6 +5,7 @@ import copy
 import os
 import warnings
 from functools import partial
+import inspect
 
 # External libs
 import numpy as np
@@ -18,7 +19,7 @@ from oggm.exceptions import InvalidParamsError, InvalidWorkflowError
 from oggm.core.massbalance import (MultipleFlowlineMassBalance,
                                    ConstantMassBalance,
                                    MonthlyTIModel,
-                                   apparent_mb_from_any_mb)
+                                   apparent_mb_from_any_mb, SfcTypeTIModel)
 from oggm.core.flowline import (decide_evolution_model, FileModel,
                                 init_present_time_glacier,
                                 run_from_climate_data)
@@ -344,6 +345,14 @@ def run_dynamic_spinup(gdir, settings_filesuffix='',
                            f'than the target year (target_yr = {target_yr}!')
 
     yr_min = gdir.get_climate_info()['baseline_yr_0']
+
+    # if mb_model_class is SfcTypeTIModel, we need to reserve spinup_years
+    if (isinstance(mb_model_class, partial) or
+            issubclass(mb_model_class, SfcTypeTIModel)):
+        yr_min += inspect.signature(
+            mb_model_class if isinstance(mb_model_class, partial)
+            else mb_model_class.__init__
+        ).parameters['spinup_years'].default
 
     if min_ice_thickness is None:
         min_ice_thickness = gdir.settings['dynamic_spinup_min_ice_thick']
@@ -2273,55 +2282,73 @@ def run_dynamic_melt_f_calibration(
                 output_filesuffix=output_filesuffix,
                 **kwargs_fallback_function)
         else:
-            # we were not able to reach the desired precision during the
-            # minimisation, but at least we conducted a few error free runs
-            # using the run_function, and therefore we save the best guess we
-            # found so far
-            if only_first_guess:
-                gdir.settings['used_spinup_option'] = first_guess_diagnostic_msg
-                # this is only for backwards compatibility
-                gdir.add_to_diagnostics('used_spinup_option',
-                                        first_guess_diagnostic_msg)
-            else:
-                gdir.settings['used_spinup_option'] = ('dynamic melt_f '
-                                                       'calibration (part success)')
-                # this is only for backwards compatibility
-                gdir.add_to_diagnostics('used_spinup_option',
-                                        'dynamic melt_f calibration (part '
-                                        'success)')
-            model, dmdtda_mdl = run_function(
-                gdir=gdir,
-                settings_filesuffix=settings_filesuffix,
-                melt_f=melt_f,
-                yr0_ref_mb=yr0_ref_mb,
-                yr1_ref_mb=yr1_ref_mb,
-                fls_init=fls_init, ys=ys, ye=ye,
-                mb_model_class=mb_model_class,
-                save_mb_diagnostics_filesuffix=save_mb_diagnostics_filesuffix,
-                output_filesuffix=output_filesuffix,
-                local_variables=local_variables_run_function,
-                **kwargs_run_function)
+            try:
+                # we were not able to reach the desired precision during the
+                # minimisation, but at least we conducted a few error free runs
+                # using the run_function, and therefore we save the best guess we
+                # found so far
+                if only_first_guess:
+                    gdir.settings['used_spinup_option'] = first_guess_diagnostic_msg
+                    # this is only for backwards compatibility
+                    gdir.add_to_diagnostics('used_spinup_option',
+                                            first_guess_diagnostic_msg)
+                else:
+                    gdir.settings['used_spinup_option'] = ('dynamic melt_f '
+                                                           'calibration (part success)')
+                    # this is only for backwards compatibility
+                    gdir.add_to_diagnostics('used_spinup_option',
+                                            'dynamic melt_f calibration (part '
+                                            'success)')
+                model, dmdtda_mdl = run_function(
+                    gdir=gdir,
+                    settings_filesuffix=settings_filesuffix,
+                    melt_f=melt_f,
+                    yr0_ref_mb=yr0_ref_mb,
+                    yr1_ref_mb=yr1_ref_mb,
+                    fls_init=fls_init, ys=ys, ye=ye,
+                    mb_model_class=mb_model_class,
+                    save_mb_diagnostics_filesuffix=save_mb_diagnostics_filesuffix,
+                    output_filesuffix=output_filesuffix,
+                    local_variables=local_variables_run_function,
+                    **kwargs_run_function)
 
-            # some dianostics for later
-            diag_dyn_melt = {
-                'dmdtda_mismatch_dynamic_calibration_reference':
-                    float(ref_mb),
-                'dmdtda_dynamic_calibration_given_error': float(ref_mb_err),
-                'dmdtda_dynamic_calibration_error_scaling_factor':
-                    float(ref_mb_err_scaling_factor),
-                'dmdtda_mismatch_dynamic_calibration': float(best_mismatch),
-                'dmdtda_mismatch_with_initial_melt_f': float(initial_mismatch),
-                'melt_f_dynamic_calibration': float(melt_f),
-                'melt_f_before_dynamic_calibration': float(melt_f_initial),
-                'run_dynamic_melt_f_calibration_iterations':
-                    int(dynamic_melt_f_calibration_runs[-1]),
-            }
+                # some dianostics for later
+                diag_dyn_melt = {
+                    'dmdtda_mismatch_dynamic_calibration_reference':
+                        float(ref_mb),
+                    'dmdtda_dynamic_calibration_given_error': float(ref_mb_err),
+                    'dmdtda_dynamic_calibration_error_scaling_factor':
+                        float(ref_mb_err_scaling_factor),
+                    'dmdtda_mismatch_dynamic_calibration': float(best_mismatch),
+                    'dmdtda_mismatch_with_initial_melt_f': float(initial_mismatch),
+                    'melt_f_dynamic_calibration': float(melt_f),
+                    'melt_f_before_dynamic_calibration': float(melt_f_initial),
+                    'run_dynamic_melt_f_calibration_iterations':
+                        int(dynamic_melt_f_calibration_runs[-1]),
+                }
 
-            for k, v in diag_dyn_melt.items():
-                gdir.settings[k] = v
+                for k, v in diag_dyn_melt.items():
+                    gdir.settings[k] = v
+                    # this is only for backwards compatibility
+                    if settings_filesuffix == '':
+                        gdir.add_to_diagnostics(k, v)
+            except RuntimeError:
+                # something unexpected happened, we just do the fallback
+
+                # this diagnostics should be overwritten inside the fallback_function
+                gdir.settings['used_spinup_option'] = 'fallback_function'
                 # this is only for backwards compatibility
-                if settings_filesuffix == '':
-                    gdir.add_to_diagnostics(k, v)
+                gdir.add_to_diagnostics('used_spinup_option', 'fallback_function')
+
+                model = fallback_function(
+                    gdir=gdir,
+                    settings_filesuffix=settings_filesuffix,
+                    melt_f=melt_f, fls_init=fls_init,
+                    mb_model_class=mb_model_class,
+                    save_mb_diagnostics_filesuffix=save_mb_diagnostics_filesuffix,
+                    ys=ys, ye=ye,
+                    output_filesuffix=output_filesuffix,
+                    **kwargs_fallback_function)
 
         return model
 

--- a/oggm/core/dynamic_spinup.py
+++ b/oggm/core/dynamic_spinup.py
@@ -36,6 +36,7 @@ def run_dynamic_spinup(gdir, settings_filesuffix='',
                        init_model_fls=None,
                        climate_input_filesuffix='',
                        evolution_model=None, mb_model_class=None,
+                       save_mb_diagnostics_filesuffix=None,
                        mb_model_historical=None, mb_model_spinup=None,
                        spinup_period_initial=20, spinup_start_yr=None,
                        min_spinup_period=10, spinup_start_yr_max=None,
@@ -104,6 +105,12 @@ def run_dynamic_spinup(gdir, settings_filesuffix='',
         Not all models work in all circumstances!
     mb_model_class : MassBalanceModel, default ``MonthlyTIModel``
         The MassBalanceModel class to use.
+    save_mb_diagnostics_filesuffix : str, optional
+        if provided, the mass balance model state is saved to
+        ``mb_diagnostics{save_mb_diagnostics_filesuffix}.nc`` after the run
+        completes, via :meth:`MultipleFlowlineMassBalance.save_to_file`.
+        Useful for saving a historical run before branching into multiple
+        projection scenarios.
     mb_model_historical : :py:class:`core.MassBalanceModel`
         User-povided MassBalanceModel instance for the historical run. Default
         is to use a MonthlyTIModel model  together with the provided
@@ -399,6 +406,13 @@ def run_dynamic_spinup(gdir, settings_filesuffix='',
     else:
         fl_diag_path = False
 
+    if save_mb_diagnostics_filesuffix is not None:
+        mb_diag_path = gdir.get_filepath('mb_diagnostics',
+                                         filesuffix=save_mb_diagnostics_filesuffix,
+                                         delete=True)
+    else:
+        mb_diag_path = False
+
     diag_path = gdir.get_filepath('model_diagnostics',
                                   filesuffix=output_filesuffix,
                                   delete=True)
@@ -466,6 +480,10 @@ def run_dynamic_spinup(gdir, settings_filesuffix='',
                 fl_diag_path=fl_diag_path,
                 store_monthly_step=store_monthly_step,
             )
+
+            if save_mb_diagnostics_filesuffix is not None:
+                model_dynamic_spinup_end.mb_model.save_to_file(
+                    filesuffix=save_mb_diagnostics_filesuffix)
 
         return model_dynamic_spinup_end
 
@@ -553,6 +571,10 @@ def run_dynamic_spinup(gdir, settings_filesuffix='',
                 fixed_geometry_spinup_yr=fixed_geometry_spinup_yr,
                 store_monthly_step=store_monthly_step,
             )
+
+            if save_mb_diagnostics_filesuffix is not None:
+                model_historical.mb_model.save_to_file(
+                    filesuffix=save_mb_diagnostics_filesuffix)
 
             # now we delete the min_h variable again if it was not
             # included before (inplace)
@@ -988,6 +1010,9 @@ def run_dynamic_spinup(gdir, settings_filesuffix='',
                     if diag_path and os.path.exists(diag_path):
                         os.remove(diag_path)
 
+                    if mb_diag_path and os.path.exists(mb_diag_path):
+                        os.remove(mb_diag_path)
+
                     raise RuntimeError(e)
 
     # hurray, dynamic spinup successfully
@@ -1022,6 +1047,10 @@ def run_dynamic_spinup(gdir, settings_filesuffix='',
                 fl_diag_path=fl_diag_path,
                 store_monthly_step=store_monthly_step,
             )
+
+            if save_mb_diagnostics_filesuffix is not None:
+                model_dynamic_spinup_end[-1].mb_model.save_to_file(
+                    filesuffix=save_mb_diagnostics_filesuffix)
 
     if return_t_spinup_best:
         return model_dynamic_spinup_end[-1], final_t_spinup_guess[-1]
@@ -1059,7 +1088,8 @@ def define_new_melt_f_in_gdir(gdir, new_melt_f):
 def dynamic_melt_f_run_with_dynamic_spinup(
         gdir, melt_f, yr0_ref_mb, yr1_ref_mb, fls_init, ys, ye,
         settings_filesuffix='', output_filesuffix=None, evolution_model=None,
-        mb_model_class=None, mb_model_historical=None, mb_model_spinup=None,
+        mb_model_class=None, save_mb_diagnostics_filesuffix=None,
+        mb_model_historical=None, mb_model_spinup=None,
         model_flowlines_filesuffix='',
         minimise_for='area', climate_input_filesuffix='', spinup_period_initial=20,
         min_spinup_period=10, target_yr=None, precision_percent=1,
@@ -1109,6 +1139,12 @@ def dynamic_melt_f_run_with_dynamic_spinup(
         Not all models work in all circumstances!
     mb_model_class : MassBalanceModel, default ``MonthlyTIModel``
         The MassBalanceModel class to use.
+    save_mb_diagnostics_filesuffix : str, optional
+        if provided, the mass balance model state is saved to
+        ``mb_diagnostics{save_mb_diagnostics_filesuffix}.nc`` after the run
+        completes, via :meth:`MultipleFlowlineMassBalance.save_to_file`.
+        Useful for saving a historical run before branching into multiple
+        projection scenarios.
     mb_model_historical : :py:class:`core.MassBalanceModel`
         User-povided MassBalanceModel instance for the historical run. Default
         is to use a MonthlyTIModel model  together with the provided
@@ -1348,6 +1384,7 @@ def dynamic_melt_f_run_with_dynamic_spinup(
             climate_input_filesuffix=climate_input_filesuffix,
             evolution_model=evolution_model,
             mb_model_class=mb_model_class,
+            save_mb_diagnostics_filesuffix=save_mb_diagnostics_filesuffix,
             mb_model_historical=mb_model_historical,
             mb_model_spinup=mb_model_spinup,
             spinup_period_initial=spinup_period_initial,
@@ -1393,7 +1430,8 @@ def dynamic_melt_f_run_with_dynamic_spinup(
 def dynamic_melt_f_run_with_dynamic_spinup_fallback(
         gdir, melt_f, fls_init, ys, ye,
         settings_filesuffix='', output_filesuffix=None,
-        evolution_model=None, mb_model_class=None, minimise_for='area',
+        evolution_model=None, mb_model_class=None,
+        save_mb_diagnostics_filesuffix=None, minimise_for='area',
         mb_model_historical=None, mb_model_spinup=None,
         climate_input_filesuffix='', spinup_period_initial=20,
         min_spinup_period=10, target_yr=None, precision_percent=1,
@@ -1435,6 +1473,12 @@ def dynamic_melt_f_run_with_dynamic_spinup_fallback(
         Not all models work in all circumstances!
     mb_model_class : MassBalanceModel, default ``MonthlyTIModel``
         The MassBalanceModel class to use.
+    save_mb_diagnostics_filesuffix : str, optional
+        if provided, the mass balance model state is saved to
+        ``mb_diagnostics{save_mb_diagnostics_filesuffix}.nc`` after the run
+        completes, via :meth:`MultipleFlowlineMassBalance.save_to_file`.
+        Useful for saving a historical run before branching into multiple
+        projection scenarios.
     mb_model_historical : :py:class:`core.MassBalanceModel`
         User-povided MassBalanceModel instance for the historical run. Default
         is to use a MonthlyTIModel model  together with the provided
@@ -1590,6 +1634,7 @@ def dynamic_melt_f_run_with_dynamic_spinup_fallback(
             climate_input_filesuffix=climate_input_filesuffix,
             evolution_model=evolution_model,
             mb_model_class=mb_model_class,
+            save_mb_diagnostics_filesuffix=save_mb_diagnostics_filesuffix,
             mb_model_historical=mb_model_historical,
             mb_model_spinup=mb_model_spinup,
             spinup_period_initial=spinup_period_initial,
@@ -1661,6 +1706,7 @@ def dynamic_melt_f_run_with_dynamic_spinup_fallback(
             store_fl_diagnostics=store_fl_diagnostics,
             init_model_fls=fls_init, evolution_model=evolution_model,
             mb_model_class=mb_model_class,
+            save_mb_diagnostics_filesuffix=save_mb_diagnostics_filesuffix,
             fixed_geometry_spinup_yr=ys)
 
         gdir.settings['used_spinup_option'] = 'fixed geometry spinup'
@@ -1673,9 +1719,9 @@ def dynamic_melt_f_run_with_dynamic_spinup_fallback(
 def dynamic_melt_f_run(
         gdir, melt_f, yr0_ref_mb, yr1_ref_mb, fls_init, ys, ye,
         settings_filesuffix='',  output_filesuffix=None, evolution_model=None,
-        mb_model_class=None, local_variables=None, set_local_variables=False,
-        target_yr=None, model_flowlines_filesuffix='',
-        **kwargs):
+        mb_model_class=None, save_mb_diagnostics_filesuffix=None,
+        local_variables=None, set_local_variables=False, target_yr=None,
+        model_flowlines_filesuffix='', **kwargs):
     """
     This function is one option for a 'run_function' for the
     'run_dynamic_melt_f_calibration' function (the corresponding
@@ -1711,6 +1757,12 @@ def dynamic_melt_f_run(
         Not all models work in all circumstances!
     mb_model_class : MassBalanceModel, default ``MonthlyTIModel``
         The MassBalanceModel class to use.
+    save_mb_diagnostics_filesuffix : str, optional
+        if provided, the mass balance model state is saved to
+        ``mb_diagnostics{save_mb_diagnostics_filesuffix}.nc`` after the run
+        completes, via :meth:`MultipleFlowlineMassBalance.save_to_file`.
+        Useful for saving a historical run before branching into multiple
+        projection scenarios.
     local_variables : None
         Not needed in this function, just here to match with the function
         call in run_dynamic_melt_f_calibration.
@@ -1747,17 +1799,19 @@ def dynamic_melt_f_run(
 
     # conduct model run
     try:
-        model = run_from_climate_data(gdir,
-                                      # force to raise an error in @entity_task
-                                      continue_on_error=False,
-                                      add_to_log_file=False,
-                                      settings_filesuffix=settings_filesuffix,
-                                      ys=ys, ye=ye,
-                                      output_filesuffix=output_filesuffix,
-                                      init_model_fls=fls_init,
-                                      evolution_model=evolution_model,
-                                      mb_model_class=mb_model_class,
-                                      **kwargs)
+        model = run_from_climate_data(
+            gdir,
+            # force to raise an error in @entity_task
+            continue_on_error=False,
+            add_to_log_file=False,
+            settings_filesuffix=settings_filesuffix,
+            ys=ys, ye=ye,
+            output_filesuffix=output_filesuffix,
+            init_model_fls=fls_init,
+            evolution_model=evolution_model,
+            mb_model_class=mb_model_class,
+            save_mb_diagnostics_filesuffix=save_mb_diagnostics_filesuffix,
+            **kwargs)
     except RuntimeError as e:
         raise RuntimeError(f'run_from_climate_data raised error! '
                            f'(Message: {e})')
@@ -1777,7 +1831,8 @@ def dynamic_melt_f_run(
 def dynamic_melt_f_run_fallback(
         gdir, melt_f, fls_init, ys, ye,
         settings_filesuffix='', output_filesuffix=None,
-        evolution_model=None, mb_model_class=None, target_yr=None, **kwargs):
+        evolution_model=None, mb_model_class=None,
+        save_mb_diagnostics_filesuffix=None, target_yr=None, **kwargs):
     """
     This is the fallback function corresponding to the function
     'dynamic_melt_f_run', which are provided to
@@ -1808,6 +1863,12 @@ def dynamic_melt_f_run_fallback(
         Not all models work in all circumstances!
     mb_model_class : MassBalanceModel, default ``MonthlyTIModel``
         The MassBalanceModel class to use.
+    save_mb_diagnostics_filesuffix : str, optional
+        if provided, the mass balance model state is saved to
+        ``mb_diagnostics{save_mb_diagnostics_filesuffix}.nc`` after the run
+        completes, via :meth:`MultipleFlowlineMassBalance.save_to_file`.
+        Useful for saving a historical run before branching into multiple
+        projection scenarios.
     target_yr : int or None
         The target year for a potential dynamic spinup (not needed here).
         Default is None
@@ -1830,17 +1891,19 @@ def dynamic_melt_f_run_fallback(
 
     # conduct model run
     try:
-        model = run_from_climate_data(gdir,
-                                      # force to raise an error in @entity_task
-                                      continue_on_error=False,
-                                      add_to_log_file=False,
-                                      settings_filesuffix=settings_filesuffix,
-                                      ys=ys, ye=ye,
-                                      output_filesuffix=output_filesuffix,
-                                      init_model_fls=fls_init,
-                                      mb_model_class=mb_model_class,
-                                      evolution_model=evolution_model,
-                                      **kwargs)
+        model = run_from_climate_data(
+            gdir,
+            # force to raise an error in @entity_task
+            continue_on_error=False,
+            add_to_log_file=False,
+            settings_filesuffix=settings_filesuffix,
+            ys=ys, ye=ye,
+            output_filesuffix=output_filesuffix,
+            init_model_fls=fls_init,
+            mb_model_class=mb_model_class,
+            save_mb_diagnostics_filesuffix=save_mb_diagnostics_filesuffix,
+            evolution_model=evolution_model,
+              **kwargs)
         gdir.settings['used_spinup_option'] = 'no spinup'
         # this is only for backwards compatibility
         gdir.add_to_diagnostics('used_spinup_option', 'no spinup')
@@ -1860,6 +1923,7 @@ def run_dynamic_melt_f_calibration(
         melt_f_max=None, melt_f_max_step_length_minimum=0.1, maxiter=20,
         ignore_errors=False, output_filesuffix=None,
         model_flowlines_filesuffix=None, mb_model_class=None,
+        save_mb_diagnostics_filesuffix=None,
         ys=None, ye=None, target_yr=None,
         run_function=dynamic_melt_f_run_with_dynamic_spinup,
         kwargs_run_function=None,
@@ -1959,6 +2023,12 @@ def run_dynamic_melt_f_calibration(
         Default is None
     mb_model_class : MassBalanceModel, default ``MonthlyTIModel``
         The MassBalanceModel class to use.
+    save_mb_diagnostics_filesuffix : str, optional
+        if provided, the mass balance model state is saved to
+        ``mb_diagnostics{save_mb_diagnostics_filesuffix}.nc`` after the run
+        completes, via :meth:`MultipleFlowlineMassBalance.save_to_file`.
+        Useful for saving a historical run before branching into multiple
+        projection scenarios.
     ys : int or None
         The start year of the conducted run. If None the first year of the
         provided climate file.
@@ -2192,13 +2262,15 @@ def run_dynamic_melt_f_calibration(
             # this is only for backwards compatibility
             gdir.add_to_diagnostics('used_spinup_option', 'fallback_function')
 
-            model = fallback_function(gdir=gdir,
-                                      settings_filesuffix=settings_filesuffix,
-                                      melt_f=melt_f, fls_init=fls_init,
-                                      mb_model_class=mb_model_class,
-                                      ys=ys, ye=ye,
-                                      output_filesuffix=output_filesuffix,
-                                      **kwargs_fallback_function)
+            model = fallback_function(
+                gdir=gdir,
+                settings_filesuffix=settings_filesuffix,
+                melt_f=melt_f, fls_init=fls_init,
+                mb_model_class=mb_model_class,
+                save_mb_diagnostics_filesuffix=save_mb_diagnostics_filesuffix,
+                ys=ys, ye=ye,
+                output_filesuffix=output_filesuffix,
+                **kwargs_fallback_function)
         else:
             # we were not able to reach the desired precision during the
             # minimisation, but at least we conducted a few error free runs
@@ -2216,16 +2288,18 @@ def run_dynamic_melt_f_calibration(
                 gdir.add_to_diagnostics('used_spinup_option',
                                         'dynamic melt_f calibration (part '
                                         'success)')
-            model, dmdtda_mdl = run_function(gdir=gdir,
-                                             settings_filesuffix=settings_filesuffix,
-                                             melt_f=melt_f,
-                                             yr0_ref_mb=yr0_ref_mb,
-                                             yr1_ref_mb=yr1_ref_mb,
-                                             fls_init=fls_init, ys=ys, ye=ye,
-                                             mb_model_class=mb_model_class,
-                                             output_filesuffix=output_filesuffix,
-                                             local_variables=local_variables_run_function,
-                                             **kwargs_run_function)
+            model, dmdtda_mdl = run_function(
+                gdir=gdir,
+                settings_filesuffix=settings_filesuffix,
+                melt_f=melt_f,
+                yr0_ref_mb=yr0_ref_mb,
+                yr1_ref_mb=yr1_ref_mb,
+                fls_init=fls_init, ys=ys, ye=ye,
+                mb_model_class=mb_model_class,
+                save_mb_diagnostics_filesuffix=save_mb_diagnostics_filesuffix,
+                output_filesuffix=output_filesuffix,
+                local_variables=local_variables_run_function,
+                **kwargs_run_function)
 
             # some dianostics for later
             diag_dyn_melt = {
@@ -2258,6 +2332,7 @@ def run_dynamic_melt_f_calibration(
                  melt_f=None, yr0_ref_mb=None, yr1_ref_mb=None,
                  fls_init=None, ys=None, ye=None,
                  mb_model_class=mb_model_class,
+                 save_mb_diagnostics_filesuffix=save_mb_diagnostics_filesuffix,
                  local_variables=local_variables_run_function,
                  model_flowlines_filesuffix=model_flowlines_filesuffix,
                  set_local_variables=True, **kwargs_run_function)
@@ -2269,16 +2344,18 @@ def run_dynamic_melt_f_calibration(
         dynamic_melt_f_calibration_runs.append(
             dynamic_melt_f_calibration_runs[-1] + 1)
 
-        model, dmdtda_mdl = run_function(gdir=gdir,
-                                         settings_filesuffix=settings_filesuffix,
-                                         melt_f=melt_f,
-                                         yr0_ref_mb=yr0_ref_mb,
-                                         yr1_ref_mb=yr1_ref_mb,
-                                         fls_init=fls_init, ys=ys, ye=ye,
-                                         mb_model_class=mb_model_class,
-                                         output_filesuffix=output_filesuffix,
-                                         local_variables=local_variables_run_function,
-                                         **kwargs_run_function)
+        model, dmdtda_mdl = run_function(
+            gdir=gdir,
+            settings_filesuffix=settings_filesuffix,
+            melt_f=melt_f,
+            yr0_ref_mb=yr0_ref_mb,
+            yr1_ref_mb=yr1_ref_mb,
+            fls_init=fls_init, ys=ys, ye=ye,
+            mb_model_class=mb_model_class,
+            save_mb_diagnostics_filesuffix=save_mb_diagnostics_filesuffix,
+            output_filesuffix=output_filesuffix,
+            local_variables=local_variables_run_function,
+            **kwargs_run_function)
         return model, dmdtda_mdl
 
     def cost_fct(melt_f, model_dynamic_spinup_end):

--- a/oggm/core/dynamic_spinup.py
+++ b/oggm/core/dynamic_spinup.py
@@ -4,6 +4,7 @@ import logging
 import copy
 import os
 import warnings
+from functools import partial
 
 # External libs
 import numpy as np
@@ -34,7 +35,7 @@ def run_dynamic_spinup(gdir, settings_filesuffix='',
                        init_model_filesuffix=None, init_model_yr=None,
                        init_model_fls=None,
                        climate_input_filesuffix='',
-                       evolution_model=None,
+                       evolution_model=None, mb_model_class=None,
                        mb_model_historical=None, mb_model_spinup=None,
                        spinup_period_initial=20, spinup_start_yr=None,
                        min_spinup_period=10, spinup_start_yr_max=None,
@@ -101,6 +102,8 @@ def run_dynamic_spinup(gdir, settings_filesuffix='',
     evolution_model : :class:oggm.core.FlowlineModel
         which evolution model to use. Default: gdir.settings['evolution_model']
         Not all models work in all circumstances!
+    mb_model_class : MassBalanceModel, default ``MonthlyTIModel``
+        The MassBalanceModel class to use.
     mb_model_historical : :py:class:`core.MassBalanceModel`
         User-povided MassBalanceModel instance for the historical run. Default
         is to use a MonthlyTIModel model  together with the provided
@@ -240,6 +243,9 @@ def run_dynamic_spinup(gdir, settings_filesuffix='',
     evolution_model = decide_evolution_model(gdir=gdir,
                                              evolution_model=evolution_model)
 
+    if mb_model_class is None:
+        mb_model_class = MonthlyTIModel
+
     # handling of the observations here, there are two options matching area or
     # volume
     if minimise_for == 'area':
@@ -370,7 +376,8 @@ def run_dynamic_spinup(gdir, settings_filesuffix='',
     if mb_model_historical is None:
         mb_model_historical = MultipleFlowlineMassBalance(
             gdir, settings_filesuffix=settings_filesuffix,
-            mb_model_class=MonthlyTIModel,
+            mb_model_class=mb_model_class,
+            flowlines_filesuffix=model_flowlines_filesuffix,
             filename='climate_historical',
             input_filesuffix=climate_input_filesuffix)
 
@@ -437,6 +444,7 @@ def run_dynamic_spinup(gdir, settings_filesuffix='',
         if settings_filesuffix == '':
             gdir.add_to_diagnostics('run_dynamic_spinup_success', False)
         yr_use = np.clip(target_yr, yr_min, None)
+        mb_model_historical.reset_state()
         model_dynamic_spinup_end = evolution_model(flowlines=fls_spinup,
                                                    mb_model=mb_model_historical,
                                                    y0=yr_use,
@@ -504,6 +512,7 @@ def run_dynamic_spinup(gdir, settings_filesuffix='',
 
         # with t_spinup the glacier state after spinup is changed between iterations
         mb_model_spinup.temp_bias = t_spinup
+        mb_model_spinup.reset_state()
         # run the spinup
         model_spinup = evolution_model(flowlines=copy.deepcopy(fls_spinup),
                                        mb_model=mb_model_spinup,
@@ -519,6 +528,7 @@ def run_dynamic_spinup(gdir, settings_filesuffix='',
             ice_free = True
 
         # Now conduct the actual model run to the rgi date
+        mb_model_historical.reset_state()
         model_historical = evolution_model(flowlines=model_spinup.fls,
                                            mb_model=mb_model_historical,
                                            y0=yr_spinup,
@@ -939,7 +949,9 @@ def run_dynamic_spinup(gdir, settings_filesuffix='',
             # ConstantMassBalance
             mb_model_spinup = MultipleFlowlineMassBalance(
                 gdir, settings_filesuffix=settings_filesuffix,
-                mb_model_class=ConstantMassBalance,
+                mb_model_class=partial(ConstantMassBalance,
+                                       mb_model_class=mb_model_class),
+                flowlines_filesuffix=model_flowlines_filesuffix,
                 filename='climate_historical',
                 input_filesuffix=climate_input_filesuffix, y0=y0_spinup,
                 halfsize=halfsize_spinup)
@@ -1047,7 +1059,7 @@ def define_new_melt_f_in_gdir(gdir, new_melt_f):
 def dynamic_melt_f_run_with_dynamic_spinup(
         gdir, melt_f, yr0_ref_mb, yr1_ref_mb, fls_init, ys, ye,
         settings_filesuffix='', output_filesuffix=None, evolution_model=None,
-        mb_model_historical=None, mb_model_spinup=None,
+        mb_model_class=None, mb_model_historical=None, mb_model_spinup=None,
         model_flowlines_filesuffix='',
         minimise_for='area', climate_input_filesuffix='', spinup_period_initial=20,
         min_spinup_period=10, target_yr=None, precision_percent=1,
@@ -1056,8 +1068,7 @@ def dynamic_melt_f_run_with_dynamic_spinup(
         store_model_geometry=True, store_fl_diagnostics=None,
         local_variables=None, set_local_variables=False, do_inversion=True,
         spinup_start_yr_max=None, add_fixed_geometry_spinup=True,
-        spinup_periods_to_try=None, mb_model_class_apparent_mb=None,
-        **kwargs):
+        spinup_periods_to_try=None, **kwargs):
     """
     This function is one option for a 'run_function' for the
     'run_dynamic_melt_f_calibration' function (the corresponding
@@ -1096,6 +1107,8 @@ def dynamic_melt_f_run_with_dynamic_spinup(
     evolution_model : :class:oggm.core.FlowlineModel
         which evolution model to use. Default: gdir.settings['evolution_model']
         Not all models work in all circumstances!
+    mb_model_class : MassBalanceModel, default ``MonthlyTIModel``
+        The MassBalanceModel class to use.
     mb_model_historical : :py:class:`core.MassBalanceModel`
         User-povided MassBalanceModel instance for the historical run. Default
         is to use a MonthlyTIModel model  together with the provided
@@ -1203,9 +1216,6 @@ def dynamic_melt_f_run_with_dynamic_spinup(
         If spinup_period_initial and min_spinup_period were not successful, you
         can provide here a list of spinup periods which should be tried in order.
         Default is None
-    mb_model_class_apparent_mb : py:class:`core.MassBalanceModel`
-        The mass balance model class which should be used to define the apparent
-        mb for the inversion.
     kwargs : dict
         kwargs to pass to the evolution_model instance
 
@@ -1220,6 +1230,9 @@ def dynamic_melt_f_run_with_dynamic_spinup(
 
     evolution_model = decide_evolution_model(gdir=gdir,
                                              evolution_model=evolution_model)
+
+    if mb_model_class is None:
+        mb_model_class = MonthlyTIModel
 
     if not isinstance(local_variables, dict):
         raise ValueError('You must provide a dict for local_variables!')
@@ -1297,7 +1310,7 @@ def dynamic_melt_f_run_with_dynamic_spinup(
             apparent_mb_from_any_mb(gdir,
                                     settings_filesuffix=settings_filesuffix,
                                     add_to_log_file=False,  # dont write to log
-                                    mb_model_class=mb_model_class_apparent_mb,
+                                    mb_model_class=mb_model_class,
                                     )
             # do inversion with A calibration to current volume
             calibrate_inversion_from_volume(
@@ -1334,6 +1347,7 @@ def dynamic_melt_f_run_with_dynamic_spinup(
             init_model_fls=fls_init,
             climate_input_filesuffix=climate_input_filesuffix,
             evolution_model=evolution_model,
+            mb_model_class=mb_model_class,
             mb_model_historical=mb_model_historical,
             mb_model_spinup=mb_model_spinup,
             spinup_period_initial=spinup_period_initial,
@@ -1379,7 +1393,7 @@ def dynamic_melt_f_run_with_dynamic_spinup(
 def dynamic_melt_f_run_with_dynamic_spinup_fallback(
         gdir, melt_f, fls_init, ys, ye,
         settings_filesuffix='', output_filesuffix=None,
-        evolution_model=None, minimise_for='area',
+        evolution_model=None, mb_model_class=None, minimise_for='area',
         mb_model_historical=None, mb_model_spinup=None,
         climate_input_filesuffix='', spinup_period_initial=20,
         min_spinup_period=10, target_yr=None, precision_percent=1,
@@ -1388,7 +1402,7 @@ def dynamic_melt_f_run_with_dynamic_spinup_fallback(
         store_model_geometry=True, store_fl_diagnostics=None,
         do_inversion=True, spinup_start_yr_max=None,
         add_fixed_geometry_spinup=True, spinup_periods_to_try=None,
-        mb_model_class_apparent_mb=None, **kwargs):
+        **kwargs):
     """
     This is the fallback function corresponding to the function
     'dynamic_melt_f_run_with_dynamic_spinup', which are provided
@@ -1419,6 +1433,8 @@ def dynamic_melt_f_run_with_dynamic_spinup_fallback(
     evolution_model : :class:oggm.core.FlowlineModel
         which evolution model to use. Default: gdir.settings['evolution_model']
         Not all models work in all circumstances!
+    mb_model_class : MassBalanceModel, default ``MonthlyTIModel``
+        The MassBalanceModel class to use.
     mb_model_historical : :py:class:`core.MassBalanceModel`
         User-povided MassBalanceModel instance for the historical run. Default
         is to use a MonthlyTIModel model  together with the provided
@@ -1513,9 +1529,6 @@ def dynamic_melt_f_run_with_dynamic_spinup_fallback(
         If spinup_period_initial and min_spinup_period were not successful, you
         can provide here a list of spinup periods which should be tried in order.
         Default is None
-    mb_model_class_apparent_mb : py:class:`core.MassBalanceModel`
-        The mass balance model class which should be used to define the apparent
-        mb for the inversion.
     kwargs : dict
         kwargs to pass to the evolution_model instance
 
@@ -1532,6 +1545,9 @@ def dynamic_melt_f_run_with_dynamic_spinup_fallback(
     evolution_model = decide_evolution_model(gdir=gdir,
                                              evolution_model=evolution_model)
 
+    if mb_model_class is None:
+        mb_model_class = MonthlyTIModel
+
     # revert gdir to original state if necessary
     if melt_f != gdir.settings['melt_f']:
         define_new_melt_f_in_gdir(gdir, melt_f)
@@ -1539,7 +1555,7 @@ def dynamic_melt_f_run_with_dynamic_spinup_fallback(
             with utils.DisableLogger():
                 apparent_mb_from_any_mb(gdir,
                                         settings_filesuffix=settings_filesuffix,
-                                        mb_model_class=mb_model_class_apparent_mb,
+                                        mb_model_class=mb_model_class,
                                         add_to_log_file=False)
                 calibrate_inversion_from_volume(
                     [gdir], settings_filesuffix=settings_filesuffix,
@@ -1573,6 +1589,7 @@ def dynamic_melt_f_run_with_dynamic_spinup_fallback(
             init_model_fls=fls_init,
             climate_input_filesuffix=climate_input_filesuffix,
             evolution_model=evolution_model,
+            mb_model_class=mb_model_class,
             mb_model_historical=mb_model_historical,
             mb_model_spinup=mb_model_spinup,
             spinup_period_initial=spinup_period_initial,
@@ -1629,6 +1646,7 @@ def dynamic_melt_f_run_with_dynamic_spinup_fallback(
         gdir.add_to_diagnostics('run_dynamic_spinup_success', False)
 
         # try to make a fixed geometry spinup
+        mb_model_historical.reset_state()
         model_end = run_from_climate_data(
             gdir,
             # force to raise an error in @entity_task
@@ -1642,6 +1660,7 @@ def dynamic_melt_f_run_with_dynamic_spinup_fallback(
             store_model_geometry=store_model_geometry,
             store_fl_diagnostics=store_fl_diagnostics,
             init_model_fls=fls_init, evolution_model=evolution_model,
+            mb_model_class=mb_model_class,
             fixed_geometry_spinup_yr=ys)
 
         gdir.settings['used_spinup_option'] = 'fixed geometry spinup'
@@ -1654,8 +1673,8 @@ def dynamic_melt_f_run_with_dynamic_spinup_fallback(
 def dynamic_melt_f_run(
         gdir, melt_f, yr0_ref_mb, yr1_ref_mb, fls_init, ys, ye,
         settings_filesuffix='',  output_filesuffix=None, evolution_model=None,
-        local_variables=None, set_local_variables=False, target_yr=None,
-        model_flowlines_filesuffix='',
+        mb_model_class=None, local_variables=None, set_local_variables=False,
+        target_yr=None, model_flowlines_filesuffix='',
         **kwargs):
     """
     This function is one option for a 'run_function' for the
@@ -1690,6 +1709,8 @@ def dynamic_melt_f_run(
     evolution_model : :class:oggm.core.FlowlineModel
         which evolution model to use. Default: gdir.settings['evolution_model']
         Not all models work in all circumstances!
+    mb_model_class : MassBalanceModel, default ``MonthlyTIModel``
+        The MassBalanceModel class to use.
     local_variables : None
         Not needed in this function, just here to match with the function
         call in run_dynamic_melt_f_calibration.
@@ -1714,6 +1735,9 @@ def dynamic_melt_f_run(
     evolution_model = decide_evolution_model(gdir=gdir,
                                              evolution_model=evolution_model)
 
+    if mb_model_class is None:
+        mb_model_class = MonthlyTIModel
+
     if set_local_variables:
         # No local variables needed in this function
         return None
@@ -1732,6 +1756,7 @@ def dynamic_melt_f_run(
                                       output_filesuffix=output_filesuffix,
                                       init_model_fls=fls_init,
                                       evolution_model=evolution_model,
+                                      mb_model_class=mb_model_class,
                                       **kwargs)
     except RuntimeError as e:
         raise RuntimeError(f'run_from_climate_data raised error! '
@@ -1752,7 +1777,7 @@ def dynamic_melt_f_run(
 def dynamic_melt_f_run_fallback(
         gdir, melt_f, fls_init, ys, ye,
         settings_filesuffix='', output_filesuffix=None,
-        evolution_model=None, target_yr=None, **kwargs):
+        evolution_model=None, mb_model_class=None, target_yr=None, **kwargs):
     """
     This is the fallback function corresponding to the function
     'dynamic_melt_f_run', which are provided to
@@ -1781,6 +1806,8 @@ def dynamic_melt_f_run_fallback(
     evolution_model : :class:oggm.core.FlowlineModel
         which evolution model to use. Default: gdir.settings['evolution_model']
         Not all models work in all circumstances!
+    mb_model_class : MassBalanceModel, default ``MonthlyTIModel``
+        The MassBalanceModel class to use.
     target_yr : int or None
         The target year for a potential dynamic spinup (not needed here).
         Default is None
@@ -1811,6 +1838,7 @@ def dynamic_melt_f_run_fallback(
                                       ys=ys, ye=ye,
                                       output_filesuffix=output_filesuffix,
                                       init_model_fls=fls_init,
+                                      mb_model_class=mb_model_class,
                                       evolution_model=evolution_model,
                                       **kwargs)
         gdir.settings['used_spinup_option'] = 'no spinup'
@@ -1831,7 +1859,7 @@ def run_dynamic_melt_f_calibration(
         ref_mb_period=None, melt_f_min=None,
         melt_f_max=None, melt_f_max_step_length_minimum=0.1, maxiter=20,
         ignore_errors=False, output_filesuffix=None,
-        model_flowlines_filesuffix=None,
+        model_flowlines_filesuffix=None, mb_model_class=None,
         ys=None, ye=None, target_yr=None,
         run_function=dynamic_melt_f_run_with_dynamic_spinup,
         kwargs_run_function=None,
@@ -1929,6 +1957,8 @@ def run_dynamic_melt_f_calibration(
         for the model flowline to use if no other flowlines for initialisation
         are provided. If None the settings_filesuffix will be used.
         Default is None
+    mb_model_class : MassBalanceModel, default ``MonthlyTIModel``
+        The MassBalanceModel class to use.
     ys : int or None
         The start year of the conducted run. If None the first year of the
         provided climate file.
@@ -1989,6 +2019,9 @@ def run_dynamic_melt_f_calibration(
 
     if model_flowlines_filesuffix is None:
         model_flowlines_filesuffix = settings_filesuffix
+
+    if mb_model_class is None:
+        mb_model_class = MonthlyTIModel
 
     # melt_f constraints
     if melt_f_min is None:
@@ -2162,6 +2195,7 @@ def run_dynamic_melt_f_calibration(
             model = fallback_function(gdir=gdir,
                                       settings_filesuffix=settings_filesuffix,
                                       melt_f=melt_f, fls_init=fls_init,
+                                      mb_model_class=mb_model_class,
                                       ys=ys, ye=ye,
                                       output_filesuffix=output_filesuffix,
                                       **kwargs_fallback_function)
@@ -2188,6 +2222,7 @@ def run_dynamic_melt_f_calibration(
                                              yr0_ref_mb=yr0_ref_mb,
                                              yr1_ref_mb=yr1_ref_mb,
                                              fls_init=fls_init, ys=ys, ye=ye,
+                                             mb_model_class=mb_model_class,
                                              output_filesuffix=output_filesuffix,
                                              local_variables=local_variables_run_function,
                                              **kwargs_run_function)
@@ -2222,6 +2257,7 @@ def run_dynamic_melt_f_calibration(
     run_function(gdir=gdir, settings_filesuffix=settings_filesuffix,
                  melt_f=None, yr0_ref_mb=None, yr1_ref_mb=None,
                  fls_init=None, ys=None, ye=None,
+                 mb_model_class=mb_model_class,
                  local_variables=local_variables_run_function,
                  model_flowlines_filesuffix=model_flowlines_filesuffix,
                  set_local_variables=True, **kwargs_run_function)
@@ -2239,6 +2275,7 @@ def run_dynamic_melt_f_calibration(
                                          yr0_ref_mb=yr0_ref_mb,
                                          yr1_ref_mb=yr1_ref_mb,
                                          fls_init=fls_init, ys=ys, ye=ye,
+                                         mb_model_class=mb_model_class,
                                          output_filesuffix=output_filesuffix,
                                          local_variables=local_variables_run_function,
                                          **kwargs_run_function)

--- a/oggm/core/dynamic_spinup.py
+++ b/oggm/core/dynamic_spinup.py
@@ -1691,7 +1691,8 @@ def dynamic_melt_f_run_with_dynamic_spinup_fallback(
         gdir.add_to_diagnostics('run_dynamic_spinup_success', False)
 
         # try to make a fixed geometry spinup
-        mb_model_historical.reset_state()
+        if mb_model_historical is not None:
+            mb_model_historical.reset_state()
         model_end = run_from_climate_data(
             gdir,
             # force to raise an error in @entity_task

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -610,7 +610,7 @@ class FlowlineModel(object):
                  is_tidewater=False, is_lake_terminating=False,
                  mb_elev_feedback='annual', check_for_boundaries=None,
                  water_level=None, required_model_steps='monthly',
-                 include_mb_model_heights=True, include_firn_outputs=False, ):
+                 include_mb_model_heights=True, include_firn_outputs=True, ):
         """Create a new flowline model from the flowlines and a MB model.
 
         Parameters
@@ -663,7 +663,7 @@ class FlowlineModel(object):
             If True we add the snow/firn height of the current mb_model (if
             available) to include this in the elevation feedback of the mb
             calculation.
-        include_firn_outputs : bool, default False
+        include_firn_outputs : bool, default True
             If True we include firn/snow output for volume, mass and thickness.
             With this you get for each of them three output variables. E.g. for
             volume: volume_m3 = volume_ice_m3 + volume_firn_m3. If False only
@@ -922,8 +922,8 @@ class FlowlineModel(object):
         if isinstance(self._mb_model, MultipleFlowlineMassBalance):
             return self._mb_model.flowline_mb_models[fl_id]
         else:
-            # we only allow a single flowline for this case
-            assert len(self.fls) == 1
+            # in this case the provided mb_model can work on any fl and has no
+            # memory (e.g. like the SfcTypeTIModel)
             return self._mb_model
 
     def _get_along_fl_thickness_firn_m(self, fl_id):

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -3985,7 +3985,8 @@ def run_random_climate(gdir, settings_filesuffix='',
                        store_fl_diagnostics=None,
                        mb_model_class=MonthlyTIModel,
                        climate_filename='climate_historical',
-                       climate_input_filesuffix='',
+                       climate_input_filesuffix=None,
+                       flowlines_filesuffix='',
                        output_filesuffix=None, init_model_fls=None,
                        init_model_filesuffix=None,
                        init_model_yr=None,
@@ -4048,6 +4049,8 @@ def run_random_climate(gdir, settings_filesuffix='',
         'gcm_data'
     climate_input_filesuffix: str
         filesuffix for the input climate file
+    flowlines_filesuffix : str
+        suffix to the model_flowlines to use. Default is ''
     output_filesuffix : str
         this add a suffix to the output file (useful to avoid overwriting
         previous experiments)
@@ -4079,6 +4082,7 @@ def run_random_climate(gdir, settings_filesuffix='',
                                            bias=bias, seed=seed,
                                            filename=climate_filename,
                                            input_filesuffix=climate_input_filesuffix,
+                                           flowlines_filesuffix=flowlines_filesuffix,
                                            unique_samples=unique_samples,
                                            settings_filesuffix=settings_filesuffix)
 
@@ -4102,6 +4106,7 @@ def run_random_climate(gdir, settings_filesuffix='',
                               init_model_yr=init_model_yr,
                               init_model_fls=init_model_fls,
                               zero_initial_glacier=zero_initial_glacier,
+                              model_flowlines_filesuffix=flowlines_filesuffix,
                               **kwargs)
 
 
@@ -4119,7 +4124,7 @@ def run_constant_climate(gdir, settings_filesuffix='',
                          output_filesuffix=None,
                          climate_filename='climate_historical',
                          mb_model_class=MonthlyTIModel,
-                         climate_input_filesuffix='',
+                         climate_input_filesuffix=None,
                          init_model_fls=None,
                          zero_initial_glacier=False,
                          **kwargs):
@@ -4239,7 +4244,7 @@ def run_from_climate_data(gdir, settings_filesuffix='',
                           climate_filename='climate_historical',
                           mb_model=None,
                           mb_model_class=MonthlyTIModel,
-                          climate_input_filesuffix='', output_filesuffix=None,
+                          climate_input_filesuffix=None, output_filesuffix=None,
                           init_model_filesuffix=None, init_model_yr=None,
                           init_model_fls=None, zero_initial_glacier=False,
                           bias=0, temperature_bias=None,

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -3427,7 +3427,7 @@ class MultipleFlowlineMassBalance(MassBalanceModel):
                  fls=None, mb_model_class=MonthlyTIModel,
                  use_inversion_flowlines=False,
                  flowlines_filesuffix='',
-                 input_filesuffix='',
+                 input_filesuffix=None,
                  **kwargs):
         """Initialize.
 
@@ -3478,6 +3478,7 @@ class MultipleFlowlineMassBalance(MassBalanceModel):
         for fl in self.fls:
             # Merged glaciers will need different climate files, use filesuffix
             if (fl.rgi_id is not None) and (fl.rgi_id != gdir.rgi_id):
+                input_filesuffix = '' if input_filesuffix is None else None
                 rgi_filesuffix = '_' + fl.rgi_id + input_filesuffix
             else:
                 rgi_filesuffix = input_filesuffix
@@ -3486,11 +3487,13 @@ class MultipleFlowlineMassBalance(MassBalanceModel):
             if 'fl' in inspect.signature(mb_model_class).parameters:
                 kwargs['fl'] = fl
 
+            if rgi_filesuffix is not None:
+                kwargs['input_filesuffix'] = rgi_filesuffix
+
             self.flowline_mb_models.append(
                 mb_model_class(
                     gdir=gdir,
                     settings_filesuffix=settings_filesuffix,
-                    input_filesuffix=rgi_filesuffix,
                     **kwargs,
                 )
             )

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -5577,6 +5577,11 @@ def fixed_geometry_mass_balance(gdir, settings_filesuffix='',
     if years is None:
         if ys is None:
             ys = mbmod.flowline_mb_models[0].ys
+            if ys is None:
+                if isinstance(mbmod.flowline_mb_models[0], SfcTypeTIModel):
+                    # for SfcTypeTIModel we need go one layer deeper
+                    sfc_mbod = mbmod.flowline_mb_models[0]
+                    ys = sfc_mbod.mbmod.ys + sfc_mbod.spinup_years
         if ye is None:
             ye = mbmod.flowline_mb_models[0].ye
         years = np.arange(ys, ye + 1)

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -5461,11 +5461,11 @@ def apparent_mb_from_any_mb(gdir, settings_filesuffix='',
         smb = 0
         for yr in mb_years:
             # some models have a climatic and ice mb (e.g. SfcTIModel), for
-            # inversion we want ice; if not available it is ignored; Similarly
-            # some models include a bucket height, and we can add this height on
-            # top to the ice surface height
+            # inversion we use climatic; if not available it is ignored;
+            # Similarly some models include a bucket height, and we can add this
+            # height on top to the ice surface height
             amb = mb_model.get_annual_mb(fl.surface_h, fls=fls, fl_id=fl_id, year=yr,
-                                         climatic_mb_or_ice_mb='ice_mb',
+                                         climatic_mb_or_ice_mb='climatic_mb',
                                          include_mb_model_heights=include_mb_model_heights
                                          )
             amb *= mb_model.sec_in_year(year=yr) * rho

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -1004,8 +1004,8 @@ class DailyTIModel(MonthlyTIModel):
     def __init__(
         self,
         gdir,
-        filename: str = 'climate_historical_daily',
-        input_filesuffix: str = '',
+        filename: str = 'climate_historical',
+        input_filesuffix: str = '_daily',
         settings_filesuffix: str = '',
         fl_id: int = None,
         melt_f: float = None,
@@ -1026,10 +1026,10 @@ class DailyTIModel(MonthlyTIModel):
         ----------
         gdir : GlacierDirectory
             The glacier directory.
-        filename : str, default 'climate_historical_daily'
+        filename : str, default 'climate_historical'
             Set to a different BASENAME if you want to use alternative
             climate data.
-        input_filesuffix : str, optional
+        input_filesuffix : str, default '_daily'
             Append a suffix to the climate input filename (useful for
             GCM runs).
         settings_filesuffix : str, optional
@@ -1339,15 +1339,15 @@ class SfcTypeTIModel(MassBalanceModel):
         gdir,
         settings_filesuffix: str = "",
         use_leap_years: bool = True,
-        mb_model_class=DailyTIModel,
+        mb_model_class=MonthlyTIModel,
         climate_resolution: str = "monthly",
         aging_frequency: str = "monthly",
         melt_f_ratio: float = 0.5,
         melt_f_change: str = "neg_exp",
         tau_e: float = 1.0,
-        ys: int = 2000,
+        ys: int = None,
         spinup_years: int = 6,
-        save_spinup_mbs: bool = False,
+        save_spinup_mbs: bool = True,
         spinup_buckets: np.ndarray = None,
         fl = None,
         use_main_fl_from: str = 'inversion_flowlines',
@@ -1397,10 +1397,18 @@ class SfcTypeTIModel(MassBalanceModel):
             melt_f=melt_f_ice+(melt_f_snow-melt_f_ice)*np.exp(-time_yr/tau_e_fold_yr)
             Must be larger than zero to prevent ``melt_f`` being set to NaN in
             the first bucket.
-        ys : int, default 2000
+        ys : int, default None
             The initial year from where we want to get mb values. This means the
             bucket system is spun up so that at ys for the first time ice
             can form. For spinup the years ys - spinup_years up to ys are used.
+            If None (the default), ys is not fixed at initialisation. Instead
+            it is set the first time get_annual_mb, get_monthly_mb or
+            get_daily_mb is called, using the first requested year (rounded
+            down to the next integer year via np.floor), and the buckets are
+            initialised at that point. Every call to reset_state resets ys
+            back to None again, so it is re-derived on the next call. If ys
+            is explicitly provided here, it is fixed and unaffected by
+            reset_state.
         spinup_years : int, default 6
             Number of spinup years. This defines the number of buckets we use
             (see aging_frequency for explanation). The minimum allowed value is
@@ -1481,8 +1489,15 @@ class SfcTypeTIModel(MassBalanceModel):
         self.input_filesuffix = self.mbmod.input_filesuffix
         self.hemisphere = self.mbmod.hemisphere
         self.bias = self.mbmod.bias
-        self.ys = self.mbmod.ys
         self.ye = self.mbmod.ye
+
+        # if ys is not provided we leave self.ys as None and set it lazily to
+        # the first year requested via get_annual_mb, get_monthly_mb or
+        # get_daily_mb (see _ensure_buckets_initialized). reset_state also
+        # resets self.ys back to None in that case, so it is again derived
+        # from the next requested year.
+        self._ys_is_dynamic = ys is None
+        self.ys = ys
 
         # check compatibility of aging_frequency and climate_resolution: aging
         # can not happen at higher temporal resolution than the climate steps
@@ -1517,22 +1532,12 @@ class SfcTypeTIModel(MassBalanceModel):
         self.spinup_buckets = spinup_buckets
         if isinstance(self.spinup_buckets, pd.core.frame.DataFrame):
             self.spinup_buckets = self.spinup_buckets.values
-        self.ys = ys
-        if self.spinup_buckets is None:
-            # check if climate data for spinup is available
-            spinup_start = self.ys - self.spinup_years
-            try:
-                self.mbmod.validate_year(spinup_start)
-                self.mbmod.validate_year(self.ys)
-            except ValueError as e:
-                raise ValueError(
-                    "Climate data for spinup not available. We need data for "
-                    f"the period {spinup_start} (ys - spinup_years) to "
-                    f"{self.ys}, but we get the following error: {e}")
+
+        if self.ys is not None:
+            self._validate_spinup_climate_data()
 
         # defining the number of grid points and the spinup heights, either with
         # fl or hbins
-        # TODO: need to test with constant_mb (maybe hbins[::-1])
         self.hbins = hbins
 
         # resolve the flowline into grid labels and spinup heights; the fl
@@ -1627,8 +1632,40 @@ class SfcTypeTIModel(MassBalanceModel):
             # covered or fully snow free
             self.snowline_inf_values = {}
 
-        # Initialise buckets and conduct a potential spinup
-        self._init_buckets()
+        # Initialise buckets and conduct a potential spinup. If ys was not
+        # provided this is deferred to the first call of get_annual_mb,
+        # get_monthly_mb or get_daily_mb (see _ensure_buckets_initialized).
+        if self.ys is not None:
+            self._init_buckets()
+
+    def reset_state(self):
+        if self._ys_is_dynamic:
+            # ys will be re-derived from the first year requested at the
+            # next call to get_annual_mb, get_monthly_mb or get_daily_mb
+            self.ys = None
+        else:
+            self._init_buckets()
+
+    def _validate_spinup_climate_data(self):
+        if self.spinup_buckets is None:
+            # check if climate data for spinup is available
+            spinup_start = self.ys - self.spinup_years
+            try:
+                self.mbmod.validate_year(spinup_start)
+                self.mbmod.validate_year(self.ys)
+            except ValueError as e:
+                raise ValueError(
+                    "Climate data for spinup not available. We need data for "
+                    f"the period {spinup_start} (ys - spinup_years) to "
+                    f"{self.ys}, but we get the following error: {e}")
+
+    def _ensure_buckets_initialized(self, year):
+        # if ys was not provided at initialisation, derive it from the
+        # first requested year and (re-)initialise the buckets
+        if self.ys is None:
+            self.ys = int(np.floor(year))
+            self._validate_spinup_climate_data()
+            self._init_buckets()
 
     def _init_buckets(self):
         # reset some containers for a fresh start
@@ -1766,8 +1803,8 @@ class SfcTypeTIModel(MassBalanceModel):
         """Set new melt_f and reset the buckets."""
         self.mbmod.melt_f = value
         self.set_melt_f_buckets()
-        # Recompute buckets
-        self._init_buckets()
+        # Reset state, we do not want to change parameters midway
+        self.reset_state()
 
     @property
     def prcp_fac(self):
@@ -1778,8 +1815,8 @@ class SfcTypeTIModel(MassBalanceModel):
     def prcp_fac(self, value):
         """Set new precipitation factor and reset buckets."""
         self.mbmod.prcp_fac = value
-        # Recompute buckets
-        self._init_buckets()
+        # Reset state, we do not want to change parameters midway
+        self.reset_state()
 
     @property
     def temp_bias(self):
@@ -1789,8 +1826,8 @@ class SfcTypeTIModel(MassBalanceModel):
     def temp_bias(self, value):
         """Set new temperature bias and reset buckets."""
         self.mbmod.temp_bias = value
-        # Recompute buckets
-        self._init_buckets()
+        # Reset state, we do not want to change parameters midway
+        self.reset_state()
 
     def set_melt_f_buckets(self):
         """Set the melt factor for each bucket."""
@@ -2258,6 +2295,10 @@ class SfcTypeTIModel(MassBalanceModel):
             solid precipitation.
         """
 
+        # if ys was not provided at initialisation, this sets it from year
+        # and (re-)initialises the buckets on the first call
+        self._ensure_buckets_initialized(year)
+
         # check if we should add the current bucket heights
         if include_mb_model_heights:
             heights = heights + self.columns_thickness_m
@@ -2350,6 +2391,10 @@ class SfcTypeTIModel(MassBalanceModel):
             temperature, the sums of melt temperature, total precipitation, and
             solid precipitation.
         """
+
+        # if ys was not provided at initialisation, this sets it from year
+        # and (re-)initialises the buckets on the first call
+        self._ensure_buckets_initialized(year)
 
         # check if we should add the current bucket heights
         if include_mb_model_heights:
@@ -2453,6 +2498,10 @@ class SfcTypeTIModel(MassBalanceModel):
             temperature, the sums of melt temperature, total precipitation, and
             solid precipitation.
         """
+
+        # if ys was not provided at initialisation, this sets it from year
+        # and (re-)initialises the buckets on the first call
+        self._ensure_buckets_initialized(year)
 
         # check if we should add the current bucket heights
         if include_mb_model_heights:
@@ -3377,6 +3426,7 @@ class MultipleFlowlineMassBalance(MassBalanceModel):
     def __init__(self, gdir, settings_filesuffix='',
                  fls=None, mb_model_class=MonthlyTIModel,
                  use_inversion_flowlines=False,
+                 flowlines_filesuffix='',
                  input_filesuffix='',
                  **kwargs):
         """Initialize.
@@ -3395,6 +3445,11 @@ class MultipleFlowlineMassBalance(MassBalanceModel):
             ``ConstantMassBalance``.
         use_inversion_flowlines: bool, optional
             use 'inversion_flowlines' instead of 'model_flowlines'
+        flowlines_filesuffix : str
+            suffix to the flowlines filename to use (could be
+            'inversion_flowlines' or 'model_flowlines', depending on
+            'use_inversion_flowlines').
+            Default is ''
         kwargs : kwargs to pass to mb_model_class
         """
 
@@ -3403,11 +3458,13 @@ class MultipleFlowlineMassBalance(MassBalanceModel):
 
         # Read in the flowlines
         if use_inversion_flowlines:
-            fls = gdir.read_pickle('inversion_flowlines')
+            fls = gdir.read_pickle('inversion_flowlines',
+                                   filesuffix=flowlines_filesuffix)
 
         if fls is None:
             try:
-                fls = gdir.read_pickle('model_flowlines')
+                fls = gdir.read_pickle('model_flowlines',
+                                       filesuffix=flowlines_filesuffix)
             except FileNotFoundError:
                 raise InvalidWorkflowError('Need a valid `model_flowlines` '
                                            'file. If you explicitly want to '
@@ -3476,6 +3533,33 @@ class MultipleFlowlineMassBalance(MassBalanceModel):
         for mbmod in self.flowline_mb_models:
             mbmod.bias = value
 
+    @property
+    def melt_f(self):
+        """Melt factor."""
+        return self.flowline_mb_models[0].melt_f
+
+    @melt_f.setter
+    def melt_f(self, value):
+        """Melt factor."""
+        for mbmod in self.flowline_mb_models:
+            mbmod.melt_f = value
+
+    @property
+    def filename(self):
+        return self.flowline_mb_models[0].filename
+
+    @property
+    def input_filesuffix(self):
+        return self.flowline_mb_models[0].input_filesuffix
+
+    @property
+    def ys_float(self):
+        return self.flowline_mb_models[0].ys_float
+
+    @property
+    def ye_float(self):
+        return self.flowline_mb_models[0].ye_float
+
     def is_year_valid(self, year):
         return self.flowline_mb_models[0].is_year_valid(year)
 
@@ -3484,6 +3568,10 @@ class MultipleFlowlineMassBalance(MassBalanceModel):
 
     def sec_in_year(self, year):
         return self.flowline_mb_models[0].sec_in_year(year)
+
+    def reset_state(self):
+        for fl_mb_mod in self.flowline_mb_models:
+            fl_mb_mod.reset_state()
 
     def get_daily_mb(self, heights, year=None, fl_id=None, **kwargs):
         if fl_id is None:
@@ -4941,15 +5029,32 @@ def mb_calibration_from_scalar_mb(gdir, *,
             temp_bias = 0
 
     # Create the MB model we will calibrate
-    mb_mod = mb_model_class(
-        gdir=gdir,
-        melt_f=melt_f,
-        temp_bias=temp_bias,
-        prcp_fac=prcp_fac,
-        check_calib_params=False,
-        settings_filesuffix=settings_filesuffix,
-        **kwargs
-    )
+    if fls is not None and len(fls) > 1:
+        # one mb model instance per flowline, needed for mb_model_class
+        # models that need to know the flowline length at initialisation
+        # (e.g. SfcTypeTIModel) whenever the glacier has more than one
+        # flowline
+        mb_mod = MultipleFlowlineMassBalance(
+            gdir=gdir,
+            fls=fls,
+            mb_model_class=mb_model_class,
+            melt_f=melt_f,
+            temp_bias=temp_bias,
+            prcp_fac=prcp_fac,
+            check_calib_params=False,
+            settings_filesuffix=settings_filesuffix,
+            **kwargs
+        )
+    else:
+        mb_mod = mb_model_class(
+            gdir=gdir,
+            melt_f=melt_f,
+            temp_bias=temp_bias,
+            prcp_fac=prcp_fac,
+            check_calib_params=False,
+            settings_filesuffix=settings_filesuffix,
+            **kwargs
+        )
 
     # Check that the years are available
     for y in years:
@@ -5321,7 +5426,10 @@ def apparent_mb_from_any_mb(gdir, settings_filesuffix='',
     fls = gdir.read_pickle('inversion_flowlines', filesuffix=input_filesuffix)
 
     if mb_model is None:
-        mb_model = mb_model_class(gdir=gdir, settings_filesuffix=settings_filesuffix)
+        mb_model = MultipleFlowlineMassBalance(
+            gdir, settings_filesuffix=settings_filesuffix,
+            fls=fls, mb_model_class=mb_model_class,
+        )
 
     if mb_years is None:
         mb_years = gdir.settings['geodetic_mb_period']
@@ -5406,7 +5514,7 @@ def fixed_geometry_mass_balance(gdir, settings_filesuffix='',
                                 climate_input_filesuffix='',
                                 temperature_bias=None,
                                 precipitation_factor=None,
-                                mb_model_class=MonthlyTIModel):
+                                mb_model_class=None):
     """Computes the mass balance with climate input from e.g. CRU or a GCM.
 
     Parameters
@@ -5439,12 +5547,15 @@ def fixed_geometry_mass_balance(gdir, settings_filesuffix='',
         Multiplicative factor applied to the precipitation time series.
         If None, uses the precipitation factor from the calibration in
         ``gdir.settings['prcp_fac']``.
-    mb_model_class : MassBalanceModel, default ``MonthlyTIModel``
+    mb_model_class : MassBalanceModel, defaults to ``MonthlyTIModel``
         The MassBalanceModel class to use.
     """
 
     if monthly_step:
         raise NotImplementedError('monthly_step not implemented yet')
+
+    if mb_model_class is None:
+        mb_model_class = MonthlyTIModel
 
     mbmod = MultipleFlowlineMassBalance(
         gdir=gdir,

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -7386,7 +7386,7 @@ class TestMassRedis:
             workflow.execute_entity_task(
                 gdirs=gdir, task=process_gswp3_w5e5_data, daily=True
             )
-            climate_file = "climate_historical_daily"
+            climate_file = "climate_historical"
             settings_filesuffix = '_daily'
             ModelSettings(gdir, filesuffix='_daily', parent_filesuffix='')
         else:
@@ -7403,12 +7403,16 @@ class TestMassRedis:
                                             overwrite_gdir=True,
                                             mb_model_class=model,
                                             )
-        tasks.apparent_mb_from_any_mb(gdir, mb_years=[1953, 2003])
+        tasks.apparent_mb_from_any_mb(
+            gdir, settings_filesuffix=settings_filesuffix,
+            mb_model_class=model, mb_years=[1953, 2003])
         # previously calibrate_inversion_from_consensus was used, but with the
         # RGI5 id not estimate is available and here we just use the first guess
         # as it is done in calibrate_inversion_from_consensus
-        workflow.inversion_tasks(gdir, glen_a=0.1 * cfg.PARAMS['inversion_glen_a'])
-        tasks.init_present_time_glacier(gdir)
+        workflow.inversion_tasks(gdir, settings_filesuffix=settings_filesuffix,
+                                 glen_a=0.1 * cfg.PARAMS['inversion_glen_a'])
+        tasks.init_present_time_glacier(gdir,
+                                        settings_filesuffix=settings_filesuffix)
 
         seed = 0
 
@@ -7424,6 +7428,7 @@ class TestMassRedis:
                 seed=seed,
                 mb_model_class=model,
                 climate_filename=climate_file,
+                flowlines_filesuffix=settings_filesuffix,
                 output_filesuffix='_fl'
             )
             with xr.open_dataset(gdir.get_filepath('model_diagnostics',
@@ -7444,6 +7449,7 @@ class TestMassRedis:
                     seed=seed,
                     mb_model_class=model,
                     climate_filename=climate_file,
+                    flowlines_filesuffix=settings_filesuffix,
                     evolution_model=MethodCurveModel,
                     output_filesuffix='_mr'
                 )

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -607,8 +607,8 @@ class TestMassBalanceModels:
             - settings_filesuffix: _daily
             - ice_density: 900.0
             - use_leap_years: True
-            - filename: climate_historical_daily
-            - input_filesuffix: 
+            - filename: climate_historical
+            - input_filesuffix: _daily
             - temp_all_solid: 0.0
             - temp_all_liq: 2.0
             - temp_melt: 0.0
@@ -635,16 +635,15 @@ class TestMassBalanceModels:
             - hemisphere: nh
             - ice_density: 900.0
             - use_leap_years: True
-            - mb_model_class: DailyTIModel
-            - filename: climate_historical_daily
+            - mb_model_class: MonthlyTIModel
+            - filename: climate_historical
             - input_filesuffix: 
             - bias: 0.0
-            - ys: 2000
-            - ye: 2019
+            - ye: 2002
             - aging_frequency: monthly
             - climate_resolution: monthly
             - spinup_years: 6
-            - save_spinup_mbs: False
+            - save_spinup_mbs: True
             - tau_e: 1.0
             - melt_f_ratio: 0.5
             - melt_f_change: neg_exp
@@ -653,8 +652,6 @@ class TestMassBalanceModels:
             - store_buckets: False
             - use_previous_mbs: False
             - store_snowline: False
-            - nr_timesteps: 240
-            - mb_buckets_year: 2000.0
         """)
         mb_mod = massbalance.SfcTypeTIModel(hef_gdir,
                                             settings_filesuffix='_daily',
@@ -670,16 +667,14 @@ class TestMassBalanceModels:
 
         if is_daily_model(cl):
             tasks.process_gswp3_w5e5_data(hef_gdir, daily=True)
-            filename = "climate_historical_daily"
             check_calib_params = False
             ModelSettings(gdir, filesuffix='_daily', parent_filesuffix='')
             settings_filesuffix = '_daily'
         else:
-            filename = "climate_historical"
             check_calib_params = True
             settings_filesuffix = ''
         mb_mod = cl(gdir, settings_filesuffix=settings_filesuffix, bias=0,
-                    filename=filename, check_calib_params=check_calib_params)
+                    check_calib_params=check_calib_params)
         # save old precipitation/temperature time series
         prcp_old = mb_mod.prcp.copy()
         temp_old = mb_mod.temp.copy()
@@ -841,7 +836,9 @@ class TestMassBalanceModels:
                         mb_gw.get_specific_mb(fls=fls, year=yrs[:30]))
 
     @pytest.mark.parametrize("model", [massbalance.MonthlyTIModel,
-                                       massbalance.DailyTIModel])
+                                       massbalance.DailyTIModel,
+                                       massbalance.SfcTypeTIModel,
+                                       ])
     def test_get_specific_mb(self, hef_gdir, model):
 
         check_calib_params = True
@@ -858,21 +855,40 @@ class TestMassBalanceModels:
         ye = 2002
         years = np.arange(ys, ye + 1)
         fls = gdir.read_pickle("inversion_flowlines")
-        heights_fls = np.concatenate([i.surface_h for i in fls], axis=0)
-        widths_fls = np.concatenate([i.widths for i in fls], axis=0)
+        if issubclass(model, massbalance.SfcTypeTIModel):
+            # SfcTypeTIModel has a fixed grid of points defined at
+            # initialisation. mb_mod_native below is built without an
+            # explicit `fl`, so it defaults to only the main flowline
+            # (fls[-1]) - use its heights/widths here instead of the
+            # concatenation over all flowlines, which would not match the
+            # number of grid points it was initialised with.
+            heights_native = fls[-1].surface_h
+            widths_native = fls[-1].widths
+        else:
+            heights_native = np.concatenate([i.surface_h for i in fls], axis=0)
+            widths_native = np.concatenate([i.widths for i in fls], axis=0)
+
+        stateful_kwargs = {}
+        if issubclass(model, massbalance.SfcTypeTIModel):
+            # SfcTypeTIModel keeps a running bucket state and by default
+            # refuses to go back to an already-passed year. Below we query
+            # the same years repeatedly (once as an array, then again as
+            # single values / at a different time_resolution), so we need
+            # to allow retrieving already-computed years.
+            stateful_kwargs['use_previous_mbs'] = True
 
         mb_mod_native = model(gdir, settings_filesuffix=settings_filesuffix,
                               check_calib_params=check_calib_params,
-                              ys=ys, ye=ye)
+                              ys=ys, ye=ye, **stateful_kwargs)
         mb_mod_multi_fls = massbalance.MultipleFlowlineMassBalance(
             gdir, settings_filesuffix=settings_filesuffix, fls=fls,
             mb_model_class=model, check_calib_params=check_calib_params,
-            ys=ys, ye=ye,
+            ys=ys, ye=ye, **stateful_kwargs,
         )
 
         for mb_mod, fls, heights, widths in zip(
                 [mb_mod_native, mb_mod_multi_fls], [None, fls],
-                [heights_fls, None], [widths_fls, None]):
+                [heights_native, None], [widths_native, None]):
             # test call with array
             smb = mb_mod.get_specific_mb(year=years, fls=fls, heights=heights,
                                          widths=widths,)
@@ -1389,7 +1405,7 @@ class TestMassBalanceModels:
             if ti_model == 'daily_timodel':
                 mb_model_class = massbalance.DailyTIModel
                 settings_filesuffix = '_daily'
-                input_filesuffix = ''
+                input_filesuffix = '_daily'
             elif ti_model == 'monthly_timodel':
                 mb_model_class = massbalance.MonthlyTIModel
                 settings_filesuffix = ''
@@ -1685,12 +1701,14 @@ class TestMassBalanceModels:
         with pytest.raises(ValueError,
                            match='Climate data for spinup not available. *'):
             massbalance.SfcTypeTIModel(gdir, settings_filesuffix='_daily',
+                                       mb_model_class=massbalance.DailyTIModel,
                                        ys=1800, check_calib_params=False,)
 
         with pytest.raises(InvalidWorkflowError,
                            match='The current buckets are valid for *'):
             mb_mod = massbalance.SfcTypeTIModel(
-                gdir, settings_filesuffix='_daily', ys=2000,
+                gdir, settings_filesuffix='_daily',
+                mb_model_class=massbalance.DailyTIModel, ys=2000,
                 use_previous_mbs=False, check_calib_params=False, )
             mb_mod.get_annual_mb(heights=h, year=2000)
             # calling the same year a second time with use_previous_mbs=False
@@ -1699,7 +1717,8 @@ class TestMassBalanceModels:
 
         # Look at different options of defining the melt_f per bucket
         mb_mod = massbalance.SfcTypeTIModel(
-            gdir, settings_filesuffix='_daily', check_calib_params=False,
+            gdir, settings_filesuffix='_daily',
+            mb_model_class=massbalance.DailyTIModel, check_calib_params=False,
             climate_resolution='monthly', aging_frequency='monthly',
             melt_f_change="neg_exp", melt_f_ratio=0.5)
         melt_f_exp = np.asarray(list(mb_mod.melt_f_buckets.values()))
@@ -1707,7 +1726,8 @@ class TestMassBalanceModels:
         np.testing.assert_allclose(melt_f_exp[0] / melt_f_exp[-1], 0.5, atol=1e-3)
 
         mb_mod = massbalance.SfcTypeTIModel(
-            gdir, settings_filesuffix='_daily', check_calib_params=False,
+            gdir, settings_filesuffix='_daily',
+            mb_model_class=massbalance.DailyTIModel, check_calib_params=False,
             climate_resolution='monthly', aging_frequency='monthly',
             melt_f_change="neg_exp", melt_f_ratio=0.5, tau_e=0.5)
         melt_f_exp_05 = np.asarray(list(mb_mod.melt_f_buckets.values()))
@@ -1716,7 +1736,8 @@ class TestMassBalanceModels:
                                    atol=1e-3)
 
         mb_mod = massbalance.SfcTypeTIModel(
-            gdir, settings_filesuffix='_daily', check_calib_params=False,
+            gdir, settings_filesuffix='_daily', ys=2000,
+            mb_model_class=massbalance.DailyTIModel, check_calib_params=False,
             climate_resolution='monthly', aging_frequency='monthly',
             melt_f_change="linear", melt_f_ratio=0.5)
         melt_f_linear = np.asarray(list(mb_mod.melt_f_buckets.values()))
@@ -1755,7 +1776,8 @@ class TestMassBalanceModels:
 
         # test starting from user provided spinup buckets
         mb_mod = massbalance.SfcTypeTIModel(
-            gdir, settings_filesuffix='_daily', check_calib_params=False,
+            gdir, settings_filesuffix='_daily',
+            mb_model_class=massbalance.DailyTIModel, check_calib_params=False,
             climate_resolution='monthly', aging_frequency='monthly',
             ys=2000, spinup_buckets=mb_buckets_2006)
         np.testing.assert_allclose(mb_mod.mb_buckets, mb_buckets_2006)
@@ -1766,6 +1788,47 @@ class TestMassBalanceModels:
         # but after setting a mb parameter it should be reset
         mb_mod.prcp_fac = 1
         np.testing.assert_allclose(mb_mod.mb_buckets, mb_buckets_2006)
+
+    def test_sfc_type_apparent_mb_from_any_mb_multiple_fl(self, hef_gdir):
+        """apparent_mb_from_any_mb with SfcTypeTIModel and centerlines, i.e.
+        several flowlines of different length (SfcTypeTIModel needs to know
+        the length of its corresponding flowline at initialisation).
+        """
+        gdir = hef_gdir
+
+        fls = gdir.read_pickle('inversion_flowlines')
+        # be sure we have multiple flowlines
+        assert len(fls) > 1
+
+        massbalance.apparent_mb_from_any_mb(
+            gdir, mb_model_class=massbalance.SfcTypeTIModel,
+            mb_years=(2000, 2003),
+            output_filesuffix='_sfc_type_multiple_fls'
+        )
+
+        fls = gdir.read_pickle('inversion_flowlines',
+                               filesuffix='_sfc_type_multiple_fls')
+        # mass flux is close to zero at the terminus of the main flowline
+        np.testing.assert_allclose(fls[-1].flux_out, 0, atol=1e-7)
+        # every flowline got a sensible apparent mb assigned
+        for fl in fls:
+            assert np.isfinite(fl.flux_out)
+            assert np.any(fl.apparent_mb != 0)
+
+        # test that inversion and flowline initialisation is working
+        workflow.inversion_tasks(gdir,
+                                 input_filesuffix='_sfc_type_multiple_fls',
+                                 output_filesuffix='_sfc_type_multiple_fls',
+                                 )
+        init_present_time_glacier(gdir,
+                                  input_filesuffix='_sfc_type_multiple_fls',
+                                  output_filesuffix='_sfc_type_multiple_fls',
+                                  )
+        fls = gdir.read_pickle('model_flowlines',
+                               filesuffix='_sfc_type_multiple_fls')
+
+        for fl in fls:
+            assert fl.volume_m3 > 0
 
     @pytest.mark.slow
     def test_sfc_type_save_load(self, hef_gdir):
@@ -2013,6 +2076,42 @@ class TestMassBalanceModels:
                 part2_mb.flowline_mb_models[i].mb_buckets_np,
                 atol=1e-2)
 
+    def test_sfc_type_mb_calibration_for_multiple_flowlines(self, hef_gdir):
+
+        gdir = hef_gdir
+        init_present_time_glacier(gdir)
+
+        fls = gdir.read_pickle('inversion_flowlines')
+        # make sure we are actually testing multiple flowlines
+        assert len(fls) > 1
+
+        df, mb_mod = massbalance.mb_calibration_from_scalar_mb(
+            gdir, observations_filesuffix='_sfc_type_multi_fl',
+            calibrate_param1='melt_f',
+            ref_mb=0, ref_mb_years=(1970, 2001),
+            write_to_gdir=False,
+            return_mb_model=True,
+            mb_model_class=massbalance.SfcTypeTIModel,
+            ys=1970, use_previous_mbs=True,
+        )
+
+        assert isinstance(mb_mod, massbalance.MultipleFlowlineMassBalance)
+        assert len(mb_mod.flowline_mb_models) == len(fls)
+        for fl, mbmod in zip(fls, mb_mod.flowline_mb_models):
+            # melt_f was correctly broadcast to every flowline mb model
+            assert mbmod.melt_f == df['melt_f']
+            # each flowline mb model is bound to its own flowline's grid
+            assert len(mbmod.buckets_grid_point_label) == fl.nx
+
+        assert mb_mod.melt_f == df['melt_f']
+        assert mb_mod.filename == mb_mod.flowline_mb_models[0].filename
+        assert (mb_mod.input_filesuffix ==
+               mb_mod.flowline_mb_models[0].input_filesuffix)
+
+        # the calibrated model reproduces the reference specific mb (0)
+        smb = mb_mod.get_specific_mb(fls=fls, year=np.arange(1970, 2001))
+        np.testing.assert_allclose(smb.mean(), 0, atol=1e-6)
+
     @pytest.mark.slow
     def test_sfc_type_mb_model_calib_dynamics(self, hef_gdir):
 
@@ -2110,7 +2209,7 @@ class TestMassBalanceModels:
             ys=1980, ye=2020,
             store_model_geometry=True, store_fl_diagnostics=True,
             store_monthly_step=True, mb_elev_feedback='monthly',
-            include_mb_model_heights=False,
+            include_mb_model_heights=False, include_firn_outputs=False,
             output_filesuffix='_daily_sfc')
         ds_daily_sfc = utils.compile_run_output(gdir,
                                                 input_filesuffix='_daily_sfc')
@@ -2278,8 +2377,10 @@ class TestMassBalanceModels:
         # projection MB model is in scenario-branch state: history reset
         proj_mb_mod = dyn_model_proj.mb_model.flowline_mb_models[0]
         assert proj_mb_mod.ys == int(hist_mb_mod.mb_buckets_year)
-        # historical mb should cover the entire period provided (ys to ye)
-        assert hist_mb_mod._climatic_mb.shape[0] == (2020 - mbdf.index[0]) * 12
+        # historical mb should cover the entire period provided
+        # (ys + spinup_years to ye)
+        assert hist_mb_mod._climatic_mb.shape[0] == (2020 - mbdf.index[0] +
+                                                     proj_mb_mod.spinup_years) * 12
         # the projection only should start at ys = 2010
         assert proj_mb_mod._climatic_mb.shape[0] == (2020 - 2010) * 12
 
@@ -2377,39 +2478,6 @@ class TestMassBalanceModels:
             plot_runoff('_daily_sfc_hydro', 'SfcTypeTIModel with DailyTIModel')
 
         # test sfc_type model with dynamic melt_f calibration
-        kwargs_sfc_type = {
-            'mb_model_class': massbalance.MonthlyTIModel,
-            'climate_resolution': "monthly",
-            'aging_frequency': "monthly",
-            'ys': 1979,
-            'spinup_years': 6,
-            'use_previous_mbs': True,
-        }
-
-        # With the bucketsystem we need to know the number of grid points
-        MySfcTypeTIModel_inv = partial(
-            massbalance.SfcTypeTIModel,
-            use_main_fl_from='inversion_flowlines',
-            **kwargs_sfc_type,
-        )
-
-        MySfcTypeTIModel_dyn = partial(
-            massbalance.SfcTypeTIModel,
-            use_main_fl_from='model_flowlines',
-            **kwargs_sfc_type,
-        )
-        mb_model_historical = massbalance.MultipleFlowlineMassBalance(
-            gdir, settings_filesuffix='',
-            mb_model_class=MySfcTypeTIModel_dyn,
-            filename='climate_historical')
-        mb_model_spinup = massbalance.MultipleFlowlineMassBalance(
-            gdir, settings_filesuffix='',
-            mb_model_class=partial(
-                massbalance.ConstantMassBalance,
-                mb_model_class=MySfcTypeTIModel_dyn,
-                y0=2001, halfsize=10,
-            ),
-            filename='climate_historical')
         dyn_models = workflow.execute_entity_task(
             tasks.run_dynamic_melt_f_calibration,
             gdir,
@@ -2417,16 +2485,9 @@ class TestMassBalanceModels:
             ye=gdir.get_climate_info()['baseline_yr_1'] + 1,
             ignore_errors=True,
             ref_mb_err_scaling_factor=0.2,
-            maxiter=10,
-            kwargs_run_function={
-                'maxiter': 10,
-                'overwrite_observations': False,
-                'mb_model_historical': mb_model_historical,
-                'mb_model_spinup': mb_model_spinup,
-                'include_mb_model_heights': True,
-                'include_firn_outputs': True,
-                'mb_model_class_apparent_mb': MySfcTypeTIModel_inv,
-            },
+            maxiter=5,
+            mb_model_class=massbalance.SfcTypeTIModel,
+            kwargs_run_function={'maxiter': 5},
             output_filesuffix='_spinup_historical',
         )
         # if the above runs without an error it is fine, but still check a few
@@ -2434,8 +2495,8 @@ class TestMassBalanceModels:
         assert isinstance(dyn_models[0].volume_m3, float)
         assert gdir.get_diagnostics()['used_spinup_option'] in [
             'dynamic melt_f calibration (full success)',
-            'dynamic melt_f calibration (part success)',
-            'dynamic spinup only',
+            #'dynamic melt_f calibration (part success)',
+            #'dynamic spinup only',
         ]
 
     def test_constant_mb_model(self, hef_gdir):
@@ -4649,6 +4710,12 @@ class TestHEFNonPolluted:
                 for y in [1992, 2000, 2003]:
                     assert new.sel(time=y).data == ref.sel(time=y).data
                 assert new.sel(time=1950).data == new.sel(time=1980).data
+
+            for vn in ['volume_ice', 'volume_firn']:
+                # should be nan for fixed geometry spinup period
+                assert np.all(np.isnan(ods[vn].sel(time=[1850, 1900, 1990])))
+                # should have some values after fixed geometry spinup period
+                assert ~np.all(np.isnan(ods[vn].sel(time=[1991, 2000, 2003])))
 
             # We pick symmetry around rgi date so show that somehow it works
             for vn in ['volume']:

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -1789,6 +1789,12 @@ class TestMassBalanceModels:
         mb_mod.prcp_fac = 1
         np.testing.assert_allclose(mb_mod.mb_buckets, mb_buckets_2006)
 
+        # test fixed_geometry_mass_balance
+        s = massbalance.fixed_geometry_mass_balance(
+            gdir, mb_model_class=massbalance.SfcTypeTIModel)
+        assert s.index[0] == 1808
+        assert s.index[-1] == 2002
+
     def test_sfc_type_apparent_mb_from_any_mb_multiple_fl(self, hef_gdir):
         """apparent_mb_from_any_mb with SfcTypeTIModel and centerlines, i.e.
         several flowlines of different length (SfcTypeTIModel needs to know

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -2487,6 +2487,7 @@ class TestMassBalanceModels:
             ref_mb_err_scaling_factor=0.2,
             maxiter=5,
             mb_model_class=massbalance.SfcTypeTIModel,
+            save_mb_diagnostics_filesuffix='_spinup_historical',
             kwargs_run_function={'maxiter': 5},
             output_filesuffix='_spinup_historical',
         )
@@ -2495,9 +2496,20 @@ class TestMassBalanceModels:
         assert isinstance(dyn_models[0].volume_m3, float)
         assert gdir.get_diagnostics()['used_spinup_option'] in [
             'dynamic melt_f calibration (full success)',
-            #'dynamic melt_f calibration (part success)',
-            #'dynamic spinup only',
+            # 'dynamic melt_f calibration (part success)',
+            # 'dynamic spinup only',
         ]
+
+        # check that mb diagnostics were saved
+        assert gdir.has_file('mb_diagnostics', filesuffix='_spinup_historical')
+        mb_model = (massbalance.MultipleFlowlineMassBalance.load_from_file(
+            gdir,
+            filesuffix='_spinup_historical', ))
+        # check that the finally snow bucktes contain some values
+        firn_thick = mb_model.flowline_mb_models[-1].columns_thickness_m
+        assert np.all(np.isfinite(firn_thick))
+        assert np.any(firn_thick > 0)  # at least some should be > 0
+        assert np.all(firn_thick >= 0)
 
     def test_constant_mb_model(self, hef_gdir):
 

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -2552,7 +2552,7 @@ class TestMassBalanceModels:
         )
         # dynamic run for 70 years
         model.run_until(2020)
-        assert_allclose(model.total_mass, model.volume_m3, rtol=1e-3)
+        assert_allclose(model.total_mass, model.volume_ice_m3, rtol=1e-3)
 
         # same check with bucket heights included in elevation feedback
         model_elev = MassConservationChecker(
@@ -2562,7 +2562,7 @@ class TestMassBalanceModels:
         )
         # dynamic run for 70 years
         model_elev.run_until(2020)
-        assert_allclose(model_elev.total_mass, model_elev.volume_m3, rtol=1e-3)
+        assert_allclose(model_elev.total_mass, model_elev.volume_ice_m3, rtol=1e-3)
 
     def test_constant_mb_model(self, hef_gdir):
 

--- a/oggm/tests/test_shop.py
+++ b/oggm/tests/test_shop.py
@@ -445,24 +445,27 @@ class Test_w5e5:
         return True
 
     @pytest.mark.parametrize(
-        "daily,filepath",
-        [(False, "climate_historical"), (True, "climate_historical_daily")],
+        "daily,filesuffix",
+        [(False, ""), (True, "_daily")],
     )
-    def test_process_w5e5_data(self, w5e5_hef_gdir, daily, filepath):
+    def test_process_w5e5_data(self, w5e5_hef_gdir, daily, filesuffix):
 
         gdir = w5e5_hef_gdir
         from oggm.shop import w5e5
 
         w5e5.process_w5e5_data(gdir, daily=daily)
-        path_clim = gdir.get_filepath(filepath)
+        path_clim = gdir.get_filepath('climate_historical',
+                                      filesuffix=filesuffix)
         if not daily:
             assert "daily" not in path_clim
             assert not os.path.exists(
-                gdir.get_filepath("climate_historical_daily")
+                gdir.get_filepath('climate_historical',
+                                  filesuffix='_daily')
             )
         else:
             assert "daily" in path_clim
-            assert os.path.exists(gdir.get_filepath("climate_historical"))
+            assert os.path.exists(gdir.get_filepath('climate_historical',
+                                                    filesuffix='_daily'))
         assert os.path.exists(path_clim)
 
         with xr.open_dataset(path_clim) as ds_clim:
@@ -509,7 +512,7 @@ class Test_w5e5:
 
         # test daily implementation
         w5e5.process_gswp3_w5e5_data(gdir, daily=True)
-        path_clim = gdir.get_filepath("climate_historical_daily")
+        path_clim = gdir.get_filepath("climate_historical", filesuffix="_daily")
         assert os.path.exists(path_clim)
 
         with xr.open_dataset(path_clim) as ds_clim:

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -2000,7 +2000,9 @@ def compile_fixed_geometry_mass_balance(gdirs, settings_filesuffix='',
                                         climate_filename='climate_historical',
                                         climate_input_filesuffix='',
                                         temperature_bias=None,
-                                        precipitation_factor=None):
+                                        precipitation_factor=None,
+                                        mb_model_class=None,
+                                        ):
 
     """Compiles a table of specific mass balance timeseries for all glaciers.
 
@@ -2042,6 +2044,8 @@ def compile_fixed_geometry_mass_balance(gdirs, settings_filesuffix='',
         multiply a factor to the precipitation time series
         default is None and means that the precipitation factor from the
         calibration is applied which is cfg.PARAMS['prcp_fac']
+    mb_model_class : MassBalanceModel, defaults to ``MonthlyTIModel``
+        The MassBalanceModel class to use.
     """
 
     from oggm.workflow import execute_entity_task
@@ -2053,7 +2057,9 @@ def compile_fixed_geometry_mass_balance(gdirs, settings_filesuffix='',
                                  ys=ys, ye=ye, years=years, climate_filename=climate_filename,
                                  climate_input_filesuffix=climate_input_filesuffix,
                                  temperature_bias=temperature_bias,
-                                 precipitation_factor=precipitation_factor)
+                                 precipitation_factor=precipitation_factor,
+                                 mb_model_class=mb_model_class,
+                                 )
 
     for idx, s in enumerate(out_df):
         if s is None:
@@ -2455,8 +2461,9 @@ def extend_past_climate_run(past_run_file=None,
             ods[vn] = ods[vn].astype(int)
 
         # New vars
-        for vn in ['volume', 'volume_m3_min_h', 'volume_bsl', 'volume_bwl',
-                   'area', 'area_m2_min_h', 'length', 'calving', 'calving_rate']:
+        for vn in ['volume', 'volume_ice', 'volume_firn', 'volume_m3_min_h',
+                   'volume_bsl', 'volume_bwl', 'area', 'area_m2_min_h',
+                   'length', 'calving', 'calving_rate']:
             if vn in ods.data_vars:
                 ods[vn + '_ext'] = ods[vn].copy(deep=True)
                 ods[vn + '_ext'].attrs['description'] += ' (extended with MB data)'
@@ -2526,6 +2533,18 @@ def extend_past_climate_run(past_run_file=None,
                 # +1 because calving rate at year 0 is unknown from the dyns model
                 orig_calv_rate_ts[:fid+1] = calv_rate
                 ods.calving_rate_ext.data[:, i] = orig_calv_rate_ts
+
+            if 'volume_ice' in ods.data_vars:
+                # we can not calculate a ice volume for the fixed geometry
+                orig_volume_ice_ts = ods.volume_ice_ext.data[:, i]
+                orig_volume_ice_ts[:fid] = np.nan
+                ods.volume_ice_ext.data[:, i] = orig_volume_ice_ts
+
+            if 'volume_firn' in ods.data_vars:
+                # we can not calculate a ice volume for the fixed geometry
+                orig_volume_firn_ts = ods.volume_firn_ext.data[:, i]
+                orig_volume_firn_ts[:fid] = np.nan
+                ods.volume_firn_ext.data[:, i] = orig_volume_firn_ts
 
             # Extend vol bsl by assuming that % stays constant
             if 'volume_bsl' in ods.data_vars:


### PR DESCRIPTION
The goal of this PR is to add `SfcTypeTIModel` as an option in `run_prepro_levels`. To do this, I needed to make several changes, in particular to allow the use of centerlines (multiple flowlines).

Changes made so far:

- `run_prepro_levels`:
  - New kwarg `mb_model_class` with options `'MonthlyTIModel'` and `'SfcTypeTIModel'`
  - Also added a new `--mb-model-class` argument when running from the terminal
  - store `mb_diagnostics` if `mb_model_class=SfcTypeTIModel`. The `mb_diagnostics` are needed to continue a projection run starting from the same snow buckets as created during the historical run
- `mb_calibration_from_scalar_mb`:
  - Now uses `MultipleFlowlineMassBalance` when `len(fls) > 1`. This is important when using `SfcTypeTIModel`, because we need to define the number of grid points at initialization (this model has memory)
  - Added a dedicated test for using `SfcTypeTIModel` with multiple flowlines
- `apparent_mb_from_any_mb`:
  - Now uses `MultipleFlowlineMassBalance` for the same reasons as `mb_calibration_from_scalar_mb`
  - Added a dedicated test for using `SfcTypeTIModel` with multiple flowlines
- `compile_fixed_geometry_mass_balance`:
  - Added `mb_model_class` as a kwarg
- `extend_past_climate_run`:
  - If firn output is available, it is now set to NaN during the fixed geometry spinup period
  - Added tests for this
- `DailyTIModel`:
  - Changed the default `filename` from `'climate_historical_daily'` to `'climate_historical'`
  - Changed the default `input_filesuffix` from `''` to `'_daily'`
- `SfcTypeTIModel`:
  - Default `ys` is now set to `None`
  - If `ys` is `None`, it will be dynamically set on the first call to one of `get_annual_mb`, `get_monthly_mb`, or `get_daily_mb`. Calling `.reset_state()` resets `ys` to `None` again. As a consequence, a call for the same year can give slightly different results depending on the currently set `ys`. However, this lets us significantly decrease runtimes, since we only calculate mb values that are actually used. If you want consistent results, you can set `ys` explicitly at initialization (or use `mb_model_class=partial(SfcTypeTIModel, ys=2000)`) to ensure you always start from the same initialized buckets
- Dynamic spinup:
  - Added kwarg `mb_model_class` (removed `mb_model_class_apparent_mb`)
  - Added `.reset_state()` calls for `mb_historical` and `mb_spinup` before every dynamic run
  - Added kwarg `save_mb_diagnostics_filesuffix` for storing `mb_diagnostics` at the end of a run

- [ ] Tests added/passed
- [ ] Fully documented
- [ ] Entry in `whats-new.rst` 
