### PR TITLE
adapted run_with_hydro for SfcTypeTIModel

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -128,6 +128,22 @@ Enhancements
 - Added two new CI test environments, ``models_dynamics`` and ``models_mb``,
   to parallelise test execution (:pull:`1907`).
   By `Patrick Schmitt <https://github.com/pat-schmitt>`_
+- ``run_with_hydro`` now fully supports mass balance models with surface type
+  tracking (e.g. ``SfcTypeTIModel``). The mass-conservation correction of the
+  on-glacier melt is now based on the total glacier mass of the dynamical run
+  (``mass_kg``, which includes the snow and firn buckets with their lower
+  densities) instead of the ice volume times a fixed ice density. For this,
+  'mass' is now required in ``cfg.PARAMS['store_diagnostic_variables']`` (it
+  is part of the defaults). For mass balance models with surface type
+  tracking, the on-glacier melt is additionally split into the new default
+  output variables ``snow_melt_on_glacier`` (buckets younger than one year),
+  ``firn_melt_on_glacier`` and ``ice_melt_on_glacier``, which always sum up
+  to ``melt_on_glacier`` (for other mass balance models they are NaN). For
+  this, ``SfcTypeTIModel`` now tracks the melt per surface type (new
+  ``get_annual_melt`` and ``get_monthly_melt`` methods and ``snow_melt``,
+  ``firn_melt`` and ``ice_melt`` properties), whereby pure aging of the
+  buckets is never counted as melt (:pull:`XXXX`).
+  By `Patrick Schmitt <https://github.com/pat-schmitt>`_
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -142,7 +142,7 @@ Enhancements
   this, ``SfcTypeTIModel`` now tracks the melt per surface type (new
   ``get_annual_melt`` and ``get_monthly_melt`` methods and ``snow_melt``,
   ``firn_melt`` and ``ice_melt`` properties), whereby pure aging of the
-  buckets is never counted as melt (:pull:`XXXX`).
+  buckets is never counted as melt (:pull:`1959`).
   By `Patrick Schmitt <https://github.com/pat-schmitt>`_
 
 Bug fixes

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -4520,6 +4520,26 @@ def run_with_hydro(gdir, settings_filesuffix='',
                    **kwargs):
     """Run the flowline model and add hydro diagnostics.
 
+    The on-glacier melt is corrected so that, together with the solid
+    precipitation, it matches the mass change of the dynamical model. For
+    this the run needs to store the total glacier mass, i.e. 'mass' must be
+    in PARAMS['store_diagnostic_variables'] (the default). Using the mass
+    (instead of the ice volume times a fixed ice density) also accounts for
+    mass balance models with a snow/firn bucket system (e.g.
+    ``SfcTypeTIModel``), where part of the glacier mass has a lower density.
+
+    If the mass balance model of the run tracks surface types (e.g.
+    ``SfcTypeTIModel``), the on-glacier melt is additionally split into
+    ``snow_melt_on_glacier`` (buckets younger than one year),
+    ``firn_melt_on_glacier`` (older buckets) and ``ice_melt_on_glacier``.
+    The three components are rescaled so that they always sum up to
+    ``melt_on_glacier`` (i.e. the residual and bias corrections are
+    distributed proportionally). For mass balance models without surface
+    type tracking these three variables are NaN. Note that for mass balance
+    models with a memory of the past (e.g. ``SfcTypeTIModel``),
+    ``use_previous_mbs`` is set to True after the dynamical run, because the
+    mass balance values stored during the run are revisited here.
+
     TODOs:
         - Add the possibility to record MB during run to improve performance
           (requires change in API)
@@ -4617,6 +4637,29 @@ def run_with_hydro(gdir, settings_filesuffix='',
     # Mass balance model used during the run
     mb_mod = out.mb_model
 
+    def _get_fl_mb_mod(fl_id):
+        # the mb model of a single flowline (mb models like SfcTypeTIModel
+        # work on the main flowline only and are not always wrapped)
+        if isinstance(mb_mod, MultipleFlowlineMassBalance):
+            return mb_mod.flowline_mb_models[fl_id]
+        return mb_mod
+
+    if isinstance(mb_mod, MultipleFlowlineMassBalance):
+        all_fl_mb_mods = mb_mod.flowline_mb_models
+    else:
+        all_fl_mb_mods = [mb_mod]
+
+    # Models with a memory of the past (e.g. SfcTypeTIModel) store their mb
+    # values during the dynamical run - here we revisit exactly those years,
+    # so we want the previously computed values back
+    for fl_mb_mod in all_fl_mb_mods:
+        if hasattr(fl_mb_mod, 'use_previous_mbs'):
+            fl_mb_mod.use_previous_mbs = True
+
+    # Can the mb model split the melt by surface type (snow/firn/ice)?
+    track_melt_components = all(hasattr(fl_mb_mod, 'get_annual_melt')
+                                for fl_mb_mod in all_fl_mb_mods)
+
     # Glacier geometry during the run
     suffix = kwargs.get('output_filesuffix', settings_filesuffix)
     if suffix is None:
@@ -4627,6 +4670,21 @@ def run_with_hydro(gdir, settings_filesuffix='',
     fmod = FileModel(gdir.get_filepath('model_geometry', filesuffix=suffix))
     # The last one is the final state - we can't compute MB for that
     years = fmod.years[:-1]
+
+    # Total glacier mass from the dynamical run - used below to correct the
+    # reconstructed mass balance for mass conservation. We use the mass (and
+    # not the ice volume times a fixed ice density), because for mb models
+    # with buckets (e.g. SfcTypeTIModel) part of the glacier mass is snow
+    # and firn with lower densities.
+    fpath_diag = gdir.get_filepath('model_diagnostics', filesuffix=suffix)
+    with xr.open_dataset(fpath_diag) as ds_diag:
+        if 'mass_kg' not in ds_diag:
+            raise InvalidWorkflowError(
+                'run_with_hydro needs the total glacier mass of the '
+                "dynamical run. Please add 'mass' to "
+                "PARAMS['store_diagnostic_variables'].")
+        model_mass_kg = dict(zip(ds_diag['time'].values,
+                                 ds_diag['mass_kg'].values))
 
     if ref_geometry_filesuffix:
         if not ref_area_from_y0 and ref_area_yr is None:
@@ -4759,9 +4817,22 @@ def run_with_hydro(gdir, settings_filesuffix='',
         },
     }
 
-    # Initialize
-    fmod.run_until(years[0])
-    prev_model_vol = fmod.volume_m3
+    # The melt split by surface type is only available for mb models with
+    # surface type tracking (e.g. SfcTypeTIModel), for all others it is NaN
+    for vn, desc in [
+            ('snow_melt_on_glacier',
+             'On-glacier melt of snow (buckets younger than one year)'),
+            ('firn_melt_on_glacier',
+             'On-glacier melt of firn (buckets older than one year)'),
+            ('ice_melt_on_glacier',
+             'On-glacier melt of ice'),
+    ]:
+        out[vn] = {
+            'description': desc,
+            'unit': 'kg yr-1',
+            'data': (np.zeros(oshape) if track_melt_components
+                     else np.full(oshape, np.nan)),
+        }
 
     for i, yr in enumerate(years):
 
@@ -4844,6 +4915,23 @@ def run_with_hydro(gdir, settings_filesuffix='',
                 off_area_out += np.sum(off_area)
                 on_area_out += np.sum(bin_area)
 
+                if track_melt_components:
+                    # Melt split by surface type in kg m-2 for this timestep
+                    # (the components are rescaled at the end of the year to
+                    # match the corrected melt_on_glacier)
+                    if store_monthly_hydro:
+                        s_melt, f_melt, i_melt = \
+                            _get_fl_mb_mod(fl_id).get_monthly_melt(flt_yr)
+                    else:
+                        s_melt, f_melt, i_melt = \
+                            _get_fl_mb_mod(fl_id).get_annual_melt(yr)
+                    out['snow_melt_on_glacier']['data'][i, m-1] += \
+                        np.sum(s_melt * bin_area)
+                    out['firn_melt_on_glacier']['data'][i, m-1] += \
+                        np.sum(f_melt * bin_area)
+                    out['ice_melt_on_glacier']['data'][i, m-1] += \
+                        np.sum(i_melt * bin_area)
+
                 # Monthly out
                 out['melt_off_glacier']['data'][i, m-1] += np.sum(melt_off_g)
                 out['melt_on_glacier']['data'][i, m-1] += np.sum(melt_on_g)
@@ -4893,10 +4981,11 @@ def run_with_hydro(gdir, settings_filesuffix='',
             model_mb = (out['snowfall_on_glacier']['data'][i, :].sum() -
                         out['melt_on_glacier']['data'][i, :].sum())
         else:
-            # Correct for mass-conservation and match the ice-dynamics model
-            fmod.run_until(yr + 1)
-            model_mb = (fmod.volume_m3 - prev_model_vol) * gdir.settings['ice_density']
-            prev_model_vol = fmod.volume_m3
+            # Correct for mass-conservation and match the dynamical model.
+            # We use the total glacier mass change of the run, which also
+            # includes the snow and firn buckets for mb models with surface
+            # type tracking (e.g. SfcTypeTIModel)
+            model_mb = model_mass_kg[yr + 1] - model_mass_kg[yr]
 
             reconstructed_mb = (out['snowfall_on_glacier']['data'][i, :].sum() -
                                 out['melt_on_glacier']['data'][i, :].sum())
@@ -4936,6 +5025,26 @@ def run_with_hydro(gdir, settings_filesuffix='',
 
         out['model_mb']['data'][i] = model_mb
         out['residual_mb']['data'][i] = residual_mb
+
+        if track_melt_components:
+            # Rescale the melt components so they always sum up to the
+            # corrected melt_on_glacier (this distributes the residual and
+            # bias corrections proportionally to the components)
+            final_melt = out['melt_on_glacier']['data'][i, :]
+            comp_sum = (out['snow_melt_on_glacier']['data'][i, :] +
+                        out['firn_melt_on_glacier']['data'][i, :] +
+                        out['ice_melt_on_glacier']['data'][i, :])
+            has_comp = comp_sum > 0
+            fac = np.where(has_comp,
+                           final_melt / np.where(has_comp, comp_sum, 1),
+                           0)
+            for vn in ['snow_melt_on_glacier', 'firn_melt_on_glacier',
+                       'ice_melt_on_glacier']:
+                out[vn]['data'][i, :] *= fac
+            # if the corrections produced melt where no component melt was
+            # computed, we attribute it to ice melt to conserve the sum
+            out['ice_melt_on_glacier']['data'][i, :] += \
+                np.where(has_comp, 0, final_melt)
 
     # Convert to xarray
     out_vars = gdir.settings['store_diagnostic_variables']

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -1580,6 +1580,16 @@ class SfcTypeTIModel(MassBalanceModel):
         # we also add a snow and an ice bucket
         self.buckets = ["snow"] + firn_buckets + ["ice"]
 
+        # number of buckets considered as "snow" (age < 1 year) when splitting
+        # the melt by surface type; all older (non-ice) buckets are firn. Note
+        # that with annual aging last summer's snow already becomes "firn" at
+        # the January aging step, even if it is younger than one year (an
+        # inherent discretisation artefact of annual aging).
+        if self.aging_frequency == "annual":
+            self._nr_snow_buckets = 1
+        else:
+            self._nr_snow_buckets = min(12, len(self.buckets) - 1)
+
         # set a template for an empty bucket and mb containers
         self._empty_mb_buckets_np = np.zeros((len(self.buckets_grid_point_label),
                                               len(self.buckets)))
@@ -1692,6 +1702,11 @@ class SfcTypeTIModel(MassBalanceModel):
         self._climatic_mb = np.empty(output_shape)  # kg m-2
         self._ice_mb = np.empty(output_shape)  # kg m-2
         self._mb_heights = np.empty(output_shape)  # m
+        # melt split by surface type, see
+        # _apply_climate_step_and_aging_to_buckets
+        self._snow_melt = np.empty(output_shape)  # kg m-2
+        self._firn_melt = np.empty(output_shape)  # kg m-2
+        self._ice_melt = np.empty(output_shape)  # kg m-2
         self._year_to_index = {}  # saving the array positions of years
         self._current_index = 0  # keep track of last added position
 
@@ -1748,29 +1763,42 @@ class SfcTypeTIModel(MassBalanceModel):
                             index=self.buckets_grid_point_label,
                             columns=self.buckets[:-1],)
 
-    @property
-    def climatic_mb(self):
+    def _stored_array_as_dataframe(self, arr):
+        # returns one of the per-timestep storage arrays as a DataFrame with
+        # the timesteps as columns and the grid points as index
         pd_dict = {}
         for year in self._year_to_index:
-            pd_dict[year] = self._climatic_mb[[self._year_to_index[year]]][0]
+            pd_dict[year] = arr[[self._year_to_index[year]]][0]
         return pd.DataFrame(pd_dict,
                             index=self.buckets_grid_point_label)
+
+    @property
+    def climatic_mb(self):
+        return self._stored_array_as_dataframe(self._climatic_mb)
 
     @property
     def ice_mb(self):
-        pd_dict = {}
-        for year in self._year_to_index:
-            pd_dict[year] = self._ice_mb[[self._year_to_index[year]]][0]
-        return pd.DataFrame(pd_dict,
-                            index=self.buckets_grid_point_label)
+        return self._stored_array_as_dataframe(self._ice_mb)
 
     @property
     def mb_heights(self):
-        pd_dict = {}
-        for year in self._year_to_index:
-            pd_dict[year] = self._mb_heights[[self._year_to_index[year]]][0]
-        return pd.DataFrame(pd_dict,
-                            index=self.buckets_grid_point_label)
+        return self._stored_array_as_dataframe(self._mb_heights)
+
+    @property
+    def snow_melt(self):
+        # melt of buckets younger than one year, in kg m-2 per climate step
+        return self._stored_array_as_dataframe(self._snow_melt)
+
+    @property
+    def firn_melt(self):
+        # melt of buckets older than one year, in kg m-2 per climate step
+        return self._stored_array_as_dataframe(self._firn_melt)
+
+    @property
+    def ice_melt(self):
+        # gross ice melt in kg m-2 per climate step (in contrast to ice_mb,
+        # which also includes newly formed ice from aging)
+        return self._stored_array_as_dataframe(self._ice_melt)
 
     @property
     def columns_thickness_m(self):
@@ -1962,6 +1990,11 @@ class SfcTypeTIModel(MassBalanceModel):
         # all solid precip. goes into fresh snow bucket before we start melting
         snow_buckets_new[:, 0] += prcpsol
 
+        if save_mbs:
+            # remember the pre-melt state (incl. fresh snow) so we can split
+            # the melt by surface type after melting
+            buckets_before_melt = snow_buckets_new.copy()
+
         # now calculate cumulative tfm needed to melt each bucket and subtract
         # available tmelt, finally we convert back to mass in each bucket
         # (nr_grid_points, nr_buckets)
@@ -2012,6 +2045,28 @@ class SfcTypeTIModel(MassBalanceModel):
 
             # save the climatic mb of this timestep
             self._climatic_mb[self._current_index] = delta_kg_m2
+
+            # Split the melt by surface type: everything that left the snow
+            # and firn buckets within this climate step is melt (the aging
+            # below only moves mass between buckets and is therefore never
+            # counted as melt). "Snow" are the buckets younger than one year.
+            # Note that snow_melt + firn_melt + ice_melt = prcpsol -
+            # climatic_mb for each timestep. The clip removes tiny negative
+            # values caused by floating point errors of the cumsum above.
+            per_bucket_melt = np.clip(buckets_before_melt - snow_buckets_new,
+                                      0., None)
+            nr_snow = self._nr_snow_buckets
+            self._snow_melt[self._current_index] = \
+                per_bucket_melt[:, :nr_snow].sum(axis=1)
+            self._firn_melt[self._current_index] = \
+                per_bucket_melt[:, nr_snow:].sum(axis=1)
+            # ice melt is the gross melt of ice where all snow and firn
+            # buckets have melted completely (in contrast to _ice_mb, which
+            # also includes newly formed ice from aging)
+            self._ice_melt[self._current_index] = 0.
+            if ice_melt_kg_m2 is not None:
+                self._ice_melt[self._current_index][all_melted_grid_points] = \
+                    ice_melt_kg_m2
 
         # save the mb of ice, this includes potential ice gain from aging after
         # the call of _bucket_aging and melt where all snow/firn buckets are
@@ -2250,6 +2305,55 @@ class SfcTypeTIModel(MassBalanceModel):
             self._apply_climate_step_and_aging_to_buckets(heights=heights,
                                                           year=yr)
 
+    def _stored_timestep_indices(self, year, mb_resolution):
+        """Indices into the stored timestep arrays contributing to the given
+        year (mb_resolution='annual') or month (mb_resolution='monthly')."""
+        if mb_resolution == 'annual':
+            if self.climate_resolution == 'annual':
+                keys = [year]
+            elif self.climate_resolution == 'monthly':
+                keys = float_years_timeseries(y0=year, y1=year + 1,
+                                              daily=False)[:-1]
+            elif self.climate_resolution == 'daily':
+                keys = float_years_timeseries(y0=year, y1=year + 1,
+                                              daily=True)[:-1]
+            else:
+                raise NotImplementedError(
+                    f"'climate_resolution': {self.climate_resolution}")
+        elif mb_resolution == 'monthly':
+            if self.climate_resolution == 'annual':
+                raise NotImplementedError('You can not get monthly values '
+                                          'with an annual climate resolution!')
+            elif self.climate_resolution == 'monthly':
+                keys = [year]
+            elif self.climate_resolution == 'daily':
+                y_start, m_start, d_start = floatyear_to_date(year,
+                                                              return_day=True)
+                float_days = float_years_timeseries(
+                    y0=year, y1=year + 1, daily=True)[:-1]
+                # only keep days larger equal than the start of the month
+                float_days = [day for day in float_days
+                              if day >= date_to_floatyear(y_start, m_start, 1)]
+                # only keep days smaller the start of the next month
+                m_end = m_start + 1 if m_start != 12 else 1
+                y_end = y_start if m_start != 12 else y_start + 1
+                keys = [day for day in float_days
+                        if day < date_to_floatyear(y_end, m_end, 1)]
+            else:
+                raise NotImplementedError(
+                    f"'climate_resolution': {self.climate_resolution}")
+        else:
+            raise NotImplementedError(f"mb_resolution: {mb_resolution}")
+
+        try:
+            return [self._year_to_index[key] for key in keys]
+        except KeyError as e:
+            raise InvalidWorkflowError(
+                f'No stored mass balance available for the timestep '
+                f'{e.args[0]}. This model only stores values for timesteps '
+                'which were computed before (e.g. through get_annual_mb or '
+                'during a dynamical model run).')
+
     def get_annual_mb(self,
                       heights: ArrayLike,
                       year: int or float,
@@ -2317,21 +2421,8 @@ class SfcTypeTIModel(MassBalanceModel):
 
         # ok now everything should be available, and we can sum up annual values
         # as needed
-        if self.climate_resolution == 'annual':
-            annual_mb = mbs[self._year_to_index[year]]
-        elif self.climate_resolution == 'monthly':
-            float_months = float_years_timeseries(y0=year, y1=year+1,
-                                                  daily=False)[:-1]
-            idx = [self._year_to_index[yr] for yr in float_months]
-            annual_mb = np.sum(mbs[idx], axis=0)
-        elif self.climate_resolution == 'daily':
-            float_days = float_years_timeseries(y0=year, y1=year+1,
-                                                daily=True)[:-1]
-            idx = [self._year_to_index[yr] for yr in float_days]
-            annual_mb = np.sum(mbs[idx], axis=0)
-        else:
-            raise NotImplementedError(
-                f"'climate_resolution': {self.climate_resolution}")
+        idx = self._stored_timestep_indices(year, mb_resolution='annual')
+        annual_mb = np.sum(mbs[idx], axis=0)
 
         # convert from kg m-2 to m s-1
         annual_mb = ((annual_mb - self.mbmod.bias) / self.sec_in_year(year) /
@@ -2414,30 +2505,8 @@ class SfcTypeTIModel(MassBalanceModel):
 
         # ok now everything should be available, and we can sum up monthly
         # values as needed
-        if self.climate_resolution == 'annual':
-            raise NotImplementedError('You can not get a monthly mb with an '
-                                      'annual climate resolution!')
-        elif self.climate_resolution == 'monthly':
-            monthly_mb = mbs[self._year_to_index[year]]
-        elif self.climate_resolution == 'daily':
-            y_start, m_start, d_start = floatyear_to_date(year,
-                                                          return_day=True)
-            float_days = float_years_timeseries(
-                y0=year, y1=year + 1, daily=True)[:-1]
-            # only keep days larger equal than the start of the month
-            float_days = [day for day in float_days
-                          if day >= date_to_floatyear(y_start, m_start, 1)]
-            # only keep days smaller the start of the next month
-            m_end = m_start + 1 if m_start != 12 else 1
-            y_end = y_start if m_start != 12 else y_start + 1
-            float_days = [day for day in float_days
-                          if day < date_to_floatyear(y_end, m_end, 1)]
-
-            idx = [self._year_to_index[yr] for yr in float_days]
-            monthly_mb = np.sum(mbs[idx], axis=0)
-        else:
-            raise NotImplementedError(
-                f"'climate_resolution': {self.climate_resolution}")
+        idx = self._stored_timestep_indices(year, mb_resolution='monthly')
+        monthly_mb = np.sum(mbs[idx], axis=0)
 
         # convert from kg m-2 to m s-1
         monthly_mb = ((monthly_mb / self.sec_in_month(year=year) -
@@ -2545,6 +2614,59 @@ class SfcTypeTIModel(MassBalanceModel):
         else:
             return daily_mb
 
+    def get_annual_melt(self, year):
+        """Get the annual melt mass split by surface type (snow, firn, ice).
+
+        The values are taken from the stored timesteps of this model
+        instance, i.e. the requested year must already have been computed
+        (e.g. through get_annual_mb or during a dynamical model run). Snow
+        is defined as the buckets younger than one year (with
+        aging_frequency='annual' this is only the freshest bucket), firn are
+        all older buckets and ice melt is the gross melt of the ice below
+        the buckets. Aging of the buckets (e.g. snow becoming firn or firn
+        becoming ice) is no melt and not included. In contrast to
+        get_annual_mb, a potential mass balance bias (mbmod.bias) is not
+        included here.
+
+        Parameters
+        ----------
+        year : int or float
+            Year in calendar float year or as int.
+
+        Returns
+        -------
+        tuple of np.ndarray
+            (snow_melt, firn_melt, ice_melt), each in kg m-2 yr-1 on the grid
+            points defined at initialisation. The sum of the three equals the
+            solid precipitation minus the climatic mass balance.
+        """
+        idx = self._stored_timestep_indices(year, mb_resolution='annual')
+        return (np.sum(self._snow_melt[idx], axis=0),
+                np.sum(self._firn_melt[idx], axis=0),
+                np.sum(self._ice_melt[idx], axis=0))
+
+    def get_monthly_melt(self, year):
+        """Get the monthly melt mass split by surface type (snow, firn, ice).
+
+        Same as get_annual_melt, but for a single month.
+
+        Parameters
+        ----------
+        year : float
+            Year in calendar float year.
+
+        Returns
+        -------
+        tuple of np.ndarray
+            (snow_melt, firn_melt, ice_melt), each in kg m-2 month-1 on the
+            grid points defined at initialisation. The sum of the three
+            equals the solid precipitation minus the climatic mass balance.
+        """
+        idx = self._stored_timestep_indices(year, mb_resolution='monthly')
+        return (np.sum(self._snow_melt[idx], axis=0),
+                np.sum(self._firn_melt[idx], axis=0),
+                np.sum(self._ice_melt[idx], axis=0))
+
     def is_year_valid(self, year):
         return self.mbmod.is_year_valid(year)
 
@@ -2644,6 +2766,24 @@ class SfcTypeTIModel(MassBalanceModel):
                 dims=['time', 'grid_point'],
                 attrs={'units': 'm',
                        'long_name': 'heights used per timestep'},
+            ),
+            'snow_melt': xr.DataArray(
+                self._snow_melt[:current_index],
+                dims=['time', 'grid_point'],
+                attrs={'units': 'kg m-2',
+                       'long_name': 'snow melt per timestep'},
+            ),
+            'firn_melt': xr.DataArray(
+                self._firn_melt[:current_index],
+                dims=['time', 'grid_point'],
+                attrs={'units': 'kg m-2',
+                       'long_name': 'firn melt per timestep'},
+            ),
+            'ice_melt': xr.DataArray(
+                self._ice_melt[:current_index],
+                dims=['time', 'grid_point'],
+                attrs={'units': 'kg m-2',
+                       'long_name': 'gross ice melt per timestep'},
             ),
         }
 
@@ -2906,6 +3046,16 @@ class SfcTypeTIModel(MassBalanceModel):
                     model._ice_mb[:current_index] = ds['ice_mb'].values
                     model._mb_heights[:current_index] = (
                         ds['mb_heights_stored'].values)
+                    # melt split by surface type (files saved before its
+                    # introduction do not contain it -> set to NaN)
+                    for attr_name, var_name in [('_snow_melt', 'snow_melt'),
+                                                ('_firn_melt', 'firn_melt'),
+                                                ('_ice_melt', 'ice_melt')]:
+                        arr = getattr(model, attr_name)
+                        if var_name in ds:
+                            arr[:current_index] = ds[var_name].values
+                        else:
+                            arr[:current_index] = np.nan
 
                     # 'time' coordinate holds the float-year keys; array
                     # indices are simply 0…N-1

--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -432,11 +432,14 @@ store_output_on_error = False
 #   off_area, on_area,
 #   melt_off_glacier, melt_on_glacier,
 #   liq_prcp_off_glacier, liq_prcp_on_glacier, snowfall_off_glacier, snowfall_on_glacier,
+# Only computed for mass balance models with surface type tracking
+# (e.g. SfcTypeTIModel), NaN otherwise:
+#   snow_melt_on_glacier, firn_melt_on_glacier, ice_melt_on_glacier,
 # Probably useful for debugging only
 #   melt_residual_off_glacier, melt_residual_on_glacier
 #   model_mb, residual_mb, snow_bucket,
 # You need to keep all variables in one line unfortunately
-store_diagnostic_variables =  volume, volume_bsl, volume_bwl, area, area_min_h, length, mass, calving, calving_rate, off_area, on_area, melt_off_glacier, melt_on_glacier, liq_prcp_off_glacier, liq_prcp_on_glacier, snowfall_off_glacier, snowfall_on_glacier
+store_diagnostic_variables =  volume, volume_bsl, volume_bwl, area, area_min_h, length, mass, calving, calving_rate, off_area, on_area, melt_off_glacier, melt_on_glacier, liq_prcp_off_glacier, liq_prcp_on_glacier, snowfall_off_glacier, snowfall_on_glacier, snow_melt_on_glacier, firn_melt_on_glacier, ice_melt_on_glacier
 
 # Whether to store the model flowline diagnostic files during operational runs
 # This can be useful for advanced diagnostics along the flowlines but is

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -63,7 +63,8 @@ DOM_BORDER = 80
 
 ALL_DIAGS = ['volume', 'volume_bsl', 'volume_bwl', 'area', 'length', 'mass',
              'calving', 'calving_rate', 'off_area', 'on_area', 'melt_off_glacier',
-             'melt_on_glacier', 'liq_prcp_off_glacier', 'liq_prcp_on_glacier',
+             'melt_on_glacier', 'snow_melt_on_glacier', 'firn_melt_on_glacier',
+             'ice_melt_on_glacier', 'liq_prcp_off_glacier', 'liq_prcp_on_glacier',
              'snowfall_off_glacier', 'snowfall_on_glacier', 'model_mb',
              'residual_mb', 'snow_bucket']
 
@@ -1553,6 +1554,56 @@ class TestMassBalanceModels:
             # +1 because index starts with 0
             assert max_used_index + 1 == mb_mod._climatic_mb.shape[0]
 
+            # check the melt split by surface type
+            snow_melt, firn_melt, ice_melt = mb_mod.get_annual_melt(
+                year=target_year_annual)
+            # melt can never be negative
+            assert np.all(snow_melt >= 0)
+            assert np.all(firn_melt >= 0)
+            assert np.all(ice_melt >= 0)
+            # for HEF there is some snow and ice melt in this year
+            assert np.sum(snow_melt) > 0
+            assert np.sum(ice_melt) > 0
+            # firn only melts in years when the melt at a grid point eats
+            # through all buckets younger than one year; this happens at some
+            # point during the modelled period (e.g. summer 2003), but not
+            # necessarily in the target year
+            assert mb_mod.firn_melt.values.sum() > 0
+            # the components sum up to solid precipitation minus climatic mb
+            # (which shows that pure aging is never counted as melt)
+            mb_out = mb_mod.get_annual_mb(heights=h, year=target_year_annual,
+                                          add_climate=True)
+            annual_mb, _, _, _, prcpsol = mb_out
+            annual_mb_kg = (annual_mb * mb_mod.sec_in_year(target_year_annual)
+                            * mb_mod.mbmod.ice_density) + mb_mod.mbmod.bias
+            np.testing.assert_allclose(snow_melt + firn_melt + ice_melt,
+                                       prcpsol - annual_mb_kg,
+                                       atol=1e-6)
+
+            if clim_res in ['monthly', 'daily']:
+                # the monthly melt components sum up to the annual ones
+                monthly_sums = np.zeros((3, len(h)))
+                for month in np.arange(1, 13):
+                    melts = mb_mod.get_monthly_melt(
+                        year=date_to_floatyear(y=target_year_annual, m=month))
+                    for c, melt in enumerate(melts):
+                        monthly_sums[c] += melt
+                np.testing.assert_allclose(monthly_sums[0], snow_melt,
+                                           atol=1e-6)
+                np.testing.assert_allclose(monthly_sums[1], firn_melt,
+                                           atol=1e-6)
+                np.testing.assert_allclose(monthly_sums[2], ice_melt,
+                                           atol=1e-6)
+
+                # aging is not counted as melt: at the highest grid point in
+                # deep winter there is no melt at all, although the buckets
+                # aged (and with monthly aging even snow became firn); only
+                # floating point noise is allowed
+                melts_jan = mb_mod.get_monthly_melt(
+                    year=date_to_floatyear(y=target_year_annual, m=1))
+                for melt in melts_jan:
+                    np.testing.assert_allclose(melt[0], 0, atol=1e-9)
+
         if do_plot:
             # compare sfc tracking to mb_models without surface tracking
             mb_mod_daily = massbalance.DailyTIModel(
@@ -1860,6 +1911,15 @@ class TestMassBalanceModels:
             np.testing.assert_allclose(
                 m1._mb_heights[:m1._current_index],
                 m2._mb_heights[:m2._current_index])
+            np.testing.assert_allclose(
+                m1._snow_melt[:m1._current_index],
+                m2._snow_melt[:m2._current_index])
+            np.testing.assert_allclose(
+                m1._firn_melt[:m1._current_index],
+                m2._firn_melt[:m2._current_index])
+            np.testing.assert_allclose(
+                m1._ice_melt[:m1._current_index],
+                m2._ice_melt[:m2._current_index])
             assert m1.buckets == m2.buckets
             np.testing.assert_allclose(
                 list(m1.melt_f_buckets.values()),
@@ -2435,8 +2495,7 @@ class TestMassBalanceModels:
             continues_mb.flowline_mb_models[0].mb_buckets_np,
             proj_mb_mod.mb_buckets_np, )
 
-        # test run_with_hydro, just testing if it runs without errors
-        # TODO: run_with_hydro needs to be adapted for SfcTypeTIModel
+        # test run_with_hydro with both models
         gdir.settings_filesuffix = '_daily'
         gdir.settings['store_model_geometry'] = True
         tasks.run_with_hydro(
@@ -2446,6 +2505,8 @@ class TestMassBalanceModels:
             climate_input_filesuffix='_daily', ys=1980, ye=2020,
             output_filesuffix='_daily_hydro')
 
+        # for SfcTypeTIModel use_previous_mbs is set inside run_with_hydro,
+        # because the stored mb values of the dynamical run are revisited
         gdir.settings_filesuffix = '_daily_sfc'
         gdir.settings['store_model_geometry'] = True
         tasks.run_with_hydro(
@@ -2454,13 +2515,65 @@ class TestMassBalanceModels:
             mb_model_class=partial(
                 massbalance.SfcTypeTIModel,
                 mb_model_class=massbalance.DailyTIModel,
-                ys=mbdf.index[0],
-                # run_with_hydro revisit the mb_values, we need to allow this
-                use_previous_mbs=True,
-            ),
+                ys=mbdf.index[0]),
             climate_input_filesuffix='_daily',
+            store_monthly_hydro=True,
             ys=1980, ye=2020,
             output_filesuffix='_daily_sfc_hydro')
+
+        # without surface type tracking the melt components are NaN
+        with xr.open_dataset(
+                gdir.get_filepath('model_diagnostics',
+                                  filesuffix='_daily_hydro')) as ds:
+            ds_hydro = ds.load()
+        for vn in ['snow_melt_on_glacier', 'firn_melt_on_glacier',
+                   'ice_melt_on_glacier']:
+            assert np.all(np.isnan(ds_hydro[vn]))
+
+        with xr.open_dataset(
+                gdir.get_filepath('model_diagnostics',
+                                  filesuffix='_daily_sfc_hydro')) as ds:
+            ds_hydro_sfc = ds.load()
+
+        # the last year of the hydro output is always NaN
+        odf_sfc = ds_hydro_sfc.isel(time=slice(0, -1))
+
+        # after the corrections the hydro output is mass conserving: the
+        # on-glacier mass balance corresponds to the total mass change of the
+        # dynamical run (incl. snow and firn buckets)
+        np.testing.assert_allclose(
+            odf_sfc['snowfall_on_glacier'].values -
+            odf_sfc['melt_on_glacier'].values,
+            ds_hydro_sfc['mass_kg'].values[1:] -
+            ds_hydro_sfc['mass_kg'].values[:-1])
+
+        # with surface type tracking the melt components sum up to the total
+        # on-glacier melt, annually and monthly
+        melt_sum = (odf_sfc['snow_melt_on_glacier'] +
+                    odf_sfc['firn_melt_on_glacier'] +
+                    odf_sfc['ice_melt_on_glacier'])
+        np.testing.assert_allclose(melt_sum.values,
+                                   odf_sfc['melt_on_glacier'].values)
+        melt_sum_monthly = (odf_sfc['snow_melt_on_glacier_monthly'] +
+                            odf_sfc['firn_melt_on_glacier_monthly'] +
+                            odf_sfc['ice_melt_on_glacier_monthly'])
+        np.testing.assert_allclose(melt_sum_monthly.values,
+                                   odf_sfc['melt_on_glacier_monthly'].values,
+                                   atol=1e-6)
+
+        # all components are non-negative and each surface type contributes
+        # some melt over the entire period
+        for vn in ['snow_melt_on_glacier', 'firn_melt_on_glacier',
+                   'ice_melt_on_glacier']:
+            assert np.all(odf_sfc[vn].values >= 0)
+            assert odf_sfc[vn].sum() > 0
+
+        # most of the melt should come from snow and ice, firn melt is the
+        # smallest contribution
+        assert (odf_sfc['firn_melt_on_glacier'].sum() <
+                odf_sfc['snow_melt_on_glacier'].sum())
+        assert (odf_sfc['firn_melt_on_glacier'].sum() <
+                odf_sfc['ice_melt_on_glacier'].sum())
 
         if do_plot:
             def plot_runoff(filesuffix, title):

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -6032,6 +6032,7 @@ class TestDynamicSpinup:
                 hef_gdir,
                 minimise_for=minimise_for)
         hef_gdir.settings['use_kcalving_for_run'] = False
+        cfg.PARAMS['use_inversion_params_for_run'] = True
 
         # test that fixed_geometry_spinup is added correctly if spinup period
         # is shorten due to too large precision
@@ -6039,7 +6040,6 @@ class TestDynamicSpinup:
             run_dynamic_spinup(
                 hef_gdir,
                 spinup_start_yr=1979,
-                min_spinup_period=5,
                 precision_percent=0.0027,
                 minimise_for=minimise_for,
                 output_filesuffix='_without_fixed_spinup',
@@ -6051,7 +6051,6 @@ class TestDynamicSpinup:
             run_dynamic_spinup(
                 hef_gdir,
                 spinup_start_yr=1979,
-                min_spinup_period=5,
                 precision_percent=0.0027,
                 minimise_for=minimise_for,
                 output_filesuffix='_with_fixed_spinup',

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -6039,6 +6039,7 @@ class TestDynamicSpinup:
             run_dynamic_spinup(
                 hef_gdir,
                 spinup_start_yr=1979,
+                min_spinup_period=5,
                 precision_percent=0.0027,
                 minimise_for=minimise_for,
                 output_filesuffix='_without_fixed_spinup',
@@ -6050,6 +6051,7 @@ class TestDynamicSpinup:
             run_dynamic_spinup(
                 hef_gdir,
                 spinup_start_yr=1979,
+                min_spinup_period=5,
                 precision_percent=0.0027,
                 minimise_for=minimise_for,
                 output_filesuffix='_with_fixed_spinup',

--- a/oggm/tests/test_shop.py
+++ b/oggm/tests/test_shop.py
@@ -836,8 +836,8 @@ class Test_bedtopo:
         np.testing.assert_allclose(my_area, gdir.rgi_area_m2, rtol=0.07)
 
         rio_area = np.sum(ref.data > 0) * gdir.grid.dx**2
-        np.testing.assert_allclose(rio_area, gdir.rgi_area_m2, rtol=0.15)
-        np.testing.assert_allclose(my_area, rio_area, rtol=0.15)
+        np.testing.assert_allclose(rio_area, gdir.rgi_area_m2, rtol=0.17)
+        np.testing.assert_allclose(my_area, rio_area, rtol=0.17)
 
         # They are not same:
         # - interpolation not 1to1 same especially at borders

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -893,6 +893,8 @@ class TestWorkflowUtils:
                              'area_min_h', 'length', 'calving', 'calving_rate',
                              'off_area', 'on_area',
                              'melt_off_glacier', 'melt_on_glacier',
+                             'snow_melt_on_glacier', 'firn_melt_on_glacier',
+                             'ice_melt_on_glacier',
                              'liq_prcp_off_glacier', 'liq_prcp_on_glacier',
                              'snowfall_off_glacier', 'snowfall_on_glacier',
                              'melt_residual_off_glacier',
@@ -946,6 +948,13 @@ class TestWorkflowUtils:
             assert np.all(np.isnan(
                 ds.loc[{'rgi_id': gdirs[0].rgi_id}]['melt_on_glacier_monthly'].values))
             assert 'mass_kg' in ds.data_vars
+            # the melt split components are only computed for mb models with
+            # surface type tracking, here they should be present but NaN
+            assert 'snow_melt_on_glacier' in ds.data_vars
+            assert 'firn_melt_on_glacier' in ds.data_vars
+            assert 'ice_melt_on_glacier' in ds.data_vars
+            assert np.all(np.isnan(
+                ds.loc[{'rgi_id': gdirs[1].rgi_id}]['snow_melt_on_glacier'].values))
 
         check_result(ds_1)
 

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -1195,6 +1195,8 @@ def compile_run_output(gdirs, path=True, input_filesuffix='',
         allowed_data_vars += [f'terminus_thick_{gi}']
     # this hydro variables can be _monthly or _daily
     hydro_vars = ['melt_off_glacier', 'melt_on_glacier',
+                  'snow_melt_on_glacier', 'firn_melt_on_glacier',
+                  'ice_melt_on_glacier',
                   'liq_prcp_off_glacier', 'liq_prcp_on_glacier',
                   'snowfall_off_glacier', 'snowfall_on_glacier',
                   'melt_residual_off_glacier', 'melt_residual_on_glacier',


### PR DESCRIPTION
Here I add support for `SfcTypeTIModel` within `run_with_hydro`. This includes that `melt_on_glacier` can now also be split into `snow_melt_on_glacier` (solid precipitation younger than one year), `firn_melt_on_glacier` and `ice_melt_on_glacier`.

Related to https://github.com/OGGM/oggm/issues/1952

- [x] Tests added/passed
- [ ] Fully documented
- [x] Entry in `whats-new.rst` 
