### PR TITLE
Audit and fix test suite

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -152,6 +152,10 @@ Bug fixes
 - Fixed a bug in ``compile_to_netcdf`` decorator, avoiding to raise an error if
   a single chunk failes (:pull:`1954`).
   By Copilot and `Patrick Schmitt <https://github.com/pat-schmitt>`_
+- Model constructors no longer silently persist a non-default ``temp_melt`` to
+  the gdir settings file. ``check_calib_params`` now validates the effective
+  model parameters instead of the settings file, and calibration tasks record ``mb_global_params`` from the model used.
+  By `Nicolas Gampierakis <https://github.com/gampnico>`_
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -14,7 +14,7 @@ Enhancements
   By `Nicolas Gampierakis <https://github.com/gampnico>`_.
 - New global task ``calibrate_inversion_from_ref_table`` generalises
   ``calibrate_inversion_from_consensus`` to calibrate the ice thickness
-  inversion against an arbitrary reference volume table (given as a DataFrame,
+  inversion against an arbitrary reference volume table (given as a DataFrame, 
   a path or a URL). By default it now uses the IceBoost v2 products, with the
   RGI6 or RGI7 table selected automatically from the glacier directories.
   ``calibrate_inversion_from_consensus`` is deprecated but still available: it
@@ -215,6 +215,8 @@ Bug fixes
   calling the tasks directly is unaffected. This has been applied to all
   "run_*" tasks to avoid memory issues (see "breaking changes") (:pull:`1977`).
   By `Fabien Maussion <https://github.com/fmaussion>`_
+- Multiple fixes to the test suite, missing assertions, test logic (:pull:`1960`).
+  By `Nicolas Gampierakis <http://github.com/gampnico>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -570,15 +570,23 @@ class MonthlyTIModel(MassBalanceModel):
         if prcp_fac is None:
             prcp_fac = self.calib_params['prcp_fac']
 
+        # Global parameters
+        self.temp_all_solid = gdir.settings['temp_all_solid']
+        self.temp_all_liq = gdir.settings['temp_all_liq']
+        if temp_melt is None:
+            temp_melt = gdir.settings['temp_melt']
+        self.temp_melt = temp_melt
+        self.temp_default_gradient = gdir.settings['temp_default_gradient']
+
         # Check the climate related params to the GlacierDir to make sure
         if check_calib_params:
             mb_calib = self.calib_params['mb_global_params']
             for k, v in mb_calib.items():
-                if v != self.gdir.settings[k]:
+                if v != getattr(self, k):
                     msg = ('You seem to use different mass balance parameters '
                            'than used for the calibration: '
-                           f"you use gdir.settings['{k}']={gdir.settings[k]} while "
-                           f"it was calibrated with gdir.settings['{k}']={v}. "
+                           f'you use {k}={getattr(self, k)} while '
+                           f'it was calibrated with {k}={v}. '
                            'Set `check_calib_params=False` to ignore this '
                            'warning.')
                     raise InvalidWorkflowError(msg)
@@ -596,19 +604,9 @@ class MonthlyTIModel(MassBalanceModel):
         self.melt_f = melt_f
         self.bias = bias
 
-        # Global parameters
-        self.temp_all_solid = gdir.settings['temp_all_solid']
-        self.temp_all_liq = gdir.settings['temp_all_liq']
-        if temp_melt is None:
-            self.temp_melt = gdir.settings['temp_melt']
-        else:
-            gdir.settings['temp_melt'] = temp_melt
-            self.temp_melt = temp_melt
-
         # check if valid prcp_fac is used
         if prcp_fac <= 0:
             raise InvalidParamsError('prcp_fac has to be above zero!')
-        self.temp_default_gradient = gdir.settings['temp_default_gradient']
 
         # Public attrs
         self.hemisphere = gdir.hemisphere
@@ -3907,6 +3905,17 @@ def decide_winter_precip_factor(gdir):
                        gdir.settings['prcp_fac_max'])
 
 
+def _mb_global_params_from_model(mb_mod):
+    """Effective MB_GLOBAL_PARAMS of a (possibly wrapped) TI model.
+
+    These can differ from the gdir settings, e.g. DailyTIModel defaults
+    to temp_melt=0.0 regardless of settings['temp_melt'].
+    """
+    mod = getattr(mb_mod, "flowline_mb_models", [mb_mod])[0]
+    mod = getattr(mod, "mbmod", mod)  # e.g. SfcTypeTIModel
+    return {k: getattr(mod, k) for k in MB_GLOBAL_PARAMS}
+
+
 @entity_task(log, writes=['mb_calib'])
 def mb_calibration_from_wgms_mb(gdir, settings_filesuffix='',
                                 observations_filesuffix='',
@@ -4200,7 +4209,7 @@ def mb_calibration_to_rmsd(gdir, *,
 
     # Add the climate related params to the GlacierDir to make sure
     # other tools cannot fool around without re-calibration
-    df['mb_global_params'] = {k: gdir.settings[k] for k in MB_GLOBAL_PARAMS}
+    df['mb_global_params'] = _mb_global_params_from_model(mb_mod)
     df['baseline_climate_source'] = gdir.get_climate_info(
         filename=mb_mod.filename, input_filesuffix=mb_mod.input_filesuffix
     )['baseline_climate_source']
@@ -4981,7 +4990,7 @@ def mb_calibration_from_scalar_mb(gdir, *,
 
     # Add the climate related params to the GlacierDir to make sure
     # other tools cannot fool around without re-calibration
-    df['mb_global_params'] = {k: gdir.settings[k] for k in MB_GLOBAL_PARAMS}
+    df['mb_global_params'] = _mb_global_params_from_model(mb_mod)
     df['baseline_climate_source'] = gdir.get_climate_info(
         filename=mb_mod.filename, input_filesuffix=mb_mod.input_filesuffix
     )['baseline_climate_source']

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -1368,6 +1368,38 @@ class TestMassBalanceModels:
         np.testing.assert_allclose(ds_daily.volume[-1], ds_monthly.volume[-1],
                                    atol=3e7)
 
+    def test_temp_melt_not_persisted_by_ctor(self, hef_gdir):
+        """Constructing model with explicit default temp_melt shouldn't
+        write to gdir settings file, and calib params check should catch
+        the mismatch.
+        """
+
+        tasks.process_gswp3_w5e5_data(hef_gdir, daily=True)
+        gdir = hef_gdir
+
+        stored_before = gdir.get_stored_settings()
+        assert "temp_melt" not in stored_before
+
+        # DailyTIModel defaults temp_melt=0.0 while gdir calibrated with
+        # monthly model (temp_melt=-1)
+        with pytest.raises(InvalidWorkflowError, match="temp_melt"):
+            massbalance.DailyTIModel(gdir)
+
+        # explicit kwarg mismatching the calibration also raises
+        with pytest.raises(InvalidWorkflowError, match="temp_melt"):
+            massbalance.MonthlyTIModel(gdir, temp_melt=5.0)
+
+        # opting out of the check works, uses value for instance
+        mb_mod = massbalance.DailyTIModel(gdir, check_calib_params=False)
+        assert mb_mod.temp_melt == 0.0
+
+        # and in no case is anything written to settings file
+        assert gdir.get_stored_settings() == stored_before
+
+        # monthly model still fine
+        mb_mod = massbalance.MonthlyTIModel(gdir)
+        assert mb_mod.temp_melt == gdir.settings["temp_melt"]
+
     @pytest.mark.slow
     def test_sfc_type_mb_model(self, hef_gdir):
 

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -1031,36 +1031,35 @@ class TestMassBalanceModels:
         np.testing.assert_allclose(prcp_d, prcp_m)
         np.testing.assert_allclose(t_d, t_m, atol=0.02)
 
+        # for checking how much has changed to OGGM v1.6 here a hard coded
+        mb_annual_oggm_v16 = [
+            -1.42297448e-07, -1.41160282e-07, -1.39199219e-07, -1.36113197e-07,
+            -1.31840437e-07, -1.26940610e-07, -1.21949801e-07, -1.17948533e-07,
+            -1.14388734e-07, -1.11166865e-07, -1.08178550e-07, -1.05308084e-07,
+            -1.02515762e-07, -9.96907271e-08, -9.67172896e-08, -9.36011930e-08,
+            -9.03592687e-08, -8.69923123e-08, -8.29093380e-08, -7.90813507e-08,
+            -7.55444959e-08, -7.24727279e-08, -6.93747120e-08, -6.63505138e-08,
+            -6.35754355e-08, -6.11641273e-08, -5.89809293e-08, -5.67949353e-08,
+            -5.44956761e-08, -5.20240215e-08, -4.93213255e-08, -4.63693337e-08,
+            -4.31273607e-08, -3.95146795e-08, -3.55167024e-08, -3.16922755e-08,
+            -2.85680526e-08, -2.60397302e-08, -2.37143703e-08, -2.13926889e-08,
+            -1.90271618e-08, -1.73486999e-08, -1.65511508e-08, -1.39938251e-08,
+            -1.14532445e-08, -8.95108401e-09, -8.90165026e-09, -6.43941025e-09,
+            -3.79873736e-09, -8.85807717e-10,  2.50943975e-09,  4.80588815e-09,
+            6.39301260e-09,  1.01207768e-08,  1.35185100e-08,  1.59884941e-08,
+            1.70314225e-08,  2.04225150e-08,  2.35563242e-08,  2.53007150e-08,
+            2.65123374e-08,  2.91862845e-08,  3.14872294e-08,  3.31400347e-08,
+            3.39361834e-08,  3.73918160e-08,  3.92227052e-08,  4.10314532e-08,
+            4.13874876e-08,  4.39342346e-08,  4.43393872e-08,  4.58317424e-08,
+            4.86526460e-08,  4.93663560e-08,  5.36643971e-08,  5.41680453e-08,
+            5.84341486e-08,  6.00092412e-08,  6.30844863e-08,  6.58271495e-08,
+            6.76431998e-08,  7.15019273e-08,  7.21872267e-08,  7.61114775e-08,
+            7.71056592e-08,  7.76305573e-08,  8.12629938e-08,  8.45592440e-08,
+            8.70176740e-08,  8.83996244e-08]
+        np.testing.assert_allclose(mb_annual_oggm_v16, mb_annual_m, atol=1.3e-9)
+
         # plot for looking at how mb gradient is changing
         if do_plot:
-            # for checking how much has changed to OGGM v1.6 here a hard coded
-            mb_annual_oggm_v16 = [
-                -1.42297448e-07, -1.41160282e-07, -1.39199219e-07, -1.36113197e-07,
-                -1.31840437e-07, -1.26940610e-07, -1.21949801e-07, -1.17948533e-07,
-                -1.14388734e-07, -1.11166865e-07, -1.08178550e-07, -1.05308084e-07,
-                -1.02515762e-07, -9.96907271e-08, -9.67172896e-08, -9.36011930e-08,
-                -9.03592687e-08, -8.69923123e-08, -8.29093380e-08, -7.90813507e-08,
-                -7.55444959e-08, -7.24727279e-08, -6.93747120e-08, -6.63505138e-08,
-                -6.35754355e-08, -6.11641273e-08, -5.89809293e-08, -5.67949353e-08,
-                -5.44956761e-08, -5.20240215e-08, -4.93213255e-08, -4.63693337e-08,
-                -4.31273607e-08, -3.95146795e-08, -3.55167024e-08, -3.16922755e-08,
-                -2.85680526e-08, -2.60397302e-08, -2.37143703e-08, -2.13926889e-08,
-                -1.90271618e-08, -1.73486999e-08, -1.65511508e-08, -1.39938251e-08,
-                -1.14532445e-08, -8.95108401e-09, -8.90165026e-09, -6.43941025e-09,
-                -3.79873736e-09, -8.85807717e-10,  2.50943975e-09,  4.80588815e-09,
-                6.39301260e-09,  1.01207768e-08,  1.35185100e-08,  1.59884941e-08,
-                1.70314225e-08,  2.04225150e-08,  2.35563242e-08,  2.53007150e-08,
-                2.65123374e-08,  2.91862845e-08,  3.14872294e-08,  3.31400347e-08,
-                3.39361834e-08,  3.73918160e-08,  3.92227052e-08,  4.10314532e-08,
-                4.13874876e-08,  4.39342346e-08,  4.43393872e-08,  4.58317424e-08,
-                4.86526460e-08,  4.93663560e-08,  5.36643971e-08,  5.41680453e-08,
-                5.84341486e-08,  6.00092412e-08,  6.30844863e-08,  6.58271495e-08,
-                6.76431998e-08,  7.15019273e-08,  7.21872267e-08,  7.61114775e-08,
-                7.71056592e-08,  7.76305573e-08,  8.12629938e-08,  8.45592440e-08,
-                8.70176740e-08,  8.83996244e-08]
-            np.testing.assert_allclose(mb_annual_oggm_v16, mb_annual_m,
-                                       atol=1.3e-9)
-
             plt.plot(prcpsol_d, h, label='daily')
             plt.plot(prcpsol_m, h, label='monthly')
             plt.title(f'annual solid prcp for {yr}')
@@ -1097,35 +1096,36 @@ class TestMassBalanceModels:
         np.testing.assert_allclose(prcp_d, prcp_m)
         np.testing.assert_allclose(t_d, t_m, atol=1e-4)
 
+        # for checking how much has changed to OGGM v1.6 here a hard coded
+        mb_monthly_oggm_v16 = [
+            -5.13190966e-07, -5.11211812e-07, -5.07798727e-07, -5.02498359e-07,
+            -4.95374449e-07, -4.87205038e-07, -4.78881443e-07, -4.71262960e-07,
+            -4.64485043e-07, -4.58350551e-07, -4.52660749e-07, -4.47195333e-07,
+            -4.41878705e-07, -4.36499791e-07, -4.30838316e-07, -4.24905215e-07,
+            -4.18732537e-07, -4.12321795e-07, -4.05990839e-07, -4.00175269e-07,
+            -3.94790126e-07, -3.89446968e-07, -3.84058153e-07, -3.78797739e-07,
+            -3.73970655e-07, -3.69776327e-07, -3.65978784e-07, -3.62176377e-07,
+            -3.58176952e-07, -3.53877655e-07, -3.49176475e-07, -3.44041660e-07,
+            -3.38402440e-07, -3.31937059e-07, -3.24663937e-07, -3.17706537e-07,
+            -3.12022949e-07, -3.07423423e-07, -3.03193127e-07, -2.98969523e-07,
+            -2.94666154e-07, -2.91612695e-07, -2.90161794e-07, -2.85509505e-07,
+            -2.80887679e-07, -2.76335747e-07, -2.76245818e-07, -2.71766509e-07,
+            -2.66962595e-07, -2.61663392e-07, -2.55486755e-07, -2.50892238e-07,
+            -2.46389327e-07, -2.34266499e-07, -2.21147635e-07, -2.11610869e-07,
+            -2.07584057e-07, -1.94490833e-07, -1.82390996e-07, -1.75655792e-07,
+            -1.70977641e-07, -1.60653361e-07, -1.51769266e-07, -1.45387680e-07,
+            -1.42313699e-07, -1.28971282e-07, -1.21902102e-07, -1.10290002e-07,
+            -1.07780730e-07, -8.98316793e-08, -8.69762307e-08, -7.64583579e-08,
+            -6.02983722e-08, -5.64291333e-08, -3.31281440e-08, -3.03977137e-08,
+            -8.33160424e-09, -1.40054651e-09,  1.21318019e-08,  2.42006525e-08,
+            3.21920240e-08,  4.91720184e-08,  5.21876188e-08,  6.94559431e-08,
+            7.11095569e-08,  7.11095569e-08,  7.11095569e-08,  7.11095569e-08,
+            7.11095569e-08,  7.11095569e-08]
+        np.testing.assert_allclose(mb_monthly_oggm_v16, mb_monthly_m,
+                                   atol=1.3e-9)
+
         # plot for looking at how mb gradient is changing
         if do_plot:
-            mb_monthly_oggm_v16 = [
-                -5.13190966e-07, -5.11211812e-07, -5.07798727e-07, -5.02498359e-07,
-                -4.95374449e-07, -4.87205038e-07, -4.78881443e-07, -4.71262960e-07,
-                -4.64485043e-07, -4.58350551e-07, -4.52660749e-07, -4.47195333e-07,
-                -4.41878705e-07, -4.36499791e-07, -4.30838316e-07, -4.24905215e-07,
-                -4.18732537e-07, -4.12321795e-07, -4.05990839e-07, -4.00175269e-07,
-                -3.94790126e-07, -3.89446968e-07, -3.84058153e-07, -3.78797739e-07,
-                -3.73970655e-07, -3.69776327e-07, -3.65978784e-07, -3.62176377e-07,
-                -3.58176952e-07, -3.53877655e-07, -3.49176475e-07, -3.44041660e-07,
-                -3.38402440e-07, -3.31937059e-07, -3.24663937e-07, -3.17706537e-07,
-                -3.12022949e-07, -3.07423423e-07, -3.03193127e-07, -2.98969523e-07,
-                -2.94666154e-07, -2.91612695e-07, -2.90161794e-07, -2.85509505e-07,
-                -2.80887679e-07, -2.76335747e-07, -2.76245818e-07, -2.71766509e-07,
-                -2.66962595e-07, -2.61663392e-07, -2.55486755e-07, -2.50892238e-07,
-                -2.46389327e-07, -2.34266499e-07, -2.21147635e-07, -2.11610869e-07,
-                -2.07584057e-07, -1.94490833e-07, -1.82390996e-07, -1.75655792e-07,
-                -1.70977641e-07, -1.60653361e-07, -1.51769266e-07, -1.45387680e-07,
-                -1.42313699e-07, -1.28971282e-07, -1.21902102e-07, -1.10290002e-07,
-                -1.07780730e-07, -8.98316793e-08, -8.69762307e-08, -7.64583579e-08,
-                -6.02983722e-08, -5.64291333e-08, -3.31281440e-08, -3.03977137e-08,
-                -8.33160424e-09, -1.40054651e-09,  1.21318019e-08,  2.42006525e-08,
-                3.21920240e-08,  4.91720184e-08,  5.21876188e-08,  6.94559431e-08,
-                7.11095569e-08,  7.11095569e-08,  7.11095569e-08,  7.11095569e-08,
-                7.11095569e-08,  7.11095569e-08]
-            np.testing.assert_allclose(mb_monthly_oggm_v16, mb_monthly_m,
-                                       atol=1.3e-9)
-
             plt.plot(prcpsol_d, h, label='daily')
             plt.plot(prcpsol_m, h, label='monthly')
             plt.title(f'monthly solid prcp for {m:02d}.{yr}')
@@ -1737,15 +1737,20 @@ class TestMassBalanceModels:
                                        mb_model_class=massbalance.DailyTIModel,
                                        ys=1800, check_calib_params=False,)
 
-        with pytest.raises(InvalidWorkflowError,
-                           match='The current buckets are valid for *'):
-            mb_mod = massbalance.SfcTypeTIModel(
-                gdir, settings_filesuffix='_daily',
-                mb_model_class=massbalance.DailyTIModel, ys=2000,
-                use_previous_mbs=False, check_calib_params=False, )
-            mb_mod.get_annual_mb(heights=h, year=2000)
-            # calling the same year a second time with use_previous_mbs=False
-            # should raise
+        mb_mod = massbalance.SfcTypeTIModel(
+            gdir,
+            settings_filesuffix="_daily",
+            mb_model_class=massbalance.DailyTIModel,
+            ys=2000,
+            use_previous_mbs=False,
+            check_calib_params=False,
+        )
+        mb_mod.get_annual_mb(heights=h, year=2000)
+        # calling the same year a second time with use_previous_mbs=False
+        # should raise
+        with pytest.raises(
+            InvalidWorkflowError, match="The current buckets are valid for"
+        ):
             mb_mod.get_annual_mb(heights=h, year=2000)
 
         # Look at different options of defining the melt_f per bucket
@@ -5285,9 +5290,20 @@ class TestHEF:
                              bias=0, output_filesuffix='_def')
         run_constant_climate(gdir_calving, nyears=10, y0=1985,
                              bias=0, output_filesuffix='_def')
-        utils.compile_run_output([gdir_calving, hef_gdir],
-                                 input_filesuffix='_def',
-                                 tmp_file_size=1)
+        # tmp_file_size=1 means compiled output is written to disk and
+        # not returned
+        assert (
+            utils.compile_run_output(
+                [gdir_calving, hef_gdir], input_filesuffix="_def", tmp_file_size=1
+            )
+            is None
+        )
+        fp = os.path.join(cfg.PATHS["working_dir"], "run_output_def.nc")
+        with xr.open_dataset(fp) as ds:
+            ds = ds.load()
+        assert sorted(ds.rgi_id.data) == sorted([gdir_calving.rgi_id, hef_gdir.rgi_id])
+        assert np.all(np.isfinite(ds.volume.data))
+        assert np.all(ds.volume.data > 0)
 
         # This should work although one calves the other not
         cfg.PARAMS['use_kcalving_for_run'] = True
@@ -5300,6 +5316,18 @@ class TestHEF:
         utils.compile_run_output([gdir_calving, hef_gdir],
                                  input_filesuffix='_def',
                                  tmp_file_size=1)
+        with xr.open_dataset(fp) as ds:
+            ds = ds.load()
+        # gdir_calving is copy of HEF flagged tidewater, but no calving
+        # actually occurs, so test finite, non-negative and non-decreasing.
+        assert 'calving' in ds
+        for i in range(2):
+            calving = ds.calving.isel(rgi_id=i).data
+            assert np.all(np.isfinite(calving))
+            assert np.all(calving >= 0)
+            assert np.all(np.diff(calving) >= 0)
+        assert np.all(np.isfinite(ds.volume.data))
+        assert np.all(ds.volume.data > 0)
 
     def test_start_from_spinup(self, hef_gdir):
 
@@ -5589,8 +5617,7 @@ class TestHEF:
             with xr.open_dataset(fp, group=f'fl_{fl_id}') as ds:
                 ds_iqr = ds.load()
 
-            # the median flowline should never be the smallest or largest
-            # value, compared to the values of the runs (as we have three runs)
+            # computed quantiles should match run quantiles
             variables_to_check = ['volume_m3', 'area_m2', 'thickness_m']
             for var in variables_to_check:
                 var_das = []
@@ -5602,21 +5629,22 @@ class TestHEF:
                 var_max = var_stack.max(dim='runs')
 
                 var_median = ds_median[var]
-                is_median_equal_to_min = (var_median == var_min).any()
-                is_median_equal_to_max = (var_median == var_max).any()
+                np.testing.assert_allclose(var_median, var_stack.median(dim="runs"))
+                assert (var_min <= var_median).all()
+                assert (var_median <= var_max).all()
 
-                assert is_median_equal_to_min
-                assert is_median_equal_to_max
+                var_5th = ds_iqr.loc[{"quantile": 0.05}][var]
+                var_95th = ds_iqr.loc[{"quantile": 0.95}][var]
+                np.testing.assert_allclose(
+                    var_5th, var_stack.quantile(0.05, dim="runs")
+                )
+                np.testing.assert_allclose(
+                    var_95th, var_stack.quantile(0.95, dim="runs")
+                )
 
                 # median should be larger/smaller than 5th/95th quantile
-                var_5th = ds_iqr.loc[{'quantile': 0.05}][var]
-                var_95th = ds_iqr.loc[{'quantile': 0.95}][var]
-
-                is_median_larger_than_5th_q = (var_median >= var_5th).all()
-                is_median_smaller_than_95th_q = (var_median <= var_95th).all()
-
-                assert is_median_larger_than_5th_q
-                assert is_median_smaller_than_95th_q
+                assert (var_median >= var_5th).all()
+                assert (var_median <= var_95th).all()
 
 
 @pytest.mark.usefixtures('with_class_wd')
@@ -5979,9 +6007,13 @@ class TestDynamicSpinup:
                     run_with_fixed_spinup.time.values[0])
             assert run_with_fixed_spinup.time.values[0] == 1979
 
-    @pytest.mark.parametrize('minimise_for', ['area', 'volume'])
+    @pytest.mark.parametrize("minimise_for", ["area", "volume"])
     @pytest.mark.slow
-    @pytest.mark.skip
+    @pytest.mark.skip(
+        reason="Disabled since the new MB calibration "
+        "(PR #1527). Needs a rewrite for the new "
+        "architecture before it can run again"
+    )
     @pytest.mark.skipif(not has_shapely2, reason="requires shapely2")
     def test_run_dynamic_spinup_special_cases(self, hef_gdir, minimise_for):
 
@@ -6258,10 +6290,14 @@ class TestDynamicSpinup:
             # smaller after calibration
             assert gdir.settings['melt_f'] < melt_f_before
 
-    @pytest.mark.parametrize('do_inversion', [True, False])
-    @pytest.mark.parametrize('minimise_for', ['area', 'volume'])
+    @pytest.mark.parametrize("do_inversion", [True, False])
+    @pytest.mark.parametrize("minimise_for", ["area", "volume"])
     @pytest.mark.slow
-    @pytest.mark.skip
+    @pytest.mark.skip(
+        reason="Disabled since the new MB calibration "
+        "(PR #1527). Needs a rewrite for the new "
+        "architecture before it can run again"
+    )
     @pytest.mark.skipif(not has_shapely2, reason="requires shapely2")
     def test_run_dynamic_melt_f_calibration_with_dynamic_spinup_special_cases(
             self, minimise_for, do_inversion):
@@ -7830,7 +7866,10 @@ def merged_hef_cfg(class_case_dir):
 class TestMergedHEF:
 
     @pytest.mark.slow
-    @pytest.mark.skip
+    @pytest.mark.skip(
+        reason="Merged simulations currently crash: "
+        "FlowlineModel rejects the merged flowlines"
+    )
     def test_merged_simulation(self):
         import geopandas as gpd
 

--- a/oggm/tests/test_numerics.py
+++ b/oggm/tests/test_numerics.py
@@ -1933,7 +1933,9 @@ class TestSia2d(unittest.TestCase):
         assert_allclose(sdmodel.volume_km3 / 3, flmodel.volume_km3, atol=2e-3)
         assert_allclose(sdmodel.area_km2 / 3, flmodel.area_km2, atol=2e-3)
 
+    @pytest.mark.skip(
+        reason="TODO: not implemented yet - add formal test "
+        "like https://github.com/alexjarosch/sia-fluxlim"
+    )
     def test_bueler(self):
-        # TODO: add formal test like Alex's
-        # https://github.com/alexjarosch/sia-fluxlim
         pass

--- a/oggm/tests/test_prepro.py
+++ b/oggm/tests/test_prepro.py
@@ -1133,6 +1133,21 @@ class TestGeometry(unittest.TestCase):
         centerlines.catchment_intersections(gdir)
         centerlines.catchment_width_geom(gdir)
 
+        # most widths should be positive, and roughly sum to glacier area
+        area = 0.0
+        cls = gdir.read_pickle("inversion_flowlines")
+        assert len(cls) > 0
+        for cl in cls:
+            assert len(cl.widths) == cl.nx
+            valid = np.isfinite(cl.widths)
+            assert np.sum(valid) > 0.5 * cl.nx
+            assert np.all(cl.widths[valid] > 0)
+            area += np.nansum(cl.widths * cl.dx)
+        with utils.ncDataset(gdir.get_filepath("gridded_data")) as nc:
+            otherarea = np.sum(nc.variables["glacier_mask"][:])
+        # geometrical widths underestimate area before correction step
+        assert 0.3 * otherarea < area < 1.5 * otherarea
+
     def test_width(self):
 
         hef_file = get_demo_file('Hintereisferner_RGI5.shp')
@@ -1924,347 +1939,6 @@ class TestClimate:
         # other (+/- 5% are tolerated)
         np.testing.assert_allclose(mb_calib_2d['melt_f'],
                                    mb_calib_1d['melt_f'], rtol=0.05)
-
-    @pytest.mark.slow
-    def test_mb_calibration_to_rmsd(self):
-
-        from oggm.core.massbalance import (mb_calibration_to_rmsd,
-                                           mb_calibration_from_scalar_mb)
-        from functools import partial
-
-        mb_calibration_to_rmsd = partial(mb_calibration_to_rmsd,
-                                         overwrite_gdir=True)
-
-        hef_file = get_demo_file('Hintereisferner_RGI5.shp')
-        entity = gpd.read_file(hef_file).iloc[0]
-
-        gdir = oggm.GlacierDirectory(entity, base_dir=self.testdir)
-        gis.define_glacier_region(gdir)
-        gis.simple_glacier_masks(gdir)
-        centerlines.elevation_band_flowline(gdir)
-        centerlines.fixed_dx_elevation_band_flowline(gdir)
-        climate.process_custom_climate_data(gdir)
-
-        mbdf = gdir.get_ref_mb_data()
-        mbdf['ref_mb'] = mbdf['ANNUAL_BALANCE']
-        ref_mb = mbdf.ANNUAL_BALANCE
-
-        # Firstly, calibrate just the melt_f
-        # Default is to calibrate melt_f
-        mb_calibration_to_rmsd(gdir, settings_filesuffix='_default_rmsd',
-                               ref_df=ref_mb)
-
-        h, w = gdir.get_inversion_flowline_hw()
-        mb_new = massbalance.MonthlyTIModel(gdir,
-                                            settings_filesuffix='_default_rmsd')
-        mbdf['melt_mb_rmsd'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
-
-        # Calibrate just prcp_fac
-        mb_calibration_to_rmsd(gdir,
-                               settings_filesuffix='_pf_rmsd',
-                               ref_df=ref_mb,
-                               calibrate_params=('prcp_fac',))
-
-        h, w = gdir.get_inversion_flowline_hw()
-        mb_new = massbalance.MonthlyTIModel(gdir,
-                                            settings_filesuffix='_pf_rmsd')
-        mbdf['prcp_fac_mb_rmsd'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
-
-        # Calibrate just temp_bias
-        mb_calibration_to_rmsd(gdir,
-                               settings_filesuffix='_tb_rmsd',
-                               ref_df=ref_mb,
-                               calibrate_params=('temp_bias',))
-
-        h, w = gdir.get_inversion_flowline_hw()
-        mb_new = massbalance.MonthlyTIModel(gdir,
-                                            settings_filesuffix='_tb_rmsd')
-        mbdf['temp_bias_mb_rmsd'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
-
-        # Calibrate melt_f and prcp_fac
-        mb_calibration_to_rmsd(gdir,
-                               settings_filesuffix='_melt_pr_rmsd',
-                               ref_df=ref_mb,
-                               calibrate_params=('melt_f', 'prcp_fac',))
-
-        h, w = gdir.get_inversion_flowline_hw()
-        mb_new = massbalance.MonthlyTIModel(gdir,
-                                            settings_filesuffix='_melt_pr_rmsd')
-        mbdf['mf_pf_mb_rmsd'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
-
-        # Calibrate melt_f and temp_bias
-        mb_calibration_to_rmsd(gdir,
-                               settings_filesuffix='_melt_tp_rmsd',
-                               ref_df=ref_mb,
-                               calibrate_params=('melt_f', 'temp_bias',))
-
-        h, w = gdir.get_inversion_flowline_hw()
-        mb_new = massbalance.MonthlyTIModel(gdir,
-                                            settings_filesuffix='_melt_tp_rmsd')
-        mbdf['mf_tb_mb_rmsd'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
-
-        # Calibrate prcp_fac and temp_bias
-        mb_calibration_to_rmsd(gdir,
-                               settings_filesuffix='_pr_tp_rmsd',
-                               ref_df=ref_mb,
-                               calibrate_params=('prcp_fac', 'temp_bias',))
-
-        h, w = gdir.get_inversion_flowline_hw()
-        mb_new = massbalance.MonthlyTIModel(gdir,
-                                            settings_filesuffix='_pr_tp_rmsd')
-        mbdf['pf_tb_mb_rmsd'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
-
-        # Calibrate all parameters together
-        mb_calibration_to_rmsd(gdir,
-                               settings_filesuffix='_all_rmsd',
-                               ref_df=ref_mb,
-                               calibrate_params=('melt_f', 'prcp_fac',
-                                                 'temp_bias',))
-
-        h, w = gdir.get_inversion_flowline_hw()
-        mb_new = massbalance.MonthlyTIModel(gdir,
-                                            settings_filesuffix='_all_rmsd')
-        mbdf['all_mb_rmsd'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
-
-        # Now check if the parameters are within the expected bounds, this can
-        # be done with our last run of calibration with rmsd
-        pdf = gdir.read_settings(['temp_bias', 'melt_f', 'prcp_fac'],
-                                 filesuffix='_all_rmsd')
-        assert cfg.PARAMS['melt_f_min'] <= pdf['melt_f'] <= cfg.PARAMS['melt_f_max']
-        assert cfg.PARAMS['prcp_fac_min'] <= pdf['prcp_fac'] <= cfg.PARAMS['prcp_fac_max']
-        assert cfg.PARAMS['temp_bias_min'] <= pdf['temp_bias'] <= cfg.PARAMS['temp_bias_max']
-
-        # Check that the mean mass balance results are all similar to the
-        # observed - TODO: What is classed as "similar" here?
-        # We are minimising the RMSD here, so the mean will not match exactly,
-        # but should be relatively close
-        np.testing.assert_allclose(ref_mb.mean(), mbdf['melt_mb_rmsd'].mean(), atol=100)
-        np.testing.assert_allclose(ref_mb.mean(), mbdf['prcp_fac_mb_rmsd'].mean(), atol=100)
-        np.testing.assert_allclose(ref_mb.mean(), mbdf['temp_bias_mb_rmsd'].mean(), atol=100)
-        np.testing.assert_allclose(ref_mb.mean(), mbdf['mf_pf_mb_rmsd'].mean(), atol=10)
-        np.testing.assert_allclose(ref_mb.mean(), mbdf['pf_tb_mb_rmsd'].mean(), atol=10)
-        np.testing.assert_allclose(ref_mb.mean(), mbdf['all_mb_rmsd'].mean(), atol=10)
-
-        # Check that there is a relatively strong correlation with simulated values
-        np.testing.assert_allclose(1, mbdf[['ref_mb', 'melt_mb_rmsd']].corr(),
-                                   atol=0.35)
-        np.testing.assert_allclose(1, mbdf[['ref_mb', 'prcp_fac_mb_rmsd']].corr(),
-                                   atol=0.35)
-        np.testing.assert_allclose(1, mbdf[['ref_mb', 'temp_bias_mb_rmsd']].corr(),
-                                   atol=0.35)
-        np.testing.assert_allclose(1, mbdf[['ref_mb', 'mf_pf_mb_rmsd']].corr(),
-                                   atol=0.35)
-        np.testing.assert_allclose(1, mbdf[['ref_mb', 'pf_tb_mb_rmsd']].corr(),
-                                   atol=0.35)
-        np.testing.assert_allclose(1, mbdf[['ref_mb', 'all_mb_rmsd']].corr(),
-                                   atol=0.35)
-
-        # Set up and run the scalar calibration to compare the RMSD from the two runs
-        mb_calibration_from_scalar_mb = partial(mb_calibration_from_scalar_mb,
-                                                overwrite_gdir=True)
-
-        # Start from scratch to avoid any overwritten values that could affect this run
-        hef_file = get_demo_file('Hintereisferner_RGI5.shp')
-        entity = gpd.read_file(hef_file).iloc[0]
-
-        gdir = oggm.GlacierDirectory(entity, base_dir=self.testdir)
-        gis.define_glacier_region(gdir)
-        gis.simple_glacier_masks(gdir)
-        centerlines.elevation_band_flowline(gdir)
-        centerlines.fixed_dx_elevation_band_flowline(gdir)
-        climate.process_custom_climate_data(gdir)
-
-        ref_mb = mbdf.ANNUAL_BALANCE
-        ref_mb_period = f'{mbdf.index[0]}-01-01_{mbdf.index[-1] + 1}-01-01'
-
-        # Now calibrate to just the melt_f
-        mb_calibration_from_scalar_mb(gdir,
-                                      settings_filesuffix='_melt_scalar',
-                                      ref_mb=ref_mb.mean(),
-                                      ref_mb_period=ref_mb_period)
-        h, w = gdir.get_inversion_flowline_hw()
-        mb_new = massbalance.MonthlyTIModel(gdir,
-                                            settings_filesuffix='_melt_scalar')
-        mbdf['melt_mb_scalar'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
-
-        # Default is to calibrate prcp_fac
-        mb_calibration_from_scalar_mb(gdir,
-                                      settings_filesuffix='_pr_scalar',
-                                      ref_mb=ref_mb.mean(),
-                                      ref_mb_period=ref_mb_period,
-                                      calibrate_param1='prcp_fac')
-
-        h, w = gdir.get_inversion_flowline_hw()
-        mb_new = massbalance.MonthlyTIModel(gdir,
-                                            settings_filesuffix='_pr_scalar')
-        mbdf['prcp_fac_mb_scalar'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
-
-        # Default is to calibrate temp_bias
-        mb_calibration_from_scalar_mb(gdir,
-                                      settings_filesuffix='_tp_scalar',
-                                      ref_mb=ref_mb.mean(),
-                                      ref_mb_period=ref_mb_period,
-                                      calibrate_param1='temp_bias')
-
-        h, w = gdir.get_inversion_flowline_hw()
-        mb_new = massbalance.MonthlyTIModel(gdir,
-                                            settings_filesuffix='_tp_scalar')
-        mbdf['temp_bias_mb_scalar'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
-
-        # Since we are now calibrating to rmsd rather than the mean, let's check
-        # that the RMSD has been reduced between the RMSD calibration technique
-        # vs the scalar calibration technique
-
-        # Unless the calibration for one parameter fails (which it wont in this
-        # case), for scalar it is equivalent to just test this to having one
-        # parameter calibrated, since it will only ever calibrate one parameter
-        # at a time
-
-        # Check that RMSD has been reduced for calibrating melt_f, compare to
-        # scalar for when melt_f is calibrated
-        # Just melt_f
-        np.testing.assert_array_less(utils.rmsd(mbdf['melt_mb_rmsd'], mbdf['ref_mb']),
-                                     utils.rmsd(mbdf['melt_mb_scalar'], mbdf['ref_mb']))
-
-        # melt_f and prcp_fac
-        np.testing.assert_array_less(utils.rmsd(mbdf['mf_pf_mb_rmsd'], mbdf['ref_mb']),
-                                     utils.rmsd(mbdf['melt_mb_scalar'], mbdf['ref_mb']))
-
-        # melt_f and temp_bias
-        np.testing.assert_array_less(utils.rmsd(mbdf['mf_tb_mb_rmsd'], mbdf['ref_mb']),
-                                     utils.rmsd(mbdf['melt_mb_scalar'], mbdf['ref_mb']))
-
-        # all parameters
-        np.testing.assert_array_less(utils.rmsd(mbdf['all_mb_rmsd'], mbdf['ref_mb']),
-                                     utils.rmsd(mbdf['melt_mb_scalar'], mbdf['ref_mb']))
-
-        # Check that RMSD has been reduced for calibrating prcp_fac
-        # Just prcp_fac
-        np.testing.assert_array_less(utils.rmsd(mbdf['prcp_fac_mb_rmsd'], mbdf['ref_mb']),
-                                     utils.rmsd(mbdf['prcp_fac_mb_scalar'], mbdf['ref_mb']))
-
-        # prcp_fac and temp_bias
-        np.testing.assert_array_less(utils.rmsd(mbdf['pf_tb_mb_rmsd'], mbdf['ref_mb']),
-                                     utils.rmsd(mbdf['prcp_fac_mb_scalar'], mbdf['ref_mb']))
-
-        # Check that RMSD has been reduced for calibrating temp_bias
-        # Just temp_bias
-        np.testing.assert_array_less(utils.rmsd(mbdf['temp_bias_mb_rmsd'], mbdf['ref_mb']),
-                                     utils.rmsd(mbdf['temp_bias_mb_scalar'], mbdf['ref_mb']))
-
-        # Now check that the order of parameters added into the  calibration
-        # does not affact the result
-
-        # Calibrate with parameters inserted in all possible permutations
-        # mf, pf, tb
-        mb_calibration_to_rmsd(gdir,
-                               settings_filesuffix='_mf_pf_tb',
-                               ref_df=ref_mb,
-                               calibrate_params=('melt_f', 'prcp_fac', 'temp_bias'),)
-
-        h, w = gdir.get_inversion_flowline_hw()
-        mb_new = massbalance.MonthlyTIModel(gdir,
-                                            settings_filesuffix='_mf_pf_tb')
-        mbdf['perm1'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
-
-        # mf, tb, pf
-        mb_calibration_to_rmsd(gdir,
-                               settings_filesuffix='_mf_tb_pf',
-                               ref_df=ref_mb,
-                               calibrate_params=('melt_f', 'temp_bias', 'prcp_fac',))
-
-        h, w = gdir.get_inversion_flowline_hw()
-        mb_new = massbalance.MonthlyTIModel(gdir,
-                                            settings_filesuffix='_mf_tb_pf')
-        mbdf['perm2'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
-
-        # pf, mf, tb
-        mb_calibration_to_rmsd(gdir,
-                               settings_filesuffix='_pf_mf_tb',
-                               ref_df=ref_mb,
-                               calibrate_params=('prcp_fac', 'melt_f', 'temp_bias',))
-
-        h, w = gdir.get_inversion_flowline_hw()
-        mb_new = massbalance.MonthlyTIModel(gdir,
-                                            settings_filesuffix='_pf_mf_tb')
-        mbdf['perm3'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
-
-        # pf, tb, mf
-        mb_calibration_to_rmsd(gdir,
-                               settings_filesuffix='_pf_tb_mf',
-                               ref_df=ref_mb,
-                               calibrate_params=('prcp_fac', 'temp_bias', 'melt_f',))
-
-        h, w = gdir.get_inversion_flowline_hw()
-        mb_new = massbalance.MonthlyTIModel(gdir,
-                                            settings_filesuffix='_pf_tb_mf')
-        mbdf['perm4'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
-
-        # tb, mf, pf
-        mb_calibration_to_rmsd(gdir,
-                               settings_filesuffix='_tb_mf_pf',
-                               ref_df=ref_mb,
-                               calibrate_params=('temp_bias', 'melt_f', 'prcp_fac',))
-
-        h, w = gdir.get_inversion_flowline_hw()
-        mb_new = massbalance.MonthlyTIModel(gdir,
-                                            settings_filesuffix='_tb_mf_pf')
-        mbdf['perm5'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
-
-        # tb, pf, mf
-        mb_calibration_to_rmsd(gdir,
-                               settings_filesuffix='_tb_pf_mf',
-                               ref_df=ref_mb,
-                               calibrate_params=('temp_bias', 'prcp_fac', 'melt_f',))
-
-        h, w = gdir.get_inversion_flowline_hw()
-        mb_new = massbalance.MonthlyTIModel(gdir,
-                                            settings_filesuffix='_tb_pf_mf')
-        mbdf['perm6'] = mb_new.get_specific_mb(h, w, year=mbdf.index)
-
-        # Check that all permutations of parameters gather the same results for
-        # differential evolution
-        # Differential evolution is stochastic and so may differ slighly (hence
-        # atol=0.1 here, to allow for 5%)
-        np.testing.assert_allclose(mbdf['perm1'].values, mbdf['perm2'].values, atol=0.1)
-        np.testing.assert_allclose(mbdf['perm2'].values, mbdf['perm3'].values, atol=0.1)
-        np.testing.assert_allclose(mbdf['perm3'].values, mbdf['perm4'].values, atol=0.1)
-        np.testing.assert_allclose(mbdf['perm4'].values, mbdf['perm5'].values, atol=0.1)
-        np.testing.assert_allclose(mbdf['perm5'].values, mbdf['perm6'].values, atol=0.1)
-
-        # Now check what happens when we input unrealistic values, lets make an
-        # invalid boundary condition
-        # This will force differential evolution to fail
-
-        with pytest.raises(RuntimeError):
-            mb_calibration_to_rmsd(gdir, ref_df=ref_mb,
-                                   calibrate_params=('melt_f',),
-                                   melt_f_min=np.nan)
-
-        # Some invalid bounds since max > min
-        with pytest.raises(RuntimeError):
-            mb_calibration_to_rmsd(gdir,
-                                   ref_df=ref_mb,
-                                   calibrate_params=('temp_bias',),
-                                   temp_bias_min=2.0,
-                                   temp_bias_max=-1.0)
-
-        # Impose infinite bounds, which will cause DE to fail
-        with pytest.raises(RuntimeError):
-            mb_calibration_to_rmsd(gdir,
-                                   ref_df=ref_mb,
-                                   calibrate_params=('temp_bias',),
-                                   temp_bias_min=-np.inf,
-                                   temp_bias_max=np.inf)
-
-        # Test for an acceptably small bias
-        np.testing.assert_allclose(0, (mbdf['melt_mb_rmsd'] - mbdf['ref_mb']).mean(), atol=100)
-        np.testing.assert_allclose(0, (mbdf['prcp_fac_mb_rmsd'] - mbdf['ref_mb']).mean(), atol=100)
-        np.testing.assert_allclose(0, (mbdf['temp_bias_mb_rmsd'] - mbdf['ref_mb']).mean(), atol=100)
-        np.testing.assert_allclose(0, (mbdf['mf_tb_mb_rmsd'] - mbdf['ref_mb']).mean(), atol=100)
-        np.testing.assert_allclose(0, (mbdf['mf_pf_mb_rmsd'] - mbdf['ref_mb']).mean(), atol=100)
-        np.testing.assert_allclose(0, (mbdf['pf_tb_mb_rmsd'] - mbdf['ref_mb']).mean(), atol=100)
-        np.testing.assert_allclose(0, (mbdf['all_mb_rmsd'] - mbdf['ref_mb']).mean(), atol=100)
 
     # Fixtures for the RMSD calibration tests
     def _build_calib_gdir(self):
@@ -3547,10 +3221,10 @@ class TestGCMClimate(unittest.TestCase):
             _sclim = sclim.groupby('time.month').std(dim='time')
             _sgcm = sgcm.groupby('time.month').std(dim='time')
             _sgcm_nc = sgcm_nc.groupby('time.month').std(dim='time')
-            # need higher tolerance here:
-            np.testing.assert_allclose(_sclim.temp, _sgcm.temp, rtol=0.08)  # 1e-3
-            # even higher for non-OGGM bias ccrrection
-            np.testing.assert_allclose(_sclim.temp, _sgcm_nc.temp, rtol=0.3)  # 1e-3
+            # need higher tolerance here (measured max rel diff ~0.04)
+            np.testing.assert_allclose(_sclim.temp, _sgcm.temp, rtol=0.08)
+            # even higher for non-OGGM bias correction (measured max rel diff ~0.24)
+            np.testing.assert_allclose(_sclim.temp, _sgcm_nc.temp, rtol=0.3)
             # not done for precipitation!
 
             # And also the annual cycle

--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -312,9 +312,12 @@ class TestFullRun(unittest.TestCase):
                                    corner_cutting=3,
                                    simplify_line_after=0.05)
         shp_ext_smooth = salem.read_shapefile(fpath)
-        # This is a bit different of course
+        # This is a bit different of course, but should still be in the
+        # range of measured max rel diff ~0.17.
+        assert (shp_ext['LE_SEGMENT'] > 0).all()
+        assert (shp_ext_smooth['LE_SEGMENT'] > 0).all()
         assert_allclose(shp_ext['LE_SEGMENT'], shp_ext_smooth['LE_SEGMENT'],
-                        rtol=2)
+                        rtol=0.25)
 
         fpath = os.path.join(_TEST_DIR, 'flowlines.shp')
         write_centerlines_to_shape(gdirs, path=fpath, flowlines_output=True)
@@ -573,7 +576,6 @@ def test_rgi7_glacier_dirs():
     hef_rgi7_df = gpd.read_file(get_demo_file('rgi7g_hef.shp'))
     # create GDIR
     gdir = workflow.init_glacier_directories(hef_rgi7_df)[0]
-    assert gdir
     assert gdir.rgi_region == '11'
     assert gdir.rgi_area_km2 > 8
     assert gdir.name == 'Hintereisferner'
@@ -601,7 +603,6 @@ def test_rgi7_complex_glacier_dirs():
     hef_rgi7_df = gpd.read_file(get_demo_file('rgi7c_hef.shp'))
     # create GDIR
     gdir = workflow.init_glacier_directories(hef_rgi7_df)[0]
-    assert gdir
     assert gdir.rgi_region == '11'
     assert gdir.rgi_area_km2 > 20
     assert gdir.name == ''


### PR DESCRIPTION
<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->

This also contains test fixes relevant to @pat-schmitt's DMB changes.

Fixes:
  - `test_mb_daily_model` wasn't actually testing `mb_annual_oggm_v16` because it was in the `do_plot` block and set to False.
  - `rtol` on smoothed segments in `test_shapefile_output` are now positive assertions and tightened. `rtol=2` was always going to pass.
  - Bare pytest skips now have reasons.
  - `test_geom_width` didn't have any assertions.
  - `test_compile_calving` also didn't have any assertions.
  - measured max rel diffs to `test_process_monthly_ismip_data`.
  - inverted assertions in `test_fl_diag_quantiles` are now direct comparisons of computed thresholds.   

Removes:
  - Duplicate `test_mb_calibration_to_rmsd`, kept newly refactored version.
  - Some redundant assert gdirs, since the following assertions will fail if it's an empty list

Refactors:
  - `test_sfc_type_mb_model` had a setup block wrapped in `pytest.raises`, so the test could pass if the setup raised an InvalidWorkflowError. Removed unnecessary trailing regex.
  
Discussion:

- `do_plot` in `test_models.py` is set to `False`. @pat-schmitt is this intentional? I could move these tests to `test_graphics.py` and compare them to baseline images.
- I added some assertions to `test_geom_width`. I do these per flowline, and just assume they should roughly sum to the glacier area. I also figured NaNs were OK, since these are removed in `catchment_width_correction`.
- What are we supposed to test in `test_compile_calving`? Since it's a copy of hef_gdir and doesn't seem to calve, I added tests to check it's finite, non-negative, and not decreasing.

- [x] Tests added/passed
- [x] Fully documented
- [x] Entry in `whats-new.rst` 
