### PR TITLE
fix: gdir.settings not correctly read

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -152,6 +152,10 @@ Bug fixes
 - Fixed a bug in ``compile_to_netcdf`` decorator, avoiding to raise an error if
   a single chunk failes (:pull:`1954`).
   By Copilot and `Patrick Schmitt <https://github.com/pat-schmitt>`_
+- Model constructors no longer silently persist a non-default ``temp_melt`` to
+  the gdir settings file. ``check_calib_params`` now validates the effective
+  model parameters instead of the settings file, and calibration tasks record ``mb_global_params`` from the model used.
+  By `Nicolas Gampierakis <https://github.com/gampnico>`_
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -154,7 +154,8 @@ Bug fixes
   By Copilot and `Patrick Schmitt <https://github.com/pat-schmitt>`_
 - Model constructors no longer silently persist a non-default ``temp_melt`` to
   the gdir settings file. ``check_calib_params`` now validates the effective
-  model parameters instead of the settings file, and calibration tasks record ``mb_global_params`` from the model used.
+  model parameters instead of the settings file, and calibration tasks record
+  ``mb_global_params`` from the model used (:pull:`1961`).
   By `Nicolas Gampierakis <https://github.com/gampnico>`_
 
 Breaking changes

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -157,6 +157,11 @@ Bug fixes
   model parameters instead of the settings file, and calibration tasks record
   ``mb_global_params`` from the model used (:pull:`1961`).
   By `Nicolas Gampierakis <https://github.com/gampnico>`_
+- ``SemiImplicitModel`` now reads its calving parameters from the model settings
+  instead of ``cfg.PARAMS``, so runs using a ``settings_filesuffix`` are no
+  longer silently calving with the default configuration. ``do_calving`` is now
+  also ignored for non-tidewater glaciers (:pull:`1961`).
+  By `Nicolas Gampierakis <https://github.com/gampnico>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -2726,14 +2726,14 @@ class SemiImplicitModel(FlowlineModel):
 
         # Calving params
         if do_calving is None:
-            do_calving = cfg.PARAMS['use_kcalving_for_run']
+            do_calving = self.settings['use_kcalving_for_run']
         self.calving_law = calving_law
-        self.do_calving = do_calving
+        self.do_calving = do_calving and self.is_tidewater
         if calving_k is None:
-            calving_k = cfg.PARAMS['calving_k']
+            calving_k = self.settings['calving_k']
         self.calving_k = calving_k / cfg.SEC_IN_YEAR
         if calving_use_limiter is None:
-            calving_use_limiter = cfg.PARAMS['calving_use_limiter']
+            calving_use_limiter = self.settings['calving_use_limiter']
         self.calving_use_limiter = calving_use_limiter
 
         # Flux gate bookkeeping

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -570,15 +570,23 @@ class MonthlyTIModel(MassBalanceModel):
         if prcp_fac is None:
             prcp_fac = self.calib_params['prcp_fac']
 
+        # Global parameters
+        self.temp_all_solid = gdir.settings['temp_all_solid']
+        self.temp_all_liq = gdir.settings['temp_all_liq']
+        if temp_melt is None:
+            temp_melt = gdir.settings['temp_melt']
+        self.temp_melt = temp_melt
+        self.temp_default_gradient = gdir.settings['temp_default_gradient']
+
         # Check the climate related params to the GlacierDir to make sure
         if check_calib_params:
             mb_calib = self.calib_params['mb_global_params']
             for k, v in mb_calib.items():
-                if v != self.gdir.settings[k]:
+                if v != getattr(self, k):
                     msg = ('You seem to use different mass balance parameters '
                            'than used for the calibration: '
-                           f"you use gdir.settings['{k}']={gdir.settings[k]} while "
-                           f"it was calibrated with gdir.settings['{k}']={v}. "
+                           f'you use {k}={getattr(self, k)} while '
+                           f'it was calibrated with {k}={v}. '
                            'Set `check_calib_params=False` to ignore this '
                            'warning.')
                     raise InvalidWorkflowError(msg)
@@ -596,19 +604,9 @@ class MonthlyTIModel(MassBalanceModel):
         self.melt_f = melt_f
         self.bias = bias
 
-        # Global parameters
-        self.temp_all_solid = gdir.settings['temp_all_solid']
-        self.temp_all_liq = gdir.settings['temp_all_liq']
-        if temp_melt is None:
-            self.temp_melt = gdir.settings['temp_melt']
-        else:
-            gdir.settings['temp_melt'] = temp_melt
-            self.temp_melt = temp_melt
-
         # check if valid prcp_fac is used
         if prcp_fac <= 0:
             raise InvalidParamsError('prcp_fac has to be above zero!')
-        self.temp_default_gradient = gdir.settings['temp_default_gradient']
 
         # Public attrs
         self.hemisphere = gdir.hemisphere
@@ -3907,6 +3905,17 @@ def decide_winter_precip_factor(gdir):
                        gdir.settings['prcp_fac_max'])
 
 
+def _mb_global_params_from_model(mb_mod):
+    """Effective MB_GLOBAL_PARAMS of a (possibly wrapped) TI model.
+
+    These can differ from the gdir settings, e.g. DailyTIModel defaults
+    to temp_melt=0.0 regardless of settings['temp_melt'].
+    """
+    mod = getattr(mb_mod, "flowline_mb_models", [mb_mod])[0]
+    mod = getattr(mod, "mbmod", mod)  # e.g. SfcTypeTIModel
+    return {k: getattr(mod, k) for k in MB_GLOBAL_PARAMS}
+
+
 @entity_task(log, writes=['mb_calib'])
 def mb_calibration_from_wgms_mb(gdir, settings_filesuffix='',
                                 observations_filesuffix='',
@@ -4200,7 +4209,7 @@ def mb_calibration_to_rmsd(gdir, *,
 
     # Add the climate related params to the GlacierDir to make sure
     # other tools cannot fool around without re-calibration
-    df['mb_global_params'] = {k: gdir.settings[k] for k in MB_GLOBAL_PARAMS}
+    df['mb_global_params'] = _mb_global_params_from_model(mb_mod)
     df['baseline_climate_source'] = gdir.get_climate_info(
         filename=mb_mod.filename, input_filesuffix=mb_mod.input_filesuffix
     )['baseline_climate_source']
@@ -4981,7 +4990,7 @@ def mb_calibration_from_scalar_mb(gdir, *,
 
     # Add the climate related params to the GlacierDir to make sure
     # other tools cannot fool around without re-calibration
-    df['mb_global_params'] = {k: gdir.settings[k] for k in MB_GLOBAL_PARAMS}
+    df['mb_global_params'] = _mb_global_params_from_model(mb_mod)
     df['baseline_climate_source'] = gdir.get_climate_info(
         filename=mb_mod.filename, input_filesuffix=mb_mod.input_filesuffix
     )['baseline_climate_source']

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -1368,6 +1368,38 @@ class TestMassBalanceModels:
         np.testing.assert_allclose(ds_daily.volume[-1], ds_monthly.volume[-1],
                                    atol=3e7)
 
+    def test_temp_melt_not_persisted_by_ctor(self, hef_gdir):
+        """Constructing model with explicit default temp_melt shouldn't
+        write to gdir settings file, and calib params check should catch
+        the mismatch.
+        """
+
+        tasks.process_gswp3_w5e5_data(hef_gdir, daily=True)
+        gdir = hef_gdir
+
+        stored_before = gdir.get_stored_settings()
+        assert "temp_melt" not in stored_before
+
+        # DailyTIModel defaults temp_melt=0.0 while gdir calibrated with
+        # monthly model (temp_melt=-1)
+        with pytest.raises(InvalidWorkflowError, match="temp_melt"):
+            massbalance.DailyTIModel(gdir)
+
+        # explicit kwarg mismatching the calibration also raises
+        with pytest.raises(InvalidWorkflowError, match="temp_melt"):
+            massbalance.MonthlyTIModel(gdir, temp_melt=5.0)
+
+        # opting out of the check works, uses value for instance
+        mb_mod = massbalance.DailyTIModel(gdir, check_calib_params=False)
+        assert mb_mod.temp_melt == 0.0
+
+        # and in no case is anything written to settings file
+        assert gdir.get_stored_settings() == stored_before
+
+        # monthly model still fine
+        mb_mod = massbalance.MonthlyTIModel(gdir)
+        assert mb_mod.temp_melt == gdir.settings["temp_melt"]
+
     @pytest.mark.slow
     def test_sfc_type_mb_model(self, hef_gdir):
 

--- a/oggm/tests/test_numerics.py
+++ b/oggm/tests/test_numerics.py
@@ -1,5 +1,6 @@
 import unittest
 from functools import partial
+from types import SimpleNamespace
 import pytest
 import copy
 import numpy as np
@@ -1596,6 +1597,37 @@ class TestFluxGate(unittest.TestCase):
             plt.show()
 
 
+def test_semi_implicit_calving_params_from_settings():
+    cfg.initialize()
+    settings = cfg.PARAMS.copy()
+    settings["use_kcalving_for_run"] = True
+    settings["calving_k"] = cfg.PARAMS["calving_k"] * 2
+    settings["calving_use_limiter"] = not cfg.PARAMS["calving_use_limiter"]
+    gdir = SimpleNamespace(settings=settings, settings_filesuffix="_calv")
+
+    fls = bu_tidewater_bed(bed_shape="trapezoidal", lambdas=0.0)
+    model = SemiImplicitModel(
+        fls,
+        mb_model=ScalarMassBalance(),
+        gdir=gdir,
+        settings_filesuffix="_calv",
+        is_tidewater=True,
+        water_level=0.0,
+    )
+    assert model.do_calving
+    assert_allclose(model.calving_k, settings["calving_k"] / cfg.SEC_IN_YEAR)
+    assert model.calving_use_limiter == settings["calving_use_limiter"]
+
+    # and calving stays off for land-terminating glaciers
+    model = SemiImplicitModel(
+        bu_tidewater_bed(bed_shape="trapezoidal", lambdas=0.0),
+        mb_model=ScalarMassBalance(),
+        do_calving=True,
+        water_level=0.0,
+    )
+    assert not model.do_calving
+
+
 @pytest.fixture(scope='function',
                 params=[
                 (
@@ -1609,7 +1641,7 @@ class TestFluxGate(unittest.TestCase):
                 (
                     SemiImplicitModel,
                     dict(bed_shape='trapezoidal', lambdas=0.0),
-                    dict(calving_use_limiter=True,
+                    dict(is_tidewater=True, calving_use_limiter=True,
                          flux_gate=0.06, do_calving=True,
                          calving_k=0.2, water_level=0.0
                     ),
@@ -1645,7 +1677,7 @@ class TestKCalving():
         if models_cls is FluxBasedModel:
             model_kwargs.update(is_tidewater=True, do_kcalving=True)
         else:
-            model_kwargs.update(do_calving=True, water_level=0.0)
+            model_kwargs.update(is_tidewater=True, do_calving=True, water_level=0.0)
 
         model = models_cls(bu_tidewater_bed(**bed_kwargs),
                                mb_model=ScalarMassBalance(),
@@ -1733,7 +1765,7 @@ class TestKCalving():
         if models_cls is FluxBasedModel:
             model_kwargs.update(is_tidewater=True, do_kcalving=True)
         else:
-            model_kwargs.update(do_calving=True)
+            model_kwargs.update(is_tidewater=True, do_calving=True)
 
         model = models_cls(
             bu_tidewater_bed(**bed_kwargs),


### PR DESCRIPTION
<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->

This patch provides two fixes:

1) The init constructor for MonthlyTIModel was writing `temp_melt` to `gdir.settings` in `mb_global_params`. When initialising `DailyTIModel`, the `check_calib_params` was running before this was written to `settings.yml`, which meant `temp_melt` was permanently set to zero, or ignored if `check_calib_params=False`.
I've removed the write and switched the order so the check occurs afterwards.

2) The `SemiImplicitModel` was silently ignoring the model settings and reading from cfg.PARAMS. It also allowed calving to occur for land-terminating glaciers. I've added a guardrail: `self.do_calving = do_calving and self.is_tidewater`

**Point for discussion**

- There was no check for `is_tidewater` before setting `do_calving` to True in the `SemiImplicitModel`, which meant in theory a land-terminating glacier could calve. The check does exist in `FluxBasedModel`. In both models, there is no check for `is_lake_terminating` which could also allow calving. Is this behaviour intentional? If so I will also need to modify `TestKCalving::test_water_level` before merging.

- [x] Tests added/passed
- [x] Fully documented
- [x] Entry in `whats-new.rst` 
