### PR TITLE
Add optional hydro output to run_prepro_levels

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -128,6 +128,16 @@ Enhancements
 - Added two new CI test environments, ``models_dynamics`` and ``models_mb``,
   to parallelise test execution (:pull:`1907`).
   By `Patrick Schmitt <https://github.com/pat-schmitt>`_
+- New ``store_hydro_output`` kwarg in ``run_prepro_levels`` (and
+  ``--store-hydro-output`` CLI flag) to also compute and store hydrological
+  model output during preprocessing, via ``run_with_hydro``. The accompanying
+  ``store_monthly_hydro`` kwarg (and ``--store-monthly-hydro`` CLI flag,
+  default ``True``) additionally stores this hydrological output at monthly
+  resolution. The new ``ref_area_yr`` kwarg (and ``--ref-area-yr`` CLI flag)
+  lets users force the hydrological reference area to the glacier state of a
+  given simulation year, instead of the default largest area during the
+  simulation period (:pull:`XXXX`).
+  By `Patrick Schmitt <https://github.com/pat-schmitt>`_
 
 Bug fixes
 ~~~~~~~~~

--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -124,7 +124,8 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
                       dynamic_spinup=False, ref_mb_err_scaling_factor=0.2,
                       dynamic_spinup_start_year=1979,
                       dynamic_spinup_periods_to_try=None,
-                      continue_on_error=True, store_fl_diagnostics=False):
+                      continue_on_error=True, store_fl_diagnostics=False,
+                      store_hydro_output=False):
     """Generate the preprocessed OGGM glacier directories for this OGGM version
 
     Parameters
@@ -274,6 +275,8 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
     store_fl_diagnostics : bool
         if True, also compute and store flowline diagnostics during preprocessing.
         This can increase data usage quite a bit.
+    store_hydro_output : bool
+        if True, also store the hydrological model output.
     """
 
     # Input check
@@ -919,12 +922,22 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
 
         # conduct historical run before dynamic melt_f calibration
         # (for comparison to old default behavior)
-        workflow.execute_entity_task(
-            tasks.run_from_climate_data, gdirs,
-            min_ys=y0, ye=ye, mb_model_class=mb_model_class,
-            save_mb_diagnostics_filesuffix='_historical' if store_mb_diagnostics else None,
-            output_filesuffix='_historical'
-        )
+        kwargs_run_from_climate_data = {
+            'min_ys': y0, 'ye': ye, 'mb_model_class': mb_model_class,
+            'save_mb_diagnostics_filesuffix': '_historical' if store_mb_diagnostics else None,
+            'output_filesuffix': '_historical',
+        }
+        if not store_hydro_output:
+            workflow.execute_entity_task(
+                tasks.run_from_climate_data, gdirs,
+                **kwargs_run_from_climate_data
+            )
+        else:
+            workflow.execute_entity_task(
+                tasks.run_with_hydro, gdirs,
+                run_task=tasks.run_from_climate_data,
+                **kwargs_run_from_climate_data
+            )
         # Now compile the output
         opath = Path(sum_dir) / f'historical_run_output_{rgi_reg}.nc'
         utils.compile_run_output(gdirs, path=opath, input_filesuffix='_historical')
@@ -937,24 +950,37 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
             minimise_for = dynamic_spinup.split('/')[0]
 
             melt_f_max = cfg.PARAMS['melt_f_max']
-            workflow.execute_entity_task(
-                tasks.run_dynamic_melt_f_calibration, gdirs,
-                ref_mb_err_scaling_factor=ref_mb_err_scaling_factor,
-                ys=dynamic_spinup_start_year, ye=ye,
-                melt_f_max=melt_f_max,
-                mb_model_class=mb_model_class,
-                kwargs_run_function={'minimise_for': minimise_for,
-                                     'spinup_periods_to_try':
-                                         dynamic_spinup_periods_to_try
-                                     },
-                ignore_errors=True,
-                kwargs_fallback_function={'minimise_for': minimise_for,
-                                          'spinup_periods_to_try':
-                                              dynamic_spinup_periods_to_try
-                                          },
-                save_mb_diagnostics_filesuffix=('_spinup_historical'
-                                                if store_mb_diagnostics else None),
-                output_filesuffix='_spinup_historical',)
+            kwargs_run_dynamic_melt_f_calibration = {
+                'ref_mb_err_scaling_factor': ref_mb_err_scaling_factor,
+                'ys': dynamic_spinup_start_year, 'ye': ye,
+                'melt_f_max': melt_f_max,
+                'mb_model_class': mb_model_class,
+                'kwargs_run_function': {'minimise_for': minimise_for,
+                                        'spinup_periods_to_try':
+                                            dynamic_spinup_periods_to_try
+                                        },
+                'ignore_errors': True,
+                'kwargs_fallback_function': {'minimise_for': minimise_for,
+                                             'spinup_periods_to_try':
+                                                 dynamic_spinup_periods_to_try
+                                             },
+                'save_mb_diagnostics_filesuffix': ('_spinup_historical'
+                                                   if store_mb_diagnostics else None),
+                'output_filesuffix': '_spinup_historical',
+            }
+
+            if not store_hydro_output:
+                workflow.execute_entity_task(
+                    tasks.run_dynamic_melt_f_calibration, gdirs,
+                    **kwargs_run_dynamic_melt_f_calibration
+                    )
+            else:
+                workflow.execute_entity_task(
+                    tasks.run_with_hydro, gdirs,
+                    run_task=tasks.run_dynamic_melt_f_calibration,
+                    **kwargs_run_dynamic_melt_f_calibration
+                )
+
             # Now compile the output
             opath = sum_dir / f'spinup_historical_run_output_{rgi_reg}.nc'
             utils.compile_run_output(gdirs, path=opath,
@@ -1217,6 +1243,8 @@ def parse_args(args):
                         help="Also compute and store flowline diagnostics during "
                              "preprocessing. This can increase data usage quite "
                              "a bit.")
+    parser.add_argument('--store-hydro-output', nargs='?', const=True, default=False,
+                        help='Add optional hydrological model output')
     parser.add_argument('--override-params', type=json.loads, default=None)
 
     args = parser.parse_args(args)
@@ -1295,6 +1323,7 @@ def parse_args(args):
                 geodetic_mb_file_path=args.geodetic_mb_file_path,
                 temp_bias_file_path=args.temp_bias_file_path,
                 store_fl_diagnostics=args.store_fl_diagnostics,
+                store_hydro_output=args.store_hydro_output,
                 override_params=args.override_params,
                 )
 

--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -125,7 +125,8 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
                       dynamic_spinup_start_year=1979,
                       dynamic_spinup_periods_to_try=None,
                       continue_on_error=True, store_fl_diagnostics=False,
-                      store_hydro_output=False):
+                      store_hydro_output=False, store_monthly_hydro=True,
+                      ref_area_yr=None):
     """Generate the preprocessed OGGM glacier directories for this OGGM version
 
     Parameters
@@ -277,6 +278,14 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
         This can increase data usage quite a bit.
     store_hydro_output : bool
         if True, also store the hydrological model output.
+    store_monthly_hydro : bool
+        if True and store_hydro_output is True the hydrological mode output will
+        also be stored in a monthly resolution (see flowline.run_with_hydro)
+    ref_area_yr : int
+        the hydrological output is computed over a reference area, which
+        per default is the largest area covered by the glacier in the simulation
+        period. Use this kwarg to force a specific area to the state of the
+        glacier at the provided simulation year.
     """
 
     # Input check
@@ -920,12 +929,17 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
             except BaseException:
                 i += 1
 
+        # here we define the actual start date of the model outputs
+        if y0 > dynamic_spinup_start_year:
+            dynamic_spinup_start_year = y0
+
         # conduct historical run before dynamic melt_f calibration
         # (for comparison to old default behavior)
         kwargs_run_from_climate_data = {
             'min_ys': y0, 'ye': ye, 'mb_model_class': mb_model_class,
             'save_mb_diagnostics_filesuffix': '_historical' if store_mb_diagnostics else None,
             'output_filesuffix': '_historical',
+            'fixed_geometry_spinup_yr': dynamic_spinup_start_year,
         }
         if not store_hydro_output:
             workflow.execute_entity_task(
@@ -936,6 +950,8 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
             workflow.execute_entity_task(
                 tasks.run_with_hydro, gdirs,
                 run_task=tasks.run_from_climate_data,
+                store_monthly_hydro=store_monthly_hydro,
+                ref_area_yr=ref_area_yr,
                 **kwargs_run_from_climate_data
             )
         # Now compile the output
@@ -944,8 +960,6 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
 
         # conduct dynamic spinup if wanted
         if dynamic_spinup:
-            if y0 > dynamic_spinup_start_year:
-                dynamic_spinup_start_year = y0
 
             minimise_for = dynamic_spinup.split('/')[0]
 
@@ -978,6 +992,8 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
                 workflow.execute_entity_task(
                     tasks.run_with_hydro, gdirs,
                     run_task=tasks.run_dynamic_melt_f_calibration,
+                    store_monthly_hydro=store_monthly_hydro,
+                    ref_area_yr=ref_area_yr,
                     **kwargs_run_dynamic_melt_f_calibration
                 )
 
@@ -1245,6 +1261,14 @@ def parse_args(args):
                              "a bit.")
     parser.add_argument('--store-hydro-output', nargs='?', const=True, default=False,
                         help='Add optional hydrological model output')
+    parser.add_argument('--store-monthly-hydro', nargs='?', const=True, default=True,
+                        help='If store-hydro-output is True, also store the '
+                             'hydrological model output in monthly resolution.')
+    parser.add_argument('--ref-area-yr', type=int, default=None,
+                        help='Force the reference area used for the hydrological '
+                             'output to the glacier state of the given simulation '
+                             'year, instead of the largest area during the '
+                             'simulation period.')
     parser.add_argument('--override-params', type=json.loads, default=None)
 
     args = parser.parse_args(args)
@@ -1324,6 +1348,8 @@ def parse_args(args):
                 temp_bias_file_path=args.temp_bias_file_path,
                 store_fl_diagnostics=args.store_fl_diagnostics,
                 store_hydro_output=args.store_hydro_output,
+                store_monthly_hydro=args.store_monthly_hydro,
+                ref_area_yr=args.ref_area_yr,
                 override_params=args.override_params,
                 )
 

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -1722,6 +1722,38 @@ class TestPreproCLI:
         assert gtiff_ds.isel(band=0).sum() > 0
 
     @pytest.mark.slow
+    def test_store_hydro_output(self):
+
+        from oggm.cli.prepro_levels import run_prepro_levels
+
+        inter, rgidf = _read_shp()
+
+        wdir = os.path.join(self.testdir, 'wd')
+        utils.mkdir(wdir)
+        odir = os.path.join(self.testdir, 'my_levs')
+        topof = utils.get_demo_file('srtm_oetztal.tif')
+        np.random.seed(0)
+
+        run_prepro_levels(rgi_version='61', rgi_reg='11', border=20,
+                          output_folder=odir, working_dir=wdir, is_test=True,
+                          rgi_file=rgidf, disable_mp=True,
+                          intersects_file=inter,
+                          test_topofile=topof,
+                          elev_bands=True,
+                          max_level=4,
+                          inversion_volume_dataset='consensus',
+                          store_hydro_output=True,
+                          continue_on_error=False,
+                          override_params={}
+                          )
+
+        opath = os.path.join(odir, 'RGI61', 'b_020', 'L4', 'summary',
+                             'historical_run_output_11.nc')
+        with xr.open_dataset(opath) as ds:
+            assert 'melt_on_glacier' in ds
+            assert 'liq_prcp_off_glacier' in ds
+
+    @pytest.mark.slow
     def test_full_run_cru_centerlines(self):
 
         from oggm.cli.prepro_levels import run_prepro_levels

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -1627,7 +1627,7 @@ class TestPreproCLI:
         gdir = oggm.GlacierDirectory(entity, from_tar=tarf)
         model = FileModel(gdir.get_filepath('model_geometry',
                                             filesuffix='_historical'))
-        assert model.y0 == 2004
+        assert model.y0 == 1979
         assert model.last_yr == 2020
         with pytest.raises(FileNotFoundError):
             # We can't create this because the glacier dir is mini
@@ -1900,7 +1900,7 @@ class TestPreproCLI:
         gdir = oggm.GlacierDirectory(entity, from_tar=tarf)
         model = FileModel(gdir.get_filepath('model_geometry',
                                             filesuffix='_historical'))
-        assert model.y0 == 2004
+        assert model.y0 == 1979
         assert model.last_yr == 2015
         with pytest.raises(FileNotFoundError):
             # We can't create this because the glacier dir is mini
@@ -2018,7 +2018,7 @@ class TestPreproCLI:
             assert isinstance(model, FlowlineModel)
             model = FileModel(gdir.get_filepath('model_geometry',
                                                 filesuffix='_historical'))
-            assert model.y0 == 2004
+            assert model.y0 == 1979
             assert model.last_yr == 2015
             model = FileModel(gdir.get_filepath('model_geometry',
                                                 filesuffix='_spinup_historical'))
@@ -2170,7 +2170,7 @@ class TestPreproCLI:
         gdir = oggm.GlacierDirectory(entity, from_tar=tarf)
         model = FileModel(gdir.get_filepath('model_geometry',
                                             filesuffix='_historical'))
-        assert model.y0 == 2004
+        assert model.y0 == 1979
         assert model.last_yr == 2015
         with pytest.raises(FileNotFoundError):
             # We can't create this because the glacier dir is mini

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -1318,12 +1318,16 @@ class TestPreproCLI:
         assert kwargs['dynamic_spinup_start_year'] == 1979
         assert kwargs['mb_calibration_strategy'] == 'informed_threestep'
         assert not kwargs['add_consensus_thickness']
+        assert not kwargs['store_hydro_output']
+        assert kwargs['store_monthly_hydro']
+        assert kwargs['ref_area_yr'] is None
 
         kwargs = prepro_levels.parse_args(['--rgi-reg', '1',
                                            '--map-border', '160',
                                            '--start-level', '2',
                                            '--mb-calibration-strategy', 'temp_melt',
                                            '--start-base-url', 'http://foo',
+                                           '--ref-area-yr', '2000',
                                            ])
 
         assert 'working_dir' in kwargs
@@ -1335,6 +1339,7 @@ class TestPreproCLI:
         assert kwargs['start_level'] == 2
         assert kwargs['start_base_url'] == 'http://foo'
         assert kwargs['mb_calibration_strategy'] == 'temp_melt'
+        assert kwargs['ref_area_yr'] == 2000
 
         with pytest.raises(InvalidParamsError):
             prepro_levels.parse_args([])
@@ -1743,6 +1748,8 @@ class TestPreproCLI:
                           max_level=4,
                           inversion_volume_dataset='consensus',
                           store_hydro_output=True,
+                          store_monthly_hydro=True,
+                          ref_area_yr=2000,
                           continue_on_error=False,
                           override_params={}
                           )
@@ -1752,6 +1759,9 @@ class TestPreproCLI:
         with xr.open_dataset(opath) as ds:
             assert 'melt_on_glacier' in ds
             assert 'liq_prcp_off_glacier' in ds
+            assert 'melt_on_glacier_monthly' in ds
+            assert 'month_2d' in ds.coords
+            assert np.all(np.isfinite(ds['on_area'].sel(time=2000)))
 
     @pytest.mark.slow
     def test_full_run_cru_centerlines(self):


### PR DESCRIPTION
Here I add the option to include hydrological outputs to the dynamic runs in prepro level 4. Accompanying kwargs are `store_monthly_hydro` (default `True`) and `ref_area_yr` (default `None` -> use largest area in the simulation period).

Further I added `fixed_geometry_spinup_yr` for the `_historical` run (Closes https://github.com/OGGM/oggm/issues/1762)

- [x] Tests added/passed
- [ ] Fully documented
- [x] Entry in `whats-new.rst` 
