### PR TITLE
Fix multiprocessing OOM with new settings

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -182,7 +182,7 @@ Bug fixes
   (e.g. ``oggm_prepro`` on tens of thousands of glaciers): ``GlacierDirectory``
   no longer re-serializes its ``settings``/``observations`` on every task
   dispatched to a worker process. They are now dropped before pickling and
-  rebuilt from disk in the worker instead (:pull:`XXXX`).
+  rebuilt from disk in the worker instead (:pull:`1967`).
   By `Patrick Schmitt <https://github.com/pat-schmitt>`_
 
 Breaking changes

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -178,6 +178,12 @@ Bug fixes
 - Fixed a bug in ``compile_to_netcdf`` decorator, avoiding to raise an error if
   a single chunk failes (:pull:`1954`).
   By Copilot and `Patrick Schmitt <https://github.com/pat-schmitt>`_
+- Fixed a multiprocessing memory blowup in large ``execute_entity_task`` runs
+  (e.g. ``oggm_prepro`` on tens of thousands of glaciers): ``GlacierDirectory``
+  no longer re-serializes its ``settings``/``observations`` on every task
+  dispatched to a worker process. They are now dropped before pickling and
+  rebuilt from disk in the worker instead (:pull:`XXXX`).
+  By `Patrick Schmitt <https://github.com/pat-schmitt>`_
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -56,6 +56,11 @@ def clean_dir(testdir):
     os.makedirs(testdir)
 
 
+def _read_prcp_fac(gdir):
+    # module-level so it can be pickled and sent to multiprocessing workers
+    return gdir.settings['prcp_fac']
+
+
 class TestFuncs(object):
 
     def setUp(self):
@@ -878,6 +883,45 @@ class TestWorkflowTools(unittest.TestCase):
         assert file_path in cfg.DATA
         import multiprocessing
         assert type(cfg.DATA) is multiprocessing.managers.DictProxy
+
+    def test_gdir_pickle_excludes_settings_and_observations(self):
+        # settings/observations must not travel through pickle as-is:
+        # GlacierDirectory.__getstate__ drops them and __setstate__
+        # rebuilds them fresh from disk, so that a private copy of
+        # cfg.PARAMS isn't re-shipped on every multiprocessing task
+        import pickle
+
+        gdir = init_hef()
+
+        state = gdir.__getstate__()
+        assert 'settings' not in state
+        assert 'observations' not in state
+
+        gdir_unpickled = pickle.loads(pickle.dumps(gdir))
+        assert gdir_unpickled.settings is not gdir.settings
+        assert gdir_unpickled.observations is not gdir.observations
+        assert (gdir_unpickled.settings['use_rgi_area'] ==
+               gdir.settings['use_rgi_area'])
+
+        # changes written to the settings file on disk must be visible
+        # after unpickling, proving it is reloaded and not a stale copy
+        gdir.settings['prcp_fac'] = 12345
+        gdir_unpickled = pickle.loads(pickle.dumps(gdir))
+        assert gdir_unpickled.settings['prcp_fac'] == 12345
+
+    def test_gdir_settings_survive_multiprocessing(self):
+        # end-to-end check that gdirs sent through a real worker pool
+        # can still read settings correctly after being rebuilt via
+        # GlacierDirectory.__setstate__
+        gdir = init_hef()
+        gdir.settings['prcp_fac'] = 42
+
+        cfg.PARAMS['use_multiprocessing'] = True
+        cfg.PARAMS['mp_processes'] = 2
+        cfg.PARAMS['use_mp_spawn'] = False
+
+        out = workflow.execute_entity_task(_read_prcp_fac, [gdir, gdir])
+        assert out == [42, 42]
 
 
 class TestWorkflowUtils:

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -914,6 +914,7 @@ class TestWorkflowTools(unittest.TestCase):
         # can still read settings correctly after being rebuilt via
         # GlacierDirectory.__setstate__
         gdir = init_hef()
+        orig_prcp_fac = gdir.settings['prcp_fac']
         gdir.settings['prcp_fac'] = 42
 
         cfg.PARAMS['use_multiprocessing'] = True
@@ -922,6 +923,9 @@ class TestWorkflowTools(unittest.TestCase):
 
         out = workflow.execute_entity_task(_read_prcp_fac, [gdir, gdir])
         assert out == [42, 42]
+
+        # set prcp_fac back for other tests
+        gdir.settings['prcp_fac'] = orig_prcp_fac
 
 
 class TestWorkflowUtils:

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -905,9 +905,11 @@ class TestWorkflowTools(unittest.TestCase):
 
         # changes written to the settings file on disk must be visible
         # after unpickling, proving it is reloaded and not a stale copy
+        orig_prcp_fac = gdir.settings['prcp_fac']
         gdir.settings['prcp_fac'] = 12345
         gdir_unpickled = pickle.loads(pickle.dumps(gdir))
         assert gdir_unpickled.settings['prcp_fac'] == 12345
+        gdir.settings['prcp_fac'] = orig_prcp_fac
 
     def test_gdir_settings_survive_multiprocessing(self):
         # end-to-end check that gdirs sent through a real worker pool

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -3188,6 +3188,22 @@ class GlacierDirectory(object):
         self._mbprofdf = None
         self._mbprofdf_cte_dh = None
 
+    def __getstate__(self):
+        # settings/observations are dropped from the pickled state (and
+        # rebuilt in __setstate__) so that they don't have to be re-shipped
+        # (with a private copy of cfg.PARAMS) on every multiprocessing task
+        state = self.__dict__.copy()
+        del state['settings']
+        del state['observations']
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self.settings = self._get_settings_class(
+            filesuffix=self._settings_filesuffix)
+        self.observations = self._get_observations_class(
+            filesuffix=self._observations_filesuffix)
+
     def __repr__(self):
 
         summary = ['<oggm.GlacierDirectory>']


### PR DESCRIPTION
Large `oggm_prepro` runs started hitting OOM errors on the cluster that didn't happen before. This could be traced back to the pickling logic of `GlacierDirectory` during multiprocessing. As a result  `settings`/`observations` gets serialized every time a gdir is sent to a worker process via `workflow.execute_entity_task()`'.

The fix is to add `__getstate__`/`__setstate__` to `GlacierDirectory`:                                                                                                                                                                                                                                                                                                                                                                                           
  - `__getstate__` drops `settings`/`observations` from the pickled state.                                                                                                                                                                                                                 
  - `__setstate__` rebuilds them via the existing `_get_settings_class()`/`_get_observations_class()` helpers, which read fresh from disk in the worker process.           

With this changes I was able to run the prepro levels for region 14 (around 37,000 glaciers) on the cluster again.

- [x] Tests added/passed
- [ ] Fully documented
- [x] Entry in `whats-new.rst` 
