### PR TITLE
fix calibrate_inversion_from_consensus

### DIFF
--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -276,10 +276,38 @@ class TestFullRun(unittest.TestCase):
         assert (gdir_0_ref_vol['value'] !=
                 gdir_0_ref_vol_user_provided['value'])
 
-        # the deprecated alias still works and warns
+        # the deprecated alias still works, warns, and always calibrates
+        # against the correct (consensus) ref table - regardless of what
+        # was stored in the observations file before (the user provided
+        # volume from the previous calibration call above)
         with pytest.warns(FutureWarning, match='deprecated'):
-            workflow.calibrate_inversion_from_consensus(gdirs,
-                                                        ignore_missing=True)
+            df_consensus = workflow.calibrate_inversion_from_consensus(
+                gdirs, ignore_missing=True)
+        df_consensus = df_consensus.dropna()
+
+        # same ref table as a direct call with ref_table='consensus'
+        np.testing.assert_allclose(df_orig.dropna().vol_itmix_m3.sum(),
+                                   df_consensus.vol_itmix_m3.sum(),
+                                   rtol=1e-9)
+        np.testing.assert_allclose(df_consensus.vol_itmix_m3.sum(),
+                                   df_consensus.vol_oggm_m3.sum(),
+                                   rtol=0.001)
+
+        # the observations file is overwritten with the newly computed
+        # volume (matching the consensus estimate), not the previously
+        # stored user provided one
+        gdir_0_ref_vol_consensus = gdirs[0].observations['ref_volume_m3']
+        assert (gdir_0_ref_vol_consensus['value'] !=
+                gdir_0_ref_vol_user_provided['value'])
+        np.testing.assert_allclose(
+            gdir_0_ref_vol_consensus['value'],
+            df_consensus.loc[gdirs[0].rgi_id, 'vol_oggm_m3'],
+            rtol=1e-6)
+        np.testing.assert_allclose(
+            gdir_0_ref_vol_consensus['value'],
+            gdir_0_ref_vol['value'],
+            rtol=1e-2)
+        assert gdir_0_ref_vol_consensus['year'] == gdir_0_ref_vol['year']
 
     @pytest.mark.slow
     def test_shapefile_output(self):

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -1011,7 +1011,7 @@ def calibrate_inversion_from_ref_table(gdirs, settings_filesuffix='',
 @global_task(log)
 def calibrate_inversion_from_consensus(gdirs, settings_filesuffix='',
                                        observations_filesuffix='',
-                                       overwrite_observations=False,
+                                       overwrite_observations=True,
                                        input_filesuffix=None,
                                        output_filesuffix=None,
                                        ignore_missing=True,

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -855,7 +855,7 @@ def calibrate_inversion_from_ref_table(gdirs, settings_filesuffix='',
         if ref_volume_m3 is not None and ref_table is None:
             df = pd.DataFrame(index=rids_use)
             ref_col = None
-        else:
+        elif ref_volume_m3 is None and ref_table is not None:
             # Get the ref data for the glaciers we have
             df, ref_col = _resolve_ref_volume_table(gdirs, ref_table)
 
@@ -867,6 +867,9 @@ def calibrate_inversion_from_ref_table(gdirs, settings_filesuffix='',
                                            'ignore this error.')
 
             df = df.reindex(rids)
+        else:
+            raise ValueError("You either need to provide a ref_volume_m3 or a "
+                             "ref_table!")
     else:
         ref_volume_m3_file = sum([gdir.observations['ref_volume_m3']['value']
                                   for gdir in gdirs_use])


### PR DESCRIPTION
Now `calibrate_inversion_from_consensus` always overwrites potential existing observations, to be sure to always use the consensus estimates when calling this function. If you want to use other datasets you should use `calibrate_inversion_from_ref_table`. 

Closes https://github.com/OGGM/oggm/issues/1962

- [x] Tests added/passed
- [ ] Fully documented
- [ ] Entry in `whats-new.rst` 
