### PR TITLE
Automate the temperature bias file creation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -64,6 +64,7 @@ Input/Output
     utils.gdir_to_tar
     utils.base_dir_to_tar
     utils.cook_rgidf
+    utils.compute_temp_bias_dataframe
     global_tasks.write_centerlines_to_shape
     global_tasks.compile_glacier_statistics
     global_tasks.compile_run_output
@@ -227,6 +228,7 @@ These commands are available:
 
 - ``oggm_netrc_credentials``
 - ``oggm_prepro``
+- ``oggm_temp_bias``
 - ``oggm_benchmark``
 
 .. autosummary::
@@ -234,6 +236,7 @@ These commands are available:
     :nosignatures:
 
     cli.prepro_levels.run_prepro_levels
+    cli.temp_bias.run_temp_bias
 
 Classes
 =======

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -61,7 +61,8 @@ Enhancements
   statistics themselves, so this works with any (custom) climate dataset.
   ``oggm_prepro`` also gets a ``--temp-bias-run`` preset for the preprocessing
   step itself: it forces the `temp_melt` strategy, stops at level 3, skips the
-  ice thickness inversion and does not write the glacier directory tar files.
+  ice thickness inversion and writes nothing but the level 3 glacier statistics
+  file, which is the input of ``oggm_temp_bias``.
   New utility function ``utils.weighted_quantile_1d``.
   By `Fabien Maussion <https://github.com/fmaussion>`_
 - Test durations are now visible in Actions logs (:pull:`1920`).

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -60,9 +60,10 @@ Enhancements
   ``--temp-bias-file-path``. The climate grid is inferred from the glacier
   statistics themselves, so this works with any (custom) climate dataset.
   ``oggm_prepro`` also gets a ``--temp-bias-run`` preset for the preprocessing
-  step itself: it forces the `temp_melt` strategy, stops at level 3, skips the
-  ice thickness inversion and writes nothing but the level 3 glacier statistics
-  file, which is the input of ``oggm_temp_bias``.
+  step itself: it stops at level 3, skips the ice thickness inversion and
+  writes nothing but the level 3 glacier statistics file, which is the input of
+  ``oggm_temp_bias`` (it requires ``--mb-calibration-strategy temp_melt`` or
+  ``temp_melt_regional`` to be set explicitly).
   New utility function ``utils.weighted_quantile_1d``.
   By `Fabien Maussion <https://github.com/fmaussion>`_
 - Test durations are now visible in Actions logs (:pull:`1920`).

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -51,6 +51,19 @@ Enhancements
   arbitrary custom climate dataset instead of the hardcoded w5e5/era5 files
   (:pull:`1941`).
   By `Fabien Maussion <https://github.com/fmaussion>`_
+- The temperature bias prior file used by the `informed_threestep` calibration
+  can now be created from the command line, instead of with a notebook. The new
+  ``oggm_temp_bias`` command (and the underlying
+  ``utils.compute_temp_bias_dataframe``) summarizes the per-glacier biases of a
+  `temp_melt` preprocessing run per climate grid point and writes the csv file
+  (plus diagnostic plots) which can then be fed back to `oggm_prepro` with
+  ``--temp-bias-file-path``. The climate grid is inferred from the glacier
+  statistics themselves, so this works with any (custom) climate dataset.
+  ``oggm_prepro`` also gets a ``--temp-bias-run`` preset for the preprocessing
+  step itself: it forces the `temp_melt` strategy, stops at level 3, skips the
+  ice thickness inversion and does not write the glacier directory tar files.
+  New utility function ``utils.weighted_quantile_1d``.
+  By `Fabien Maussion <https://github.com/fmaussion>`_
 - Test durations are now visible in Actions logs (:pull:`1920`).
   By `Nicolas Gampierakis <https://github.com/gampnico>`_
 - New kwarg `spinup_periods_to_try` in `run_dynamic_spinup` to be able to

--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -126,8 +126,7 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
                       dynamic_spinup_periods_to_try=None,
                       continue_on_error=True, store_fl_diagnostics=False,
                       store_hydro_output=False, store_monthly_hydro=True,
-                      ref_area_yr=None, temp_bias_run=False,
-                      temp_bias_run_kwargs=None):
+                      ref_area_yr=None, temp_bias_run=False):
     """Generate the preprocessed OGGM glacier directories for this OGGM version
 
     Parameters
@@ -291,17 +290,13 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
         set to True to run the preprocessing needed to create the temperature
         bias prior file used by the `informed_threestep` calibration. This is
         a preset which forces `max_level=3`, `skip_inversion=True` and the
-        `temp_melt` calibration strategy, skips writing the glacier directory
-        tar files (they are of no use here) and, at the end of L3, computes the
-        temperature bias file for this region with
-        `utils.compute_temp_bias_dataframe`.
-        Note that the grouping of climate grid points crosses RGI region
-        borders: for multi-region setups, the resulting file is only a
-        diagnostic, and the `oggm_temp_bias` command should be run over the
-        glacier statistics of all the regions instead.
-    temp_bias_run_kwargs : dict
-        if `temp_bias_run` is set, optional kwargs passed to
-        `utils.compute_temp_bias_dataframe` (e.g. `min_glaciers`).
+        `temp_melt` calibration strategy, and skips everything which is of no
+        use for this purpose: the glacier directory tar files, the climate
+        statistics and the fixed geometry mass balance. The only output is the
+        L3 `glacier_statistics` file, which is then turned into the
+        temperature bias file with the `oggm_temp_bias` command (the grouping
+        of climate grid points crosses RGI region borders, so this has to be
+        done over all the regions at once).
     """
 
     # The temp bias preset overrides a couple of options - be loud about it
@@ -894,16 +889,13 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
         utils.compile_glacier_statistics(gdirs, path=opath)
 
         if temp_bias_run:
-            # This is all we need - summarize the biases per climate grid point
-            log.warning('The grouping of climate grid points crosses RGI '
-                        'region borders: for multi-region setups, run the '
-                        '`oggm_temp_bias` command on the glacier statistics '
-                        'of all the regions instead of using this file.')
-            utils.compute_temp_bias_dataframe(
-                opath,
-                path=sum_dir / f'temp_bias_{rgi_reg}.csv',
-                plot_path=sum_dir / f'temp_bias_{rgi_reg}',
-                **(temp_bias_run_kwargs or {}))
+            # The glacier statistics is all we need: the temperature bias file
+            # itself is made by the `oggm_temp_bias` command, out of the
+            # statistics of all the RGI regions at once.
+            log.workflow('`temp_bias_run` is done. Now run the '
+                         '`oggm_temp_bias` command on the L3 summary folder '
+                         'of all the regions to create the temperature bias '
+                         'file.')
             _time_log()
             return
 
@@ -1298,15 +1290,12 @@ def parse_args(args):
                              'only). Use together with --custom-climate-task.')
     parser.add_argument('--temp-bias-run', nargs='?', const=True, default=False,
                         help='run the preprocessing needed to create the '
-                             'temperature bias prior file (see the '
-                             '`oggm_temp_bias` command). This forces '
+                             'temperature bias prior file. This forces '
                              '--max-level 3, --skip-inversion and the '
-                             '`temp_melt` calibration strategy, and does not '
-                             'write the glacier directory tar files.')
-    parser.add_argument('--temp-bias-run-kwargs', type=json.loads, default=None,
-                        help='optional kwargs passed to '
-                             'utils.compute_temp_bias_dataframe when '
-                             '--temp-bias-run is set.')
+                             '`temp_melt` calibration strategy, and writes '
+                             'nothing but the L3 glacier statistics file. Feed '
+                             'it to the `oggm_temp_bias` command (together '
+                             'with the other regions) to create the file.')
     parser.add_argument('--store-fl-diagnostics', nargs='?', const=True, default=False,
                         help="Also compute and store flowline diagnostics during "
                              "preprocessing. This can increase data usage quite "
@@ -1399,7 +1388,6 @@ def parse_args(args):
                 geodetic_mb_file_path=args.geodetic_mb_file_path,
                 temp_bias_file_path=args.temp_bias_file_path,
                 temp_bias_run=args.temp_bias_run,
-                temp_bias_run_kwargs=args.temp_bias_run_kwargs,
                 store_fl_diagnostics=args.store_fl_diagnostics,
                 store_hydro_output=args.store_hydro_output,
                 store_monthly_hydro=args.store_monthly_hydro,

--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -289,26 +289,26 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
     temp_bias_run : bool
         set to True to run the preprocessing needed to create the temperature
         bias prior file used by the `informed_threestep` calibration. This is
-        a preset which forces `max_level=3`, `skip_inversion=True` and the
-        `temp_melt` calibration strategy, and skips everything which is of no
-        use for this purpose: the glacier directory tar files, the climate
-        statistics and the fixed geometry mass balance. The only output is the
-        L3 `glacier_statistics` file, which is then turned into the
-        temperature bias file with the `oggm_temp_bias` command (the grouping
-        of climate grid points crosses RGI region borders, so this has to be
-        done over all the regions at once).
+        a preset which forces `max_level=3` and `skip_inversion=True`, and
+        skips everything which is of no use for this purpose: the glacier
+        directory tar files, the climate statistics and the fixed geometry
+        mass balance. `mb_calibration_strategy` has to be set explicitly to
+        `temp_melt` (or `temp_melt_regional`), an error is raised otherwise.
+        The only output is the L3 `glacier_statistics` file, which is then
+        turned into the temperature bias file with the `oggm_temp_bias`
+        command (the grouping of climate grid points crosses RGI region
+        borders, so this has to be done over all the regions at once).
     """
 
-    # The temp bias preset overrides a couple of options - be loud about it
+    # The temp bias preset overrides a couple of options. We log about it
+    # further down, once cfg.initialize() has set the logging up.
     if temp_bias_run:
         if not mb_calibration_strategy.startswith('temp_melt'):
-            log.workflow('`temp_bias_run` is set: overriding the mass balance '
-                         'calibration strategy '
-                         f'({mb_calibration_strategy}) with `temp_melt`.')
-            mb_calibration_strategy = 'temp_melt'
-        log.workflow('`temp_bias_run` is set: forcing max_level=3, '
-                     'skip_inversion=True, and not writing the glacier '
-                     'directory tar files.')
+            raise InvalidParamsError(
+                'With `temp_bias_run`, the mass balance calibration strategy '
+                'has to be set explicitly to `temp_melt` (or to '
+                '`temp_melt_regional` for the regional flavor of the '
+                f'temperature bias file), not `{mb_calibration_strategy}`.')
         max_level = 3
         skip_inversion = True
 
@@ -386,6 +386,13 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
 
     # Prepare the download of climate file to be shared across processes
     # TODO
+
+    if temp_bias_run:
+        log.workflow('`temp_bias_run` is set: forcing max_level=3 and '
+                     'skip_inversion=True. The only output will be the L3 '
+                     'glacier statistics file: no glacier directory tar '
+                     'files, no climate statistics, no fixed geometry mass '
+                     'balance.')
 
     # Log the parameters
     msg = '# OGGM Run parameters:'
@@ -1291,11 +1298,12 @@ def parse_args(args):
     parser.add_argument('--temp-bias-run', nargs='?', const=True, default=False,
                         help='run the preprocessing needed to create the '
                              'temperature bias prior file. This forces '
-                             '--max-level 3, --skip-inversion and the '
-                             '`temp_melt` calibration strategy, and writes '
-                             'nothing but the L3 glacier statistics file. Feed '
-                             'it to the `oggm_temp_bias` command (together '
-                             'with the other regions) to create the file.')
+                             '--max-level 3 and --skip-inversion, and writes '
+                             'nothing but the L3 glacier statistics file. '
+                             'Requires --mb-calibration-strategy temp_melt '
+                             '(or temp_melt_regional). Feed the result to the '
+                             '`oggm_temp_bias` command (together with the '
+                             'other regions) to create the file.')
     parser.add_argument('--store-fl-diagnostics', nargs='?', const=True, default=False,
                         help="Also compute and store flowline diagnostics during "
                              "preprocessing. This can increase data usage quite "

--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -126,7 +126,8 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
                       dynamic_spinup_periods_to_try=None,
                       continue_on_error=True, store_fl_diagnostics=False,
                       store_hydro_output=False, store_monthly_hydro=True,
-                      ref_area_yr=None):
+                      ref_area_yr=None, temp_bias_run=False,
+                      temp_bias_run_kwargs=None):
     """Generate the preprocessed OGGM glacier directories for this OGGM version
 
     Parameters
@@ -286,7 +287,35 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
         per default is the largest area covered by the glacier in the simulation
         period. Use this kwarg to force a specific area to the state of the
         glacier at the provided simulation year.
+    temp_bias_run : bool
+        set to True to run the preprocessing needed to create the temperature
+        bias prior file used by the `informed_threestep` calibration. This is
+        a preset which forces `max_level=3`, `skip_inversion=True` and the
+        `temp_melt` calibration strategy, skips writing the glacier directory
+        tar files (they are of no use here) and, at the end of L3, computes the
+        temperature bias file for this region with
+        `utils.compute_temp_bias_dataframe`.
+        Note that the grouping of climate grid points crosses RGI region
+        borders: for multi-region setups, the resulting file is only a
+        diagnostic, and the `oggm_temp_bias` command should be run over the
+        glacier statistics of all the regions instead.
+    temp_bias_run_kwargs : dict
+        if `temp_bias_run` is set, optional kwargs passed to
+        `utils.compute_temp_bias_dataframe` (e.g. `min_glaciers`).
     """
+
+    # The temp bias preset overrides a couple of options - be loud about it
+    if temp_bias_run:
+        if not mb_calibration_strategy.startswith('temp_melt'):
+            log.workflow('`temp_bias_run` is set: overriding the mass balance '
+                         'calibration strategy '
+                         f'({mb_calibration_strategy}) with `temp_melt`.')
+            mb_calibration_strategy = 'temp_melt'
+        log.workflow('`temp_bias_run` is set: forcing max_level=3, '
+                     'skip_inversion=True, and not writing the glacier '
+                     'directory tar files.')
+        max_level = 3
+        skip_inversion = True
 
     # Input check
     if max_level not in [1, 2, 3, 4, 5]:
@@ -474,11 +503,12 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
         utils.compile_glacier_statistics(gdirs, path=opath)
 
         # L0 OK - compress all in output directory
-        log.workflow('L0 done. Writing to tar...')
-        level_base_dir = Path(output_base_dir) / 'L0'
-        workflow.execute_entity_task(utils.gdir_to_tar, gdirs, delete=False,
-                                     base_dir=level_base_dir)
-        utils.base_dir_to_tar(level_base_dir)
+        if not temp_bias_run:
+            log.workflow('L0 done. Writing to tar...')
+            level_base_dir = Path(output_base_dir) / 'L0'
+            workflow.execute_entity_task(utils.gdir_to_tar, gdirs, delete=False,
+                                         base_dir=level_base_dir)
+            utils.base_dir_to_tar(level_base_dir)
         if max_level == 0:
             _time_log()
             return
@@ -545,11 +575,13 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
                                                  gdirs, source=dem_source)
 
             # L1 OK - compress all in output directory
-            log.workflow('L1 done. Writing to tar...')
-            level_base_dir = Path(output_base_dir) / 'L1'
-            workflow.execute_entity_task(utils.gdir_to_tar, gdirs, delete=False,
-                                         base_dir=level_base_dir)
-            utils.base_dir_to_tar(level_base_dir)
+            if not temp_bias_run:
+                log.workflow('L1 done. Writing to tar...')
+                level_base_dir = Path(output_base_dir) / 'L1'
+                workflow.execute_entity_task(utils.gdir_to_tar, gdirs,
+                                             delete=False,
+                                             base_dir=level_base_dir)
+                utils.base_dir_to_tar(level_base_dir)
 
             _time_log()
             return
@@ -580,11 +612,12 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
         utils.compile_glacier_statistics(gdirs, path=opath)
 
         # L1 OK - compress all in output directory
-        log.workflow('L1 done. Writing to tar...')
-        level_base_dir = Path(output_base_dir) / 'L1'
-        workflow.execute_entity_task(utils.gdir_to_tar, gdirs, delete=False,
-                                     base_dir=level_base_dir)
-        utils.base_dir_to_tar(level_base_dir)
+        if not temp_bias_run:
+            log.workflow('L1 done. Writing to tar...')
+            level_base_dir = Path(output_base_dir) / 'L1'
+            workflow.execute_entity_task(utils.gdir_to_tar, gdirs, delete=False,
+                                         base_dir=level_base_dir)
+            utils.base_dir_to_tar(level_base_dir)
         if max_level == 1:
             _time_log()
             return
@@ -751,11 +784,12 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
                                              path=opath)
 
         # L2 OK - compress all in output directory
-        log.workflow('L2 done. Writing to tar...')
-        level_base_dir = Path(output_base_dir) / 'L2'
-        workflow.execute_entity_task(utils.gdir_to_tar, gdirs, delete=False,
-                                     base_dir=level_base_dir)
-        utils.base_dir_to_tar(level_base_dir)
+        if not temp_bias_run:
+            log.workflow('L2 done. Writing to tar...')
+            level_base_dir = Path(output_base_dir) / 'L2'
+            workflow.execute_entity_task(utils.gdir_to_tar, gdirs, delete=False,
+                                         base_dir=level_base_dir)
+            utils.base_dir_to_tar(level_base_dir)
         if max_level == 2:
             _time_log()
             return
@@ -858,6 +892,20 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
         # Glacier stats
         opath = sum_dir / f'glacier_statistics_{rgi_reg}.csv'
         utils.compile_glacier_statistics(gdirs, path=opath)
+
+        if temp_bias_run:
+            # This is all we need - summarize the biases per climate grid point
+            log.warning('The grouping of climate grid points crosses RGI '
+                        'region borders: for multi-region setups, run the '
+                        '`oggm_temp_bias` command on the glacier statistics '
+                        'of all the regions instead of using this file.')
+            utils.compute_temp_bias_dataframe(
+                opath,
+                path=sum_dir / f'temp_bias_{rgi_reg}.csv',
+                plot_path=sum_dir / f'temp_bias_{rgi_reg}',
+                **(temp_bias_run_kwargs or {}))
+            _time_log()
+            return
 
         # Export thickness to GeoTIFF if requested
         if add_export_thickness_geotiff and add_distributed_thickness:
@@ -1248,6 +1296,17 @@ def parse_args(args):
                         help='optional path or URL to a custom temperature-bias '
                              'file passed to MB calibration (informed_threestep '
                              'only). Use together with --custom-climate-task.')
+    parser.add_argument('--temp-bias-run', nargs='?', const=True, default=False,
+                        help='run the preprocessing needed to create the '
+                             'temperature bias prior file (see the '
+                             '`oggm_temp_bias` command). This forces '
+                             '--max-level 3, --skip-inversion and the '
+                             '`temp_melt` calibration strategy, and does not '
+                             'write the glacier directory tar files.')
+    parser.add_argument('--temp-bias-run-kwargs', type=json.loads, default=None,
+                        help='optional kwargs passed to '
+                             'utils.compute_temp_bias_dataframe when '
+                             '--temp-bias-run is set.')
     parser.add_argument('--store-fl-diagnostics', nargs='?', const=True, default=False,
                         help="Also compute and store flowline diagnostics during "
                              "preprocessing. This can increase data usage quite "
@@ -1339,6 +1398,8 @@ def parse_args(args):
                 mb_calibration_strategy=args.mb_calibration_strategy,
                 geodetic_mb_file_path=args.geodetic_mb_file_path,
                 temp_bias_file_path=args.temp_bias_file_path,
+                temp_bias_run=args.temp_bias_run,
+                temp_bias_run_kwargs=args.temp_bias_run_kwargs,
                 store_fl_diagnostics=args.store_fl_diagnostics,
                 store_hydro_output=args.store_hydro_output,
                 store_monthly_hydro=args.store_monthly_hydro,

--- a/oggm/cli/temp_bias.py
+++ b/oggm/cli/temp_bias.py
@@ -1,0 +1,146 @@
+"""Command line arguments to the oggm_temp_bias command
+
+Type `$ oggm_temp_bias -h` for help
+
+This creates the temperature bias prior file used by the `informed_threestep`
+mass balance calibration. The full workflow to make one for a new setup is:
+
+1. run the preprocessing with the same options as your target setup, but with
+   the `temp_melt` calibration strategy::
+
+     $ oggm_prepro --temp-bias-run <all your other options> --rgi-reg 01
+     $ ...  # one job per RGI region
+
+2. summarize the per-glacier biases of all the regions per climate grid point::
+
+     $ oggm_temp_bias --input RGI62/b_080/L3/summary \\
+                      --output-file temp_bias_v2026.1.csv
+
+3. put the resulting csv somewhere your runs can reach it, and use it for the
+   real preprocessing::
+
+     $ oggm_prepro --temp-bias-file-path <path or url> <your options>
+
+"""
+
+# Standard libraries
+import os
+import sys
+import argparse
+import logging
+from pathlib import Path
+
+# Locals
+import oggm.cfg as cfg
+from oggm import utils
+from oggm.exceptions import InvalidParamsError
+
+log = logging.getLogger(__name__)
+
+
+def run_temp_bias(input_files=None, output_file=None, make_plots=True,
+                  min_glaciers=12, max_radius=10, err_fill_quantile=0.9,
+                  rgi_region=None, rgi_subregion=None,
+                  logging_level='WORKFLOW'):
+    """Creates the temperature bias prior file out of a `temp_melt` run.
+
+    This is a thin wrapper around
+    :py:func:`utils.compute_temp_bias_dataframe`, which does all the work
+    (and where all the parameters are documented).
+
+    Parameters
+    ----------
+    input_files : str or list of str
+        path(s) to the `glacier_statistics` files of the `temp_melt` run.
+        Directories and glob patterns are accepted as well.
+    output_file : str
+        path of the csv file to write.
+    make_plots : bool
+        write the diagnostic plots next to the output file.
+    """
+
+    cfg.initialize(logging_level=logging_level)
+
+    output_file = Path(output_file).absolute()
+    utils.mkdir(output_file.parent)
+
+    plot_path = None
+    if make_plots:
+        plot_path = output_file.parent / output_file.stem
+
+    utils.compute_temp_bias_dataframe(input_files,
+                                      min_glaciers=min_glaciers,
+                                      max_radius=max_radius,
+                                      err_fill_quantile=err_fill_quantile,
+                                      rgi_region=rgi_region,
+                                      rgi_subregion=rgi_subregion,
+                                      path=output_file,
+                                      plot_path=plot_path)
+
+    log.workflow(f'oggm_temp_bias is done! Output written to: {output_file}')
+
+
+def parse_args(args):
+    """Check input arguments and env variables"""
+
+    description = ('Create the OGGM temperature bias prior file out of the '
+                   'glacier statistics of a preprocessing run made with the '
+                   '`temp_melt` mass balance calibration strategy. The '
+                   'resulting file can be fed back into `oggm_prepro` with '
+                   '`--temp-bias-file-path`.')
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument('--input', type=str, nargs='+',
+                        help='path(s) to the `glacier_statistics_*.csv` files '
+                             'of the `temp_melt` run. Can be files, '
+                             'directories or glob patterns. Since the grouping '
+                             'of grid points crosses RGI region borders, all '
+                             'the regions should be given at once.')
+    parser.add_argument('--output-file', type=str, default='temp_bias.csv',
+                        help='path of the csv file to write (default: '
+                             '`temp_bias.csv` in the current directory).')
+    parser.add_argument('--no-plots', nargs='?', const=True, default=False,
+                        help='do not write the diagnostic plots.')
+    parser.add_argument('--min-glaciers', type=int, default=12,
+                        help='minimum number of glaciers per grid point. Grid '
+                             'points with fewer glaciers are grouped with '
+                             'their neighbours (default: 12).')
+    parser.add_argument('--max-radius', type=int, default=10,
+                        help='the maximum search radius (in grid points) used '
+                             'for the grouping (default: 10).')
+    parser.add_argument('--err-fill-quantile', type=float, default=0.9,
+                        help='glaciers with a missing reference mass balance '
+                             'error are attributed this quantile of the error '
+                             'distribution (default: 0.9).')
+    parser.add_argument('--rgi-region', type=str, nargs='+', default=None,
+                        help='select only these RGI regions (e.g. 11).')
+    parser.add_argument('--rgi-subregion', type=str, nargs='+', default=None,
+                        help='select only these RGI subregions (e.g. 11-01).')
+    parser.add_argument('--logging-level', type=str, default='WORKFLOW',
+                        help='the logging level to use (DEBUG, INFO, WARNING, '
+                             'WORKFLOW).')
+
+    args = parser.parse_args(args)
+
+    input_files = args.input
+    if not input_files:
+        input_files = os.environ.get('OGGM_TEMP_BIAS_INPUT', None)
+        if input_files is None:
+            raise InvalidParamsError('--input is required!')
+        input_files = input_files.split()
+
+    return dict(input_files=input_files,
+                output_file=args.output_file,
+                make_plots=not args.no_plots,
+                min_glaciers=args.min_glaciers,
+                max_radius=args.max_radius,
+                err_fill_quantile=args.err_fill_quantile,
+                rgi_region=args.rgi_region,
+                rgi_subregion=args.rgi_subregion,
+                logging_level=args.logging_level,
+                )
+
+
+def main():
+    """Script entry point"""
+
+    run_temp_bias(**parse_args(sys.argv[1:]))

--- a/oggm/cli/temp_bias.py
+++ b/oggm/cli/temp_bias.py
@@ -8,8 +8,11 @@ mass balance calibration. The full workflow to make one for a new setup is:
 1. run the preprocessing with the same options as your target setup, but with
    the `temp_melt` calibration strategy::
 
-     $ oggm_prepro --temp-bias-run <all your other options> --rgi-reg 01
+     $ oggm_prepro --temp-bias-run --mb-calibration-strategy temp_melt \\
+                   <all your other options> --rgi-reg 01
      $ ...  # one job per RGI region
+
+   (use `temp_melt_regional` instead to build the regional flavor of the file)
 
 2. summarize the per-glacier biases of all the regions per climate grid point.
    The grouping of grid points crosses RGI region borders, so this is always a

--- a/oggm/cli/temp_bias.py
+++ b/oggm/cli/temp_bias.py
@@ -11,7 +11,9 @@ mass balance calibration. The full workflow to make one for a new setup is:
      $ oggm_prepro --temp-bias-run <all your other options> --rgi-reg 01
      $ ...  # one job per RGI region
 
-2. summarize the per-glacier biases of all the regions per climate grid point::
+2. summarize the per-glacier biases of all the regions per climate grid point.
+   The grouping of grid points crosses RGI region borders, so this is always a
+   separate step, run once over all the regions::
 
      $ oggm_temp_bias --input RGI62/b_080/L3/summary \\
                       --output-file temp_bias_v2026.1.csv

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -1,4 +1,5 @@
 import unittest
+import glob
 import os
 import shutil
 import time
@@ -90,6 +91,42 @@ class TestFuncs(object):
         b = utils.smooth1d(a, 3, kernel=kernel)
         c = utils.smooth1d(a, 3)
         assert_allclose(b, c)
+
+    def test_weighted_quantile_1d(self):
+
+        data = np.array([1., 2., 3., 4., 5.])
+
+        # With equal weights this is the plain median
+        w = np.ones(5)
+        assert_allclose(utils.weighted_quantile_1d(data, w, 0.5),
+                        np.median(data))
+        assert_allclose(utils.weighted_quantile_1d(data[:4], w[:4], 0.5),
+                        np.median(data[:4]))
+
+        # The extremes
+        assert_allclose(utils.weighted_quantile_1d(data, w, 0), data.min())
+        assert_allclose(utils.weighted_quantile_1d(data, w, 1), data.max())
+
+        # Order does not matter
+        assert_allclose(utils.weighted_quantile_1d(data[::-1], w, 0.5),
+                        np.median(data))
+
+        # Two values: the result is pulled towards the heavier one, and the
+        # two mirrored cases are symmetric
+        lo = utils.weighted_quantile_1d([0., 1.], [3., 1.], 0.5)
+        hi = utils.weighted_quantile_1d([0., 1.], [1., 3.], 0.5)
+        assert lo < 0.5 < hi
+        assert_allclose(lo, 1 - hi)
+        assert_allclose(utils.weighted_quantile_1d([0., 1.], [1., 1.], 0.5), 0.5)
+
+        # Weighting one value out is like removing it
+        assert_allclose(utils.weighted_quantile_1d(data, [1, 1, 1, 1, 0], 0.5),
+                        utils.weighted_quantile_1d(data[:4], w[:4], 0.5))
+
+        with pytest.raises(InvalidParamsError):
+            utils.weighted_quantile_1d(data, w, 1.5)
+        with pytest.raises(ZeroDivisionError):
+            utils.weighted_quantile_1d(data, np.zeros(5), 0.5)
 
     def test_utm_proj4_from_lonlat(self):
 
@@ -2332,6 +2369,303 @@ class TestPreproCLI:
         entity = rgidf.iloc[0]
         gdir = oggm.GlacierDirectory(entity, from_tar=tarf)
         assert os.path.isfile(os.path.join(gdir.dir, 'USER', 'dem.tif'))
+
+
+def _fake_glacier_statistics(grid_points, reg='11', dlon=0.5, dlat=0.5,
+                             seed=0):
+    """A synthetic `glacier_statistics` file of a `temp_melt` run.
+
+    `grid_points` is a list of (lon, lat, n_glaciers) tuples. The temp bias of
+    a glacier is its grid point longitude plus some noise, so that the
+    aggregated values are easy to check.
+    """
+    rng = np.random.RandomState(seed)
+    rows = []
+    for lon, lat, n in grid_points:
+        for _ in range(n):
+            rows.append({'rgi_id': 'RGI60-{}.{:05d}'.format(reg, len(rows)),
+                         'rgi_region': reg,
+                         'rgi_subregion': f'{reg}-01',
+                         'cenlon': lon + rng.uniform(-dlon / 2, dlon / 2),
+                         'cenlat': lat + rng.uniform(-dlat / 2, dlat / 2),
+                         'rgi_area_km2': rng.uniform(0.1, 10),
+                         'temp_bias': lon + rng.normal(scale=0.1),
+                         'reference_mb_err': rng.uniform(100, 300),
+                         'baseline_climate_ref_pix_lon': lon,
+                         'baseline_climate_ref_pix_lat': lat,
+                         })
+    return pd.DataFrame(rows)
+
+
+class TestTempBiasCLI:
+
+    @pytest.fixture(autouse=True)
+    def setup(self, tmpdir_factory):
+        self.testdir = str(tmpdir_factory.mktemp("tmp_temp_bias"))
+        utils.mkdir(self.testdir, reset=True)
+        cfg.initialize()
+
+    def test_parse_args(self):
+
+        from oggm.cli import temp_bias
+
+        kwargs = temp_bias.parse_args(['--input', 'in_dir'])
+        assert kwargs['input_files'] == ['in_dir']
+        assert kwargs['output_file'] == 'temp_bias.csv'
+        assert kwargs['make_plots']
+        assert kwargs['min_glaciers'] == 12
+        assert kwargs['max_radius'] == 10
+        assert kwargs['err_fill_quantile'] == 0.9
+        assert kwargs['rgi_region'] is None
+        assert kwargs['rgi_subregion'] is None
+
+        kwargs = temp_bias.parse_args(['--input', 'd1', 'd2',
+                                       '--output-file', 'out/tb.csv',
+                                       '--no-plots',
+                                       '--min-glaciers', '5',
+                                       '--max-radius', '3',
+                                       '--err-fill-quantile', '0.5',
+                                       '--rgi-subregion', '11-01',
+                                       ])
+        assert kwargs['input_files'] == ['d1', 'd2']
+        assert kwargs['output_file'] == 'out/tb.csv'
+        assert not kwargs['make_plots']
+        assert kwargs['min_glaciers'] == 5
+        assert kwargs['max_radius'] == 3
+        assert kwargs['err_fill_quantile'] == 0.5
+        assert kwargs['rgi_subregion'] == ['11-01']
+
+        with pytest.raises(InvalidParamsError):
+            temp_bias.parse_args([])
+
+        with TempEnvironmentVariable(OGGM_TEMP_BIAS_INPUT='d1 d2'):
+            kwargs = temp_bias.parse_args([])
+            assert kwargs['input_files'] == ['d1', 'd2']
+
+    def test_compute_temp_bias_dataframe(self):
+
+        # Three grid points: two well populated, one with too few glaciers
+        df = _fake_glacier_statistics([(10.25, 46.25, 20),
+                                       (10.75, 46.25, 15),
+                                       (11.25, 46.25, 3)])
+        # A failed glacier and a missing MB error should not be a problem
+        df.loc[0, 'temp_bias'] = np.nan
+        df.loc[1, 'reference_mb_err'] = np.nan
+
+        out = utils.compute_temp_bias_dataframe(df, min_glaciers=12)
+
+        # The file format is set in stone - this is what OGGM reads back
+        assert list(out.columns) == utils.TEMP_BIAS_FILE_COLUMNS
+        assert out.index.name == 'unique_id'
+        assert len(out) == 3
+        assert out['n_glaciers'].sum() == len(df) - 1  # the failed one is out
+
+        # The grid was correctly inferred from the ref pix coordinates
+        assert_allclose(sorted(out['lon_val']), [10.25, 10.75, 11.25])
+        assert_array_equal(sorted(out['lon_id']), [0, 1, 2])
+        assert_array_equal(out['lat_id'], 0)
+
+        # The values are dominated by the grid point longitude
+        for _, s in out.iterrows():
+            assert_allclose(s['median_temp_bias'], s['lon_val'], atol=0.1)
+
+        # Populated grid points are used as is
+        big = out.loc[out['n_glaciers'] >= 12]
+        assert len(big) == 2
+        assert_array_equal(big['search_radius'], 0)
+        assert_array_equal(big['n_glaciers_grouped'], big['n_glaciers'])
+        for c in ['median_temp_bias', 'median_temp_bias_w_area',
+                  'median_temp_bias_w_err']:
+            assert_allclose(big[c], big[c + '_grouped'])
+
+        # The lonely one is grouped with its neighbours
+        small = out.loc[out['n_glaciers'] < 12]
+        assert len(small) == 1
+        assert small['search_radius'].iloc[0] == 1
+        # radius 1 around 11.25 reaches 10.75 but not 10.25
+        assert small['n_glaciers_grouped'].iloc[0] == 3 + 15
+        assert (small['median_temp_bias_grouped'].iloc[0] <
+                small['median_temp_bias'].iloc[0])
+
+        # Check one weighted median by hand
+        sel = df.loc[df['baseline_climate_ref_pix_lon'] == 10.75]
+        assert_allclose(out.loc['001_000', 'median_temp_bias_w_area'],
+                        utils.weighted_quantile_1d(sel['temp_bias'].values,
+                                                   sel['rgi_area_km2'].values,
+                                                   0.5))
+        assert_allclose(out.loc['001_000', 'median_temp_bias_w_err'],
+                        utils.weighted_quantile_1d(
+                            sel['temp_bias'].values,
+                            1 / sel['reference_mb_err'].values, 0.5))
+
+        # Without grouping, all grid points are on their own
+        out = utils.compute_temp_bias_dataframe(df, min_glaciers=1)
+        assert_array_equal(out['search_radius'], 0)
+        assert_array_equal(out['n_glaciers_grouped'], out['n_glaciers'])
+
+        # Subregion selection
+        df['rgi_subregion'] = ['11-01'] * 20 + ['11-02'] * 18
+        out = utils.compute_temp_bias_dataframe(df, min_glaciers=1,
+                                                rgi_subregion='11-02')
+        assert len(out) == 2
+        out = utils.compute_temp_bias_dataframe(df, min_glaciers=1,
+                                                rgi_region=11)
+        assert len(out) == 3
+
+        # Garbage in
+        with pytest.raises(InvalidWorkflowError):
+            utils.compute_temp_bias_dataframe(df.drop(columns=['temp_bias']))
+        with pytest.raises(InvalidWorkflowError):
+            # All the glaciers in the same grid point
+            utils.compute_temp_bias_dataframe(
+                _fake_glacier_statistics([(10.25, 46.25, 20)]))
+
+    def test_compute_temp_bias_dataframe_wrap(self):
+
+        # Grid points on both sides of the dateline should see each other
+        df = _fake_glacier_statistics([(-179.75, 60.25, 2),
+                                       (-179.25, 60.25, 2),
+                                       (179.25, 60.25, 2),
+                                       (179.75, 60.25, 2)])
+        out = utils.compute_temp_bias_dataframe(df, min_glaciers=6)
+
+        # 720 longitudes at 0.5 deg - the grid is anchored on the westernmost
+        assert_array_equal(sorted(out['lon_id']), [0, 1, 718, 719])
+
+        # The two grid points either side of the dateline are neighbours: at
+        # radius 1 they see each other and reach the 6 glaciers they need
+        for uid in ['000_000', '719_000']:
+            assert out.loc[uid, 'search_radius'] == 1
+            assert out.loc[uid, 'n_glaciers_grouped'] == 6
+
+        # Without the wrap-around they would never find enough glaciers
+        assert (out['n_glaciers_grouped'] >= 6).all()
+
+    def test_temp_bias_cli(self):
+
+        from oggm.cli.temp_bias import run_temp_bias
+
+        # Two "regions", written as two files, as prepro_levels would
+        sum_dir = os.path.join(self.testdir, 'summary')
+        utils.mkdir(sum_dir)
+        for reg, lon0 in [('11', 10.25), ('12', 20.25)]:
+            df = _fake_glacier_statistics([(lon0, 46.25, 20),
+                                           (lon0 + 0.5, 46.25, 20),
+                                           (lon0 + 1, 46.75, 3)], reg=reg)
+            df.to_csv(os.path.join(sum_dir,
+                                   f'glacier_statistics_{reg}.csv'),
+                      index=False)
+
+        opath = os.path.join(self.testdir, 'out', 'temp_bias_v42.csv')
+        run_temp_bias(input_files=[sum_dir], output_file=opath,
+                      min_glaciers=12)
+
+        out = pd.read_csv(opath, index_col=0)
+        assert len(out) == 6
+        assert list(out.columns) == utils.TEMP_BIAS_FILE_COLUMNS
+        assert os.path.isfile(os.path.join(self.testdir, 'out',
+                                           'temp_bias_v42_map.png'))
+        assert os.path.isfile(os.path.join(self.testdir, 'out',
+                                           'temp_bias_v42_hist.png'))
+
+        # This is what OGGM does with the file: it must be readable and the
+        # nearest grid point lookup must work (see mb_calibration_from_
+        # geodetic_mb)
+        bias_df = utils.get_temp_bias_dataframe(file_path=opath)
+        assert_array_equal(bias_df.index, out.index)
+        dis = ((bias_df.lon_val - 20.75) ** 2 +
+               (bias_df.lat_val - 46.25) ** 2) ** 0.5
+        assert dis.min() < 1
+        sel = bias_df.iloc[np.argmin(dis)]
+        assert_allclose(sel['median_temp_bias_w_err_grouped'], 20.75, atol=0.1)
+        assert np.isfinite(bias_df['median_temp_bias_w_err_grouped']).all()
+
+        # No plots if asked
+        opath = os.path.join(self.testdir, 'out2', 'temp_bias_v42.csv')
+        run_temp_bias(input_files=[sum_dir], output_file=opath,
+                      make_plots=False)
+        assert os.path.isfile(opath)
+        assert not os.path.isfile(os.path.join(self.testdir, 'out2',
+                                               'temp_bias_v42_map.png'))
+
+    @pytest.mark.slow
+    def test_prepro_temp_bias_run(self):
+
+        from oggm.cli.prepro_levels import run_prepro_levels
+
+        inter, rgidf = _read_shp()
+
+        # Two glaciers in one W5E5 grid point, one in the next
+        test_ids = ['RGI60-11.00897', 'RGI60-11.00746', 'RGI60-11.00929']
+
+        wdir = os.path.join(self.testdir, 'wd')
+        utils.mkdir(wdir)
+        odir = os.path.join(self.testdir, 'levs')
+        topof = utils.get_demo_file('srtm_oetztal.tif')
+        run_prepro_levels(rgi_version='61', rgi_reg='11', border=20,
+                          output_folder=odir, working_dir=wdir,
+                          is_test=True, test_ids=test_ids,
+                          rgi_file=rgidf, disable_mp=True,
+                          intersects_file=inter,
+                          test_topofile=topof,
+                          elev_bands=True,
+                          continue_on_error=False,
+                          temp_bias_run=True,
+                          temp_bias_run_kwargs={'min_glaciers': 2},
+                          override_params={},
+                          )
+
+        sum_dir = os.path.join(odir, 'RGI61', 'b_020', 'L3', 'summary')
+        opath = os.path.join(sum_dir, 'temp_bias_11.csv')
+        assert os.path.isfile(opath)
+        assert os.path.isfile(os.path.join(sum_dir, 'temp_bias_11_map.png'))
+        assert os.path.isfile(os.path.join(sum_dir, 'temp_bias_11_hist.png'))
+
+        # The gdirs are not copied back, and we stopped at L3
+        for lev in ['L0', 'L1', 'L2', 'L3']:
+            base = os.path.join(odir, 'RGI61', 'b_020', lev)
+            assert len(glob.glob(os.path.join(base, '*.tar*'))) == 0
+            assert len(glob.glob(os.path.join(base, 'RGI*'))) == 0
+        assert not os.path.isdir(os.path.join(odir, 'RGI61', 'b_020', 'L4'))
+
+        # The two grid points are there, one of them had to be grouped
+        out = pd.read_csv(opath, index_col=0)
+        assert len(out) == 2
+        assert list(out.columns) == utils.TEMP_BIAS_FILE_COLUMNS
+        assert out['n_glaciers'].sum() == 3
+        assert (out['search_radius'] == [0, 1]).all()
+        assert np.isfinite(out['median_temp_bias_w_err_grouped']).all()
+
+        # And now the real test: the file we just made must work as a prior
+        wdir2 = os.path.join(self.testdir, 'wd2')
+        utils.mkdir(wdir2)
+        odir2 = os.path.join(self.testdir, 'levs2')
+        run_prepro_levels(rgi_version='61', rgi_reg='11', border=20,
+                          output_folder=odir2, working_dir=wdir2,
+                          is_test=True, test_ids=test_ids,
+                          rgi_file=rgidf, disable_mp=True,
+                          intersects_file=inter,
+                          test_topofile=topof,
+                          elev_bands=True,
+                          continue_on_error=False,
+                          max_level=3, skip_inversion=True,
+                          mb_calibration_strategy='informed_threestep',
+                          temp_bias_file_path=opath,
+                          override_params={},
+                          )
+
+        df = pd.read_csv(os.path.join(odir2, 'RGI61', 'b_020', 'L3', 'summary',
+                                      'glacier_statistics_11.csv'),
+                         index_col=0)
+        assert len(df) == 3
+        assert np.isfinite(df['temp_bias']).all()
+        # The prior was used: the calibrated bias is close to the file value
+        # (informed_threestep only moves it as a last resort)
+        for rid, s in df.iterrows():
+            dis = ((out.lon_val - s['baseline_climate_ref_pix_lon']) ** 2 +
+                   (out.lat_val - s['baseline_climate_ref_pix_lat']) ** 2) ** 0.5
+            prior = out.iloc[np.argmin(dis)]['median_temp_bias_w_err_grouped']
+            assert_allclose(s['temp_bias'], prior, atol=1e-3)
 
 
 class TestBenchmarkCLI(unittest.TestCase):

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -2,6 +2,8 @@ import unittest
 import glob
 import os
 import shutil
+import subprocess
+import sys
 import time
 import hashlib
 import tarfile
@@ -2442,6 +2444,27 @@ class TestTempBiasCLI:
             kwargs = temp_bias.parse_args([])
             assert kwargs['input_files'] == ['d1', 'd2']
 
+    def test_temp_bias_run_preset_before_initialize(self):
+
+        # `log.workflow` is added to the Logger class by cfg.initialize(), so
+        # the --temp-bias-run preset must not log before that or it crashes on
+        # a fresh interpreter. A test session cannot catch this (cfg is
+        # already initialized), hence the subprocess.
+        code = (
+            'import logging\n'
+            'from oggm.cli.prepro_levels import run_prepro_levels\n'
+            'from oggm.exceptions import InvalidParamsError\n'
+            'assert not hasattr(logging.Logger, "workflow")\n'
+            'try:\n'
+            '    run_prepro_levels(rgi_reg="11", border=80,\n'
+            '                      temp_bias_run=True, start_level=2,\n'
+            '                      mb_calibration_strategy="temp_melt")\n'
+            'except InvalidParamsError:\n'
+            '    pass  # raised after the preset block, before cfg.initialize\n'
+        )
+        out = subprocess.run([sys.executable, '-c', code], capture_output=True)
+        assert out.returncode == 0, out.stderr.decode()
+
     def test_compute_temp_bias_dataframe(self):
 
         # Three grid points: two well populated, one with too few glaciers
@@ -2612,8 +2635,16 @@ class TestTempBiasCLI:
                           elev_bands=True,
                           continue_on_error=False,
                           temp_bias_run=True,
+                          mb_calibration_strategy='temp_melt',
                           override_params={},
                           )
+
+        # The strategy has to be explicit
+        with pytest.raises(InvalidParamsError):
+            run_prepro_levels(rgi_version='61', rgi_reg='11', border=20,
+                              output_folder=odir, working_dir=wdir,
+                              temp_bias_run=True,
+                              mb_calibration_strategy='informed_threestep')
 
         # The statistics file is the only thing this run is good for
         sum_dir = os.path.join(odir, 'RGI61', 'b_020', 'L3', 'summary')

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -2592,6 +2592,7 @@ class TestTempBiasCLI:
     def test_prepro_temp_bias_run(self):
 
         from oggm.cli.prepro_levels import run_prepro_levels
+        from oggm.cli.temp_bias import run_temp_bias
 
         inter, rgidf = _read_shp()
 
@@ -2611,15 +2612,15 @@ class TestTempBiasCLI:
                           elev_bands=True,
                           continue_on_error=False,
                           temp_bias_run=True,
-                          temp_bias_run_kwargs={'min_glaciers': 2},
                           override_params={},
                           )
 
+        # The statistics file is the only thing this run is good for
         sum_dir = os.path.join(odir, 'RGI61', 'b_020', 'L3', 'summary')
-        opath = os.path.join(sum_dir, 'temp_bias_11.csv')
-        assert os.path.isfile(opath)
-        assert os.path.isfile(os.path.join(sum_dir, 'temp_bias_11_map.png'))
-        assert os.path.isfile(os.path.join(sum_dir, 'temp_bias_11_hist.png'))
+        assert os.path.isfile(os.path.join(sum_dir,
+                                           'glacier_statistics_11.csv'))
+        assert not os.path.isfile(os.path.join(sum_dir,
+                                               'climate_statistics_11.csv'))
 
         # The gdirs are not copied back, and we stopped at L3
         for lev in ['L0', 'L1', 'L2', 'L3']:
@@ -2627,6 +2628,10 @@ class TestTempBiasCLI:
             assert len(glob.glob(os.path.join(base, '*.tar*'))) == 0
             assert len(glob.glob(os.path.join(base, 'RGI*'))) == 0
         assert not os.path.isdir(os.path.join(odir, 'RGI61', 'b_020', 'L4'))
+
+        # Second command: the temperature bias file itself
+        opath = os.path.join(self.testdir, 'temp_bias_test.csv')
+        run_temp_bias(input_files=[sum_dir], output_file=opath, min_glaciers=2)
 
         # The two grid points are there, one of them had to be grouped
         out = pd.read_csv(opath, index_col=0)

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -1317,8 +1317,11 @@ def get_temp_bias_dataframe(dataset=None, regional=False, rgi_version='62',
     The dataframe was created by the OGGM>=v16 pre-calibration
     (further explained in the `OGGM mass balance tutorial <https://tutorials.oggm.org/stable/notebooks/tutorials/massbalance_calibration.html>`_
 
-    The data preparation script is available at
-    https://nbviewer.jupyter.org/urls/cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.6/calibration/1.6.1/prepare_bias_map.ipynb
+    To create such a file yourself (e.g. for a custom climate dataset), run the
+    preprocessing with the `temp_melt` calibration strategy
+    (``oggm_prepro --temp-bias-run``) and summarize its glacier statistics with
+    the ``oggm_temp_bias`` command (see
+    :py:func:`utils.compute_temp_bias_dataframe`).
 
     The file differs between climate datasets and OGGM versions. For W5E5 and OGGM v162, it is e.g.
     https://cluster.klima.uni-bremen.de/~oggm/ref_mb_params/oggm_v1.6/w5e5_temp_bias_v2023.4.csv

--- a/oggm/utils/_funcs.py
+++ b/oggm/utils/_funcs.py
@@ -461,6 +461,42 @@ def weighted_average_2d(data, weights):
     return np.multiply(np.transpose(data), weights).sum(axis=1) / scl
 
 
+def weighted_quantile_1d(data, weights, quantile):
+    """The weighted quantile of a 1D array, without dimension checks.
+
+    Parameters
+    ----------
+    data : ArrayLike
+        Must be of shape (n, ).
+    weights : ArrayLike
+        Must be of shape (n, ).
+    quantile : float
+        the quantile to compute, between 0 and 1.
+
+    Returns
+    -------
+    the weighted quantile of the data.
+    """
+    if quantile > 1 or quantile < 0:
+        raise InvalidParamsError('quantile must have a value between 0 and 1.')
+
+    data = np.asarray(data)
+    weights = np.asarray(weights)
+
+    # Sort the data
+    ind_sorted = np.argsort(data)
+    sorted_data = data[ind_sorted]
+    sorted_weights = weights[ind_sorted]
+
+    # Compute the auxiliary arrays
+    sn = np.cumsum(sorted_weights)
+    if sn[-1] == 0:
+        raise ZeroDivisionError("Weights sum to zero, can't be normalized")
+    pn = (sn - 0.5 * sorted_weights) / sn[-1]
+
+    return np.interp(quantile, pn, sorted_data)
+
+
 if Version(np.__version__) < Version('1.17'):
     clip_array = np.clip
 else:

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -70,7 +70,8 @@ from oggm import __version__
 from oggm.utils._funcs import (calendardate_to_hydrodate, date_to_floatyear,
                                tolist, filter_rgi_name, parse_rgi_meta,
                                haversine, multipolygon_to_polygon,
-                               recursive_valid_polygons)
+                               recursive_valid_polygons,
+                               weighted_quantile_1d)
 from oggm.utils._downloads import (get_demo_file, get_wgms_files,
                                    get_rgi_glacier_entities)
 from oggm import cfg
@@ -2449,6 +2450,355 @@ def compile_climate_statistics(gdirs, filesuffix='', path=True,
         else:
             out.to_csv(path)
     return out
+
+
+# Columns of the temperature bias file, in the order in which they are
+# written out. The index of the file is `unique_id`.
+TEMP_BIAS_FILE_COLUMNS = [
+    'lon_id', 'lat_id', 'lon_val', 'lat_val', 'rgi_area_km2', 'n_glaciers',
+    'median_temp_bias', 'median_temp_bias_w_area', 'median_temp_bias_w_err',
+    'n_glaciers_grouped', 'search_radius', 'median_temp_bias_grouped',
+    'median_temp_bias_w_area_grouped', 'median_temp_bias_w_err_grouped',
+]
+
+
+def _read_glacier_statistics_files(glacier_statistics):
+    """Read and concatenate glacier statistics files.
+
+    Parameters
+    ----------
+    glacier_statistics : pandas.DataFrame, str, Path or list
+        a DataFrame (used as is), or one or more paths. A path can point to a
+        csv file, to a directory (all `glacier_statistics*.csv` files therein
+        are read) or be a glob pattern.
+
+    Returns
+    -------
+    a DataFrame with one row per glacier
+    """
+
+    if isinstance(glacier_statistics, pd.DataFrame):
+        return glacier_statistics.copy()
+
+    files = []
+    for item in tolist(glacier_statistics):
+        item = str(item)
+        if os.path.isdir(item):
+            found = sorted(glob.glob(os.path.join(item,
+                                                  'glacier_statistics*.csv')))
+            if not found:
+                raise InvalidParamsError('No `glacier_statistics*.csv` file '
+                                         f'found in directory: {item}')
+        elif os.path.isfile(item):
+            found = [item]
+        else:
+            found = sorted(glob.glob(item))
+            if not found:
+                raise InvalidParamsError(f'No such file or directory: {item}')
+        files.extend(found)
+
+    log.workflow(f'Reading {len(files)} glacier statistics file(s).')
+
+    df = pd.concat([pd.read_csv(f, low_memory=False) for f in files],
+                   axis=0, ignore_index=True)
+
+    if 'rgi_id' in df:
+        n_before = len(df)
+        df = df.drop_duplicates(subset='rgi_id').set_index('rgi_id').sort_index()
+        if len(df) != n_before:
+            log.warning(f'{n_before - len(df)} duplicated glaciers were found '
+                        'in the input files and were removed.')
+    return df
+
+
+def _infer_grid_spacing(values, name):
+    """Infer the spacing of a regular grid from the coordinates in use.
+
+    Returns None if all the glaciers sit in the same band, in which case the
+    caller falls back on the spacing of the other axis.
+    """
+
+    uniq = np.unique(values)
+    if len(uniq) < 2:
+        log.warning(f'Cannot infer the climate grid {name} spacing: all '
+                    f'glaciers are in the same {name} band. Falling back on '
+                    'the spacing of the other axis.')
+        return None
+    return float(np.min(np.diff(uniq)))
+
+
+def compute_temp_bias_dataframe(glacier_statistics, min_glaciers=12,
+                                max_radius=10, err_fill_quantile=0.9,
+                                rgi_region=None, rgi_subregion=None,
+                                path=None, plot_path=None):
+    """Computes the temperature bias prior file out of a `temp_melt` run.
+
+    This is the counterpart of :py:func:`utils.get_temp_bias_dataframe`: it
+    creates the file which the `informed_threestep` mass balance calibration
+    reads as a prior (see `mb_calibration_from_geodetic_mb`).
+
+    The input is the `glacier_statistics` file(s) of a preprocessing run made
+    with the `temp_melt` calibration strategy, i.e. a run in which the melt
+    factor was kept at its default and the temperature bias was chosen so as
+    to match the geodetic observations. This function summarizes these
+    per-glacier temperature biases per climate grid point, using the (weighted)
+    median of all glaciers within the grid point. Grid points with fewer than
+    `min_glaciers` glaciers are grouped with their neighbours, by growing a
+    square search radius until enough glaciers are found.
+
+    The climate grid is reconstructed from the
+    `baseline_climate_ref_pix_lon` / `baseline_climate_ref_pix_lat` columns of
+    the statistics file, i.e. the very coordinates the calibration matches
+    against. Note that the resulting `lon_id` / `lat_id` columns (and hence the
+    index) are relative to the extent of the data, not absolute indices into
+    the climate file. They are used internally only.
+
+    Since the grouping of grid points crosses RGI region borders, this should
+    be applied to the statistics files of *all* the regions at once.
+
+    Parameters
+    ----------
+    glacier_statistics : pandas.DataFrame, str, Path or list
+        the glacier statistics of a `temp_melt` run: a DataFrame, or one or
+        more paths to csv files, directories or glob patterns.
+    min_glaciers : int, default 12
+        minimum number of glaciers per grid point. Grid points with fewer
+        glaciers are grouped with their neighbours.
+    max_radius : int, default 10
+        the maximum search radius (in grid points) used for the grouping.
+    err_fill_quantile : float, default 0.9
+        glaciers with a missing (or zero) reference mass balance error are
+        attributed this quantile of the error distribution.
+    rgi_region : str or list, optional
+        select only these RGI regions (e.g. '11').
+    rgi_subregion : str or list, optional
+        select only these RGI subregions (e.g. '11-01').
+    path : str or Path, optional
+        where to write the resulting csv file.
+    plot_path : str or Path, optional
+        base path for the diagnostic plots (without extension). Two files are
+        written: `{plot_path}_map.png` and `{plot_path}_hist.png`.
+
+    Returns
+    -------
+    a DataFrame with one row per climate grid point.
+    """
+
+    df = _read_glacier_statistics_files(glacier_statistics)
+
+    if rgi_region is not None:
+        regs = ['{:02d}'.format(int(r)) for r in tolist(rgi_region)]
+        sel = df['rgi_region'].apply(lambda r: '{:02d}'.format(int(r)))
+        df = df.loc[sel.isin(regs)]
+    if rgi_subregion is not None:
+        df = df.loc[df['rgi_subregion'].isin(tolist(rgi_subregion))]
+
+    needed = ['rgi_area_km2', 'temp_bias', 'reference_mb_err',
+              'baseline_climate_ref_pix_lon', 'baseline_climate_ref_pix_lat']
+    missing = [c for c in needed if c not in df]
+    if missing:
+        raise InvalidWorkflowError(
+            f'The glacier statistics file(s) are missing the {missing} '
+            'column(s). Are you sure they come from a level 3 run with the '
+            '`temp_melt` mass balance calibration strategy?')
+
+    n_tot = len(df)
+    area_tot = df['rgi_area_km2'].sum()
+
+    # Sanitize: glaciers without a calibrated temp bias are of no use here
+    odf = df.loc[df['temp_bias'].notnull() &
+                 df['baseline_climate_ref_pix_lon'].notnull() &
+                 df['baseline_climate_ref_pix_lat'].notnull()].copy()
+    if len(odf) == 0:
+        raise InvalidWorkflowError('No glacier with a valid temperature bias '
+                                   'found in the glacier statistics file(s).')
+
+    log.workflow('compute_temp_bias_dataframe: using {} glaciers out of {} '
+                 '({:.1f}% of the area was discarded because the calibration '
+                 'failed).'.format(len(odf), n_tot,
+                                   (1 - odf['rgi_area_km2'].sum() /
+                                    area_tot) * 100))
+
+    # The MB error is used as a weight - fill the missing ones
+    err = odf['reference_mb_err'].copy()
+    invalid = err.isnull() | (err <= 0)
+    if invalid.all():
+        log.warning('compute_temp_bias_dataframe: no glacier has a valid '
+                    'reference MB error - using uniform weights instead.')
+        err = pd.Series(1., index=err.index)
+        invalid = pd.Series(False, index=err.index)
+    err_fill = err.loc[~invalid].quantile(err_fill_quantile)
+    if invalid.sum() > 0:
+        log.workflow('compute_temp_bias_dataframe: {} glaciers have no valid '
+                     'reference MB error - using the {} quantile instead '
+                     '({:.1f} kg m-2 yr-1).'.format(invalid.sum(),
+                                                    err_fill_quantile,
+                                                    err_fill))
+        err.loc[invalid] = err_fill
+    odf['reference_mb_err'] = err
+
+    # The climate grid, inferred from the coordinates the calibration uses
+    lon = odf['baseline_climate_ref_pix_lon'].values.astype(float)
+    lat = odf['baseline_climate_ref_pix_lat'].values.astype(float)
+    dlon = _infer_grid_spacing(lon, 'longitude')
+    dlat = _infer_grid_spacing(lat, 'latitude')
+    if dlon is None and dlat is None:
+        raise InvalidWorkflowError(
+            'Cannot infer the climate grid spacing: all the glaciers are in '
+            'the same grid point. The temperature bias file needs glaciers '
+            'spread over at least two grid points.')
+    dlon = dlat if dlon is None else dlon
+    dlat = dlon if dlat is None else dlat
+    lon0, lat0 = lon.min(), lat.min()
+    lon_id = np.round((lon - lon0) / dlon).astype(int)
+    lat_id = np.round((lat - lat0) / dlat).astype(int)
+    if not (np.allclose(lon0 + lon_id * dlon, lon, atol=dlon / 100) and
+            np.allclose(lat0 + lat_id * dlat, lat, atol=dlat / 100)):
+        raise InvalidWorkflowError(
+            'The climate grid points do not lie on a regular lon-lat grid '
+            f'(inferred spacing: {dlon} x {dlat}). This is not supported.')
+
+    # Number of longitudes of the (assumed global) grid, for the wrap-around
+    nlon = int(np.round(360 / dlon))
+
+    odf['lon_id'] = lon_id
+    odf['lat_id'] = lat_id
+    odf['unique_id'] = ['{:03d}_{:03d}'.format(i, j)
+                        for i, j in zip(lon_id, lat_id)]
+
+    # Numpy arrays - the grouping below is a hot loop
+    temp_bias = odf['temp_bias'].values.astype(float)
+    areas = odf['rgi_area_km2'].values.astype(float)
+    weights = 1 / odf['reference_mb_err'].values.astype(float)
+
+    # Positional indices of the glaciers in each grid point
+    groups = odf.groupby('unique_id').indices
+
+    log.workflow('compute_temp_bias_dataframe: inferred a {} x {} deg '
+                 'lon-lat climate grid, with {} grid points containing '
+                 'glaciers.'.format(dlon, dlat, len(groups)))
+
+    def _stats(sel):
+        """The three flavors of median for a selection of glaciers."""
+        return (np.median(temp_bias[sel]),
+                weighted_quantile_1d(temp_bias[sel], areas[sel], 0.5),
+                weighted_quantile_1d(temp_bias[sel], weights[sel], 0.5))
+
+    rows = []
+    for uid in sorted(groups.keys()):
+        sel = groups[uid]
+        s_lon_id, s_lat_id = lon_id[sel[0]], lat_id[sel[0]]
+        med, med_area, med_err = _stats(sel)
+
+        d = {'unique_id': uid,
+             'lon_id': s_lon_id,
+             'lat_id': s_lat_id,
+             'lon_val': lon[sel[0]],
+             'lat_val': lat[sel[0]],
+             'rgi_area_km2': areas[sel].sum(),
+             'n_glaciers': len(sel),
+             'median_temp_bias': med,
+             'median_temp_bias_w_area': med_area,
+             'median_temp_bias_w_err': med_err,
+             }
+
+        if len(sel) >= min_glaciers:
+            # Enough glaciers in this grid point - no grouping needed
+            d.update({'n_glaciers_grouped': len(sel),
+                      'search_radius': 0,
+                      'median_temp_bias_grouped': med,
+                      'median_temp_bias_w_area_grouped': med_area,
+                      'median_temp_bias_w_err_grouped': med_err,
+                      })
+            rows.append(d)
+            continue
+
+        # Grow a square search radius until we have enough glaciers
+        d_lat_id = np.abs(lat_id - s_lat_id)
+        d_lon_id = np.abs(lon_id - s_lon_id)
+        d_lon_id = np.minimum(d_lon_id, nlon - d_lon_id)  # wrap-around
+        radius = 1
+        while radius <= max_radius:
+            sel = np.nonzero((d_lon_id <= radius) & (d_lat_id <= radius))[0]
+            med_g, med_area_g, med_err_g = _stats(sel)
+            d.update({'n_glaciers_grouped': len(sel),
+                      'search_radius': radius,
+                      'median_temp_bias_grouped': med_g,
+                      'median_temp_bias_w_area_grouped': med_area_g,
+                      'median_temp_bias_w_err_grouped': med_err_g,
+                      })
+            if len(sel) >= min_glaciers:
+                break
+            radius += 1
+        rows.append(d)
+
+    mdf = pd.DataFrame(rows).set_index('unique_id')
+    mdf = mdf[TEMP_BIAS_FILE_COLUMNS]
+    for c in ['lon_id', 'lat_id', 'n_glaciers', 'n_glaciers_grouped',
+              'search_radius']:
+        mdf[c] = mdf[c].astype(int)
+
+    # Log a summary - this is the sanity check in the job log
+    counts = mdf['search_radius'].value_counts().sort_index()
+    log.workflow('compute_temp_bias_dataframe: number of grid points per '
+                 'search radius: {}'.format(counts.to_dict()))
+    qs = mdf['median_temp_bias_w_err_grouped'].quantile([0.1, 0.5, 0.9])
+    log.workflow('compute_temp_bias_dataframe: quantiles [0.1, 0.5, 0.9] of '
+                 'the final temperature bias: {}'
+                 ''.format(np.round(qs.values, 3).tolist()))
+
+    if path is not None:
+        mdf.to_csv(path)
+
+    if plot_path is not None:
+        _plot_temp_bias_dataframe(mdf, odf, plot_path,
+                                  dlon=dlon, dlat=dlat, lon0=lon0, lat0=lat0)
+
+    return mdf
+
+
+def _plot_temp_bias_dataframe(mdf, odf, plot_path, dlon=None, dlat=None,
+                              lon0=None, lat0=None):
+    """Diagnostic plots for `compute_temp_bias_dataframe`.
+
+    Writes `{plot_path}_map.png` and `{plot_path}_hist.png`.
+    """
+    import matplotlib.pyplot as plt
+
+    # Map of the final bias
+    nx = int(mdf['lon_id'].max()) + 1
+    ny = int(mdf['lat_id'].max()) + 1
+    data = np.full((ny, nx), np.nan)
+    data[mdf['lat_id'].values, mdf['lon_id'].values] = \
+        mdf['median_temp_bias_w_err_grouped'].values
+    extent = [lon0 - dlon / 2, lon0 + (nx - 0.5) * dlon,
+              lat0 - dlat / 2, lat0 + (ny - 0.5) * dlat]
+    vmax = np.nanpercentile(np.abs(data), 98)
+
+    f, ax = plt.subplots(figsize=(12, 6))
+    im = ax.imshow(data, origin='lower', extent=extent, cmap='RdBu_r',
+                   vmin=-vmax, vmax=vmax, interpolation='nearest')
+    f.colorbar(im, ax=ax, label='Temp bias (K)')
+    ax.set_xlabel('Longitude (deg)')
+    ax.set_ylabel('Latitude (deg)')
+    ax.set_title('Median temp bias per climate grid point '
+                 '(weighted by the MB error)')
+    f.savefig(f'{plot_path}_map.png', dpi=150, bbox_inches='tight')
+    plt.close(f)
+
+    # Histograms
+    f, axs = plt.subplots(2, 2, figsize=(12, 8))
+    odf['temp_bias'].plot.hist(bins=101, ax=axs[0, 0])
+    axs[0, 0].set_title('Per-glacier temp bias (K)')
+    odf['reference_mb_err'].plot.hist(bins=101, ax=axs[0, 1])
+    axs[0, 1].set_title('Reference MB error (kg m-2 yr-1)')
+    mdf['search_radius'].value_counts().sort_index().plot.bar(ax=axs[1, 0])
+    axs[1, 0].set_title('Grid points per search radius')
+    mdf['median_temp_bias_w_err_grouped'].plot.hist(bins=101, ax=axs[1, 1])
+    axs[1, 1].set_title('Final temp bias per grid point (K)')
+    f.tight_layout()
+    f.savefig(f'{plot_path}_hist.png', dpi=150, bbox_inches='tight')
+    plt.close(f)
 
 
 def extend_past_climate_run(past_run_file=None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ tests = [
 
 [project.scripts]
 oggm_prepro = "oggm.cli.prepro_levels:main"
+oggm_temp_bias = "oggm.cli.temp_bias:main"
 oggm_benchmark = "oggm.cli.benchmark:main"
 oggm_netrc_credentials = "oggm.cli.netrc_credentials:cli"
 "pytest.oggm" = "oggm.tests.__main__:main"


### PR DESCRIPTION
The temperature bias prior file used by the `informed_threestep` calibration
was, until now, produced by copy-pasting an exploratory notebook
(`prepare_bias_map.ipynb` and its many descendants) for each new setup. The
notebook had long lost its exploratory purpose: out of ~50 cells, only the csv
file and one map were ever used. This replaces it with a command.

### New workflow

```
1. the temp_melt preprocessing (one job per region)
oggm_prepro --temp-bias-run <all your usual options> --rgi-reg 01

2. summarize all the regions into the bias file (+ diagnostic plots)
oggm_temp_bias --input RGI62/b_080/L3/summary --output-file temp_bias_v2026.1.csv

3. copy it somewhere reachable, then use it for the real run
oggm_prepro --temp-bias-file-path <path or url> <your options>
```

### What's in here

- **`utils.compute_temp_bias_dataframe()`** does the work: drops glaciers whose
  calibration failed, fills missing MB errors with a quantile of the
  distribution, computes the three medians (plain / area-weighted /
  MB-error-weighted) per climate grid point, and grows a square search radius
  (with longitude wrap-around) for grid points holding fewer than
  `min_glaciers` glaciers. Output columns are identical to the current
  reference files. All the notebook's magic numbers are kwargs, defaulting to
  the notebook values.

- **The climate netCDF is no longer needed.** `glacier_statistics_*.csv`
  already carries `baseline_climate_ref_pix_lon` / `_lat` (via
  `get_climate_info()`), which is *exactly* the coordinate
  `mb_calibration_from_geodetic_mb` matches against, so the grid is
  reconstructed from the statistics file alone. This is what makes the command
  work with an arbitrary `--custom-climate-task` without the user having to
  know where the forcing file lives. Side effect: `lon_id`/`lat_id` (and hence
  `unique_id`) are now relative to the extent of the data instead of absolute
  indices into the climate file. Nothing reads them — the calibration matches
  on `lon_val`/`lat_val` and selects positionally — they are only used
  internally for the grouping and the map.

- **`oggm_temp_bias`** (new console script) wraps it, and writes `<stem>_map.png`
  and `<stem>_hist.png` next to the csv plus a summary in the log (glaciers
  used/dropped, inferred grid spacing, grid points per search radius, bias
  quantiles). Plots are plain matplotlib — no cartopy, which is an optional
  dependency.

- **`oggm_prepro --temp-bias-run`** is a preset for step 1: it forces the
  `temp_melt` strategy, `max_level=3` and `skip_inversion` (the inversion has
  no effect on the MB calibration — this is most of the runtime), writes no
  glacier directory tar files (they are thrown away anyway), and computes the
  bias file for that region at the end of L3. It logs everything it overrides.

- **`utils.weighted_quantile_1d()`**, the notebook's `quantile_1D`, promoted to
  a public utility next to `weighted_average_1d`.

### Note on the region split

The neighbour grouping crosses RGI region borders and wraps in longitude, so it
is only correct when applied to all regions at once. `--temp-bias-run` therefore
emits a warning next to its per-region file: for anything but a single-region
setup, `oggm_temp_bias` should be re-run over all the regions' statistics. That
is why the bias computation is its own command rather than only a prepro option.

### Tests

- `TestFuncs.test_weighted_quantile_1d`
- `TestTempBiasCLI`: arg parsing, file format and grouping invariants against a
  synthetic statistics file, dateline wrap-around, and the CLI writing csv +
  plots and round-tripping through `get_temp_bias_dataframe` and the
  nearest-pixel lookup.
- `TestTempBiasCLI.test_prepro_temp_bias_run` (slow) is the end-to-end one: a
  `--temp-bias-run` prepro on 3 Oetztal glaciers produces the file with no tars
  written, and feeding that file back in as `--temp-bias-file-path` for an
  `informed_threestep` run reproduces the prior to 1e-3.

- [x] Tests added/passed
- [x] Fully documented
- [x] Entry in `whats-new.rst`