### PR TITLE
delete hard coded melt_f values in run_prepro_levels

### DIFF
--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -341,16 +341,9 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
 
     # define the default melt_f depending on the the used mb_model_class
     if mb_model_class == 'MonthlyTIModel':
-        override_params['melt_f'] = 5.
         mb_model_class = MonthlyTIModel
         store_mb_diagnostics = False
     elif mb_model_class == 'SfcTypeTIModel':
-        # TODO: According to Schuster et al. (2023) Figure 1, the default melt_f
-        # should be larger when including snow tacking (around 6. to 7.). If we
-        # change this we also need to include this for the preparation of the
-        # three step calibration. Currently I stick to the same value as the
-        # MonthlyTIModel.
-        override_params['melt_f'] = 5.
         mb_model_class = SfcTypeTIModel
         store_mb_diagnostics = True
     else:


### PR DESCRIPTION
I recently added hard coded values for `melt_f` to `run_prepro_levels` to account for different default values for `MonthlyTIModel` and `SfcTypeTIModel`. However, this should not be hard coded but provided via `PARAMS.cfg`. For `SfcTypeTIModel` the default should be around 6 and for `MonthlyTIModel` around 5 (according to [Schuster et al. 2023](https://doi.org/10.1017/aog.2023.57)).

- [ ] Tests added/passed
- [ ] Fully documented
- [ ] Entry in `whats-new.rst` 
