### PR TITLE
Add RGI7 ref MB - explicit temp bias files

### DIFF
--- a/docs/reference-mass-balance-data.rst
+++ b/docs/reference-mass-balance-data.rst
@@ -87,6 +87,10 @@ You can access the table with:
     mbdf = utils.get_geodetic_mb_dataframe()
     mbdf.head()
 
+The table is indexed by glacier id, i.e. there is one file per RGI version:
+``get_geodetic_mb_dataframe`` selects it based on ``rgi_version`` (RGI6 per
+default, ``'70G'`` for RGI7G). RGI7C is not available yet.
+
 The data contains the climatic mass balance (in units meters water-equivalent per year)
 for three reference periods (2000-2010, 2010-2020, 2000-2020):
 

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -51,6 +51,31 @@ Enhancements
   arbitrary custom climate dataset instead of the hardcoded w5e5/era5 files
   (:pull:`1941`).
   By `Fabien Maussion <https://github.com/fmaussion>`_
+- **Breaking change**: the temperature-bias prior file of the
+  `informed_threestep` calibration is now always given explicitly. There is no
+  default file anymore: `utils.get_temp_bias_dataframe` takes a single
+  `file_path` argument (its `dataset`, `rgi_version` and `regional` arguments
+  are gone), and `mb_calibration_from_geodetic_mb` (hence `run_prepro_levels`
+  and ``oggm_prepro``) raises an error if `temp_bias_file_path` is not set.
+  The file has to match the setup it is used with, and it is created with a
+  `temp_bias_run` and the ``oggm_temp_bias`` command.
+  By `Fabien Maussion <https://github.com/fmaussion>`_
+- **Breaking change**: the regional mass balance calibration is removed. The
+  `use_regional_avg` keyword of `mb_calibration_from_geodetic_mb` and the
+  `_regional` suffix of the `run_prepro_levels` / ``oggm_prepro``
+  `mb_calibration_strategy` are gone: the calibration always uses the
+  glacier specific geodetic observations, and the temperature bias prior
+  always the `median_temp_bias_w_err_grouped` column of the prior file.
+  `utils.get_geodetic_mb_dataframe` loses its `regional` keyword as well: the
+  regional averages of the observations are not used by OGGM anymore.
+  By `Fabien Maussion <https://github.com/fmaussion>`_
+- `utils.get_geodetic_mb_dataframe` now selects the geodetic observations file
+  matching the RGI version (new `rgi_version` keyword, defaulting to
+  ``cfg.PARAMS['rgi_version']``): the observations are indexed by glacier id,
+  so RGI6 and RGI7G need different files. `mb_calibration_from_geodetic_mb`
+  passes the glacier's own RGI version, so RGI7G glacier directories now
+  calibrate on RGI7G observations out of the box. RGI7C is not available yet.
+  By `Fabien Maussion <https://github.com/fmaussion>`_
 - The temperature bias prior file used by the `informed_threestep` calibration
   can now be created from the command line, instead of with a notebook. The new
   ``oggm_temp_bias`` command (and the underlying

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -14,7 +14,7 @@ Enhancements
   By `Nicolas Gampierakis <https://github.com/gampnico>`_.
 - New global task ``calibrate_inversion_from_ref_table`` generalises
   ``calibrate_inversion_from_consensus`` to calibrate the ice thickness
-  inversion against an arbitrary reference volume table (given as a DataFrame, 
+  inversion against an arbitrary reference volume table (given as a DataFrame,
   a path or a URL). By default it now uses the IceBoost v2 products, with the
   RGI6 or RGI7 table selected automatically from the glacier directories.
   ``calibrate_inversion_from_consensus`` is deprecated but still available: it
@@ -51,30 +51,13 @@ Enhancements
   arbitrary custom climate dataset instead of the hardcoded w5e5/era5 files
   (:pull:`1941`).
   By `Fabien Maussion <https://github.com/fmaussion>`_
-- **Breaking change**: the temperature-bias prior file of the
-  `informed_threestep` calibration is now always given explicitly. There is no
-  default file anymore: `utils.get_temp_bias_dataframe` takes a single
-  `file_path` argument (its `dataset`, `rgi_version` and `regional` arguments
-  are gone), and `mb_calibration_from_geodetic_mb` (hence `run_prepro_levels`
-  and ``oggm_prepro``) raises an error if `temp_bias_file_path` is not set.
-  The file has to match the setup it is used with, and it is created with a
-  `temp_bias_run` and the ``oggm_temp_bias`` command.
-  By `Fabien Maussion <https://github.com/fmaussion>`_
-- **Breaking change**: the regional mass balance calibration is removed. The
-  `use_regional_avg` keyword of `mb_calibration_from_geodetic_mb` and the
-  `_regional` suffix of the `run_prepro_levels` / ``oggm_prepro``
-  `mb_calibration_strategy` are gone: the calibration always uses the
-  glacier specific geodetic observations, and the temperature bias prior
-  always the `median_temp_bias_w_err_grouped` column of the prior file.
-  `utils.get_geodetic_mb_dataframe` loses its `regional` keyword as well: the
-  regional averages of the observations are not used by OGGM anymore.
-  By `Fabien Maussion <https://github.com/fmaussion>`_
 - `utils.get_geodetic_mb_dataframe` now selects the geodetic observations file
   matching the RGI version (new `rgi_version` keyword, defaulting to
   ``cfg.PARAMS['rgi_version']``): the observations are indexed by glacier id,
   so RGI6 and RGI7G need different files. `mb_calibration_from_geodetic_mb`
   passes the glacier's own RGI version, so RGI7G glacier directories now
-  calibrate on RGI7G observations out of the box. RGI7C is not available yet.
+  calibrate on RGI7G observations out of the box. RGI7C is not available yet
+  (:pull:`1976`).
   By `Fabien Maussion <https://github.com/fmaussion>`_
 - The temperature bias prior file used by the `informed_threestep` calibration
   can now be created from the command line, instead of with a notebook. The new
@@ -98,8 +81,7 @@ Enhancements
   glaciers have no bias for their own grid point because it had to be grouped,
   which grid points are still below ``min_glaciers`` at the maximum search
   radius (with the largest ones listed), and the mean, standard deviation and
-  percentiles of all the bias columns. This is meant to be read after every run
-  - a temperature bias file without its summary cannot be judged.
+  percentiles of all the bias columns.
   By `Fabien Maussion <https://github.com/fmaussion>`_
 - Test durations are now visible in Actions logs (:pull:`1920`).
   By `Nicolas Gampierakis <https://github.com/gampnico>`_
@@ -273,6 +255,17 @@ Breaking changes
   wherever the parameters are, which is not what a parameter dict is for. The
   way to set them, ``cfg.set_intersects_db``, is unchanged, and so is
   ``cfg.PARAMS['use_intersects']`` (:pull:`1980`).
+  By `Fabien Maussion <https://github.com/fmaussion>`_
+- The temperature-bias prior file of the `informed_threestep` calibration
+  now always has to given explicitly. There is no
+  default file anymore: `utils.get_temp_bias_dataframe` takes a single
+  `file_path` argument and `mb_calibration_from_geodetic_mb` raises an error
+  if `temp_bias_file_path` is not set.
+  The file has to match the setup it is used with, and it is created with a
+  `temp_bias_run` and the ``oggm_temp_bias`` command (:pull:`1976`).
+  By `Fabien Maussion <https://github.com/fmaussion>`_
+- The regional mass balance calibration introduced in 163 is removed again.
+  It was useful as RGI7 calibration data was missing (:pull:`1976`).
   By `Fabien Maussion <https://github.com/fmaussion>`_
 - The default reference for RGI6 all initial glacier volumes is now
   IceBoost v2 - this replaces the previous consensus estimate (:pull:`1942`).

--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -179,18 +179,18 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
         - 'informed_threestep' (default)
         - 'melt_temp'
         - 'temp_melt'
-        Add the `_regional` suffix to use regional values instead,
-        for example `informed_threestep_regional`
     geodetic_mb_file_path : str
         optional path or URL to a custom geodetic MB file, passed to
         utils.get_geodetic_mb_dataframe and
         tasks.mb_calibration_from_geodetic_mb.
     temp_bias_file_path : str
-        optional path or URL to a custom temperature-bias file, passed to
-        tasks.mb_calibration_from_geodetic_mb (only used with the
-        'informed_threestep' calibration strategy). Use this together with a
-        `custom_climate_task` to calibrate on an arbitrary climate dataset.
-        The file must follow the same format as the default temp-bias files.
+        path or URL to the temperature-bias prior file, passed to
+        tasks.mb_calibration_from_geodetic_mb. Required by the
+        'informed_threestep' calibration strategy (and unused otherwise):
+        there is no default, the file has to match the setup it is used with
+        (climate dataset, RGI version, ...). It is created with a
+        `temp_bias_run` and the `oggm_temp_bias` command (see
+        utils.get_temp_bias_dataframe).
     select_source_from_dir : str
         if starting from a level 1 "ALL" or "STANDARD" DEM sources directory,
         select the chosen DEM source here. If you set it to "BY_RES" here,
@@ -293,7 +293,7 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
         skips everything which is of no use for this purpose: the glacier
         directory tar files, the climate statistics and the fixed geometry
         mass balance. `mb_calibration_strategy` has to be set explicitly to
-        `temp_melt` (or `temp_melt_regional`), an error is raised otherwise.
+        `temp_melt`, an error is raised otherwise.
         The only output is the L3 `glacier_statistics` file, which is then
         turned into the temperature bias file with the `oggm_temp_bias`
         command (the grouping of climate grid points crosses RGI region
@@ -303,18 +303,22 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
     # The temp bias preset overrides a couple of options. We log about it
     # further down, once cfg.initialize() has set the logging up.
     if temp_bias_run:
-        if not mb_calibration_strategy.startswith('temp_melt'):
+        if mb_calibration_strategy != 'temp_melt':
             raise InvalidParamsError(
                 'With `temp_bias_run`, the mass balance calibration strategy '
-                'has to be set explicitly to `temp_melt` (or to '
-                '`temp_melt_regional` for the regional flavor of the '
-                f'temperature bias file), not `{mb_calibration_strategy}`.')
+                'has to be set explicitly to `temp_melt`, not '
+                f'`{mb_calibration_strategy}`.')
         max_level = 3
         skip_inversion = True
 
     # Input check
     if max_level not in [1, 2, 3, 4, 5]:
         raise InvalidParamsError('max_level should be one of [1, 2, 3, 4, 5]')
+
+    if mb_calibration_strategy not in ['informed_threestep', 'melt_temp',
+                                       'temp_melt']:
+        raise InvalidParamsError('mb_calibration_strategy not understood: '
+                                 f'{mb_calibration_strategy}')
 
     if start_level is not None:
         if start_level not in [0, 1, 2, 3, 4]:
@@ -329,6 +333,16 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
                          'files we start from.')
     else:
         start_level = 0
+
+    # The mass balance is calibrated in L3 only
+    if (start_level <= 2 and max_level >= 3 and
+            mb_calibration_strategy == 'informed_threestep' and
+            temp_bias_file_path is None):
+        raise InvalidParamsError(
+            'The `informed_threestep` calibration strategy needs a temperature '
+            'bias prior file: set `temp_bias_file_path` to the file matching '
+            'your setup. Such a file is created with a `temp_bias_run` and '
+            'the `oggm_temp_bias` command.')
 
     if dynamic_spinup:
         if dynamic_spinup not in ['area/dmdtda', 'volume/dmdtda']:
@@ -828,17 +842,11 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
         else:
             workflow.execute_entity_task(tasks.process_climate_data, gdirs)
 
-        use_regional_avg = False
-        if '_regional' in mb_calibration_strategy:
-            use_regional_avg = True
-            mb_calibration_strategy = mb_calibration_strategy.replace('_regional', '')
-
         if mb_calibration_strategy == 'informed_threestep':
             workflow.execute_entity_task(tasks.mb_calibration_from_geodetic_mb,
                                          gdirs,
                                          informed_threestep=True,
                                          mb_model_class=mb_model_class,
-                                         use_regional_avg=use_regional_avg,
                                          file_path=geodetic_mb_file_path,
                                          temp_bias_file_path=temp_bias_file_path)
         elif mb_calibration_strategy == 'melt_temp':
@@ -847,7 +855,6 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
                                          calibrate_param1='melt_f',
                                          calibrate_param2='temp_bias',
                                          mb_model_class=mb_model_class,
-                                         use_regional_avg=use_regional_avg,
                                          file_path=geodetic_mb_file_path)
         elif mb_calibration_strategy == 'temp_melt':
             workflow.execute_entity_task(tasks.mb_calibration_from_geodetic_mb,
@@ -855,7 +862,6 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
                                          calibrate_param1='temp_bias',
                                          calibrate_param2='melt_f',
                                          mb_model_class=mb_model_class,
-                                         use_regional_avg=use_regional_avg,
                                          file_path=geodetic_mb_file_path)
         else:
             raise InvalidParamsError('mb_calibration_strategy not understood: '
@@ -1185,11 +1191,11 @@ def parse_args(args):
                              "(Farinotti et al. 2019, RGI62 only).")
     parser.add_argument('--mb-calibration-strategy', type=str,
                         default='informed_threestep',
-                        help='how to calibrate the massbalance. Currently one of '
-                             'informed_threestep (default) , melt_temp '
-                             'or temp_melt. Add the _regional suffix to '
-                             'use regional values instead, for example '
-                             'informed_threestep_regional')
+                        choices=['informed_threestep', 'melt_temp',
+                                 'temp_melt'],
+                        help='how to calibrate the massbalance. Currently one '
+                             'of informed_threestep (default), melt_temp '
+                             'or temp_melt.')
     parser.add_argument('--dem-source', type=str, default='',
                         help='which DEM source to use. Possible options are '
                              'the name of a specific DEM (e.g. RAMP, SRTM...) '
@@ -1300,18 +1306,22 @@ def parse_args(args):
                         help='optional path or URL to a custom geodetic MB '
                              'file passed to MB calibration.')
     parser.add_argument('--temp-bias-file-path', type=str, default=None,
-                        help='optional path or URL to a custom temperature-bias '
-                             'file passed to MB calibration (informed_threestep '
-                             'only). Use together with --custom-climate-task.')
+                        help='path or URL to the temperature-bias prior file '
+                             'passed to MB calibration. Required by the '
+                             'informed_threestep strategy (and unused '
+                             'otherwise): there is no default, the file has to '
+                             'match the setup it is used with. It is created '
+                             'with --temp-bias-run and the `oggm_temp_bias` '
+                             'command.')
     parser.add_argument('--temp-bias-run', nargs='?', const=True, default=False,
                         help='run the preprocessing needed to create the '
                              'temperature bias prior file. This forces '
                              '--max-level 3 and --skip-inversion, and writes '
                              'nothing but the L3 glacier statistics file. '
-                             'Requires --mb-calibration-strategy temp_melt '
-                             '(or temp_melt_regional). Feed the result to the '
-                             '`oggm_temp_bias` command (together with the '
-                             'other regions) to create the file.')
+                             'Requires --mb-calibration-strategy temp_melt. '
+                             'Feed the result to the `oggm_temp_bias` command '
+                             '(together with the other regions) to create the '
+                             'file.')
     parser.add_argument('--store-fl-diagnostics', nargs='?', const=True, default=False,
                         help="Also compute and store flowline diagnostics during "
                              "preprocessing. This can increase data usage quite "

--- a/oggm/cli/temp_bias.py
+++ b/oggm/cli/temp_bias.py
@@ -12,8 +12,6 @@ mass balance calibration. The full workflow to make one for a new setup is:
                    <all your other options> --rgi-reg 01
      $ ...  # one job per RGI region
 
-   (use `temp_melt_regional` instead to build the regional flavor of the file)
-
 2. summarize the per-glacier biases of all the regions per climate grid point.
    The grouping of grid points crosses RGI region borders, so this is always a
    separate step, run once over all the regions::

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -4388,7 +4388,6 @@ def mb_calibration_from_geodetic_mb(gdir, *,
                                     temp_bias_file_path=None,
                                     write_to_gdir=True,
                                     overwrite_gdir=False,
-                                    use_regional_avg=False,
                                     override_missing=None,
                                     use_2d_mb=False,
                                     informed_threestep=False,
@@ -4405,10 +4404,6 @@ def mb_calibration_from_geodetic_mb(gdir, *,
     values filtered. See this notebook* for more details.
 
     https://nbviewer.org/urls/cluster.klima.uni-bremen.de/~oggm/geodetic_ref_mb/convert_vold1.ipynb
-
-    This glacier-specific calibration can be replaced by a region-wide calibration
-    by using regional averages (same units: mm w.e.) instead of the glacier
-    specific averages.
 
     The problem of calibrating many unknown parameters on geodetic data is
     currently unsolved. This is OGGM's current take, based on trial and
@@ -4437,14 +4432,13 @@ def mb_calibration_from_geodetic_mb(gdir, *,
         the same format but can be any date.
     file_path : str, optional
         path or URL to a custom geodetic mass-balance file, passed to
-        utils.get_geodetic_mb_dataframe.
+        utils.get_geodetic_mb_dataframe. Per default, the file matching the
+        glacier's RGI version is used.
     temp_bias_file_path : str, optional
-        path or URL to a custom temperature-bias file, passed to
-        utils.get_temp_bias_dataframe. Only used with `informed_threestep`.
-        When set, it overrides the default w5e5/era5 file selection based on
-        the glacier's climate source, so it can be used together with an
-        arbitrary (custom) climate dataset. The file must follow the same
-        format as the default temp-bias files (check the format first!).
+        path or URL to the temperature-bias prior file, passed to
+        utils.get_temp_bias_dataframe. Required by `informed_threestep`
+        (and unused otherwise): there is no default, the file has to match
+        the setup it is used with (climate dataset, RGI version, ...).
     write_to_gdir : bool
         whether to write the results of the calibration to the glacier
         directory. If True (the default), this will be saved as `mb_calib.json`
@@ -4454,8 +4448,6 @@ def mb_calibration_from_geodetic_mb(gdir, *,
         if a `mb_calib.json` exists, this task won't overwrite it per default.
         Set this to True to enforce overwriting (i.e. with consequences for the
         future workflow).
-    use_regional_avg : bool
-        use the regional average instead of the glacier specific one.
     override_missing : scalar
         if the reference geodetic data is not available, use this value instead
         (mostly for testing with exotic datasets, but could be used to open
@@ -4501,27 +4493,18 @@ def mb_calibration_from_geodetic_mb(gdir, *,
 
         # Get the reference data
         ref_mb_err = np.nan
-        if use_regional_avg:
-            ref_mb_df_o = get_geodetic_mb_dataframe(file_path=file_path,
-                                                    regional=True)
-            ref_mb_df = ref_mb_df_o.loc[ref_mb_df_o.period == ref_mb_period].set_index('reg')
-            if len(ref_mb_df) == 0:
-                raise InvalidParamsError(f'Ref period {ref_mb_period} not found '
-                                         f'in file: {ref_mb_df_o.period.unique()}')
+        try:
+            ref_mb_df = get_geodetic_mb_dataframe(
+                file_path=file_path,
+                rgi_version=gdir.rgi_version).loc[gdir.rgi_id]
+            ref_mb_df = ref_mb_df.loc[ref_mb_df['period'] == ref_mb_period]
             # dmdtda: in meters water-equivalent per year -> we convert to kg m-2 yr-1
-            ref_mb = ref_mb_df.loc[int(gdir.rgi_region), 'dmdtda'] * 1000
-            ref_mb_err = ref_mb_df.loc[int(gdir.rgi_region), 'err_dmdtda'] * 1000
-        else:
-            try:
-                ref_mb_df = get_geodetic_mb_dataframe(file_path=file_path).loc[gdir.rgi_id]
-                ref_mb_df = ref_mb_df.loc[ref_mb_df['period'] == ref_mb_period]
-                # dmdtda: in meters water-equivalent per year -> we convert to kg m-2 yr-1
-                ref_mb = ref_mb_df['dmdtda'].iloc[0] * 1000
-                ref_mb_err = ref_mb_df['err_dmdtda'].iloc[0] * 1000
-            except KeyError:
-                if override_missing is None:
-                    raise
-                ref_mb = override_missing
+            ref_mb = ref_mb_df['dmdtda'].iloc[0] * 1000
+            ref_mb_err = ref_mb_df['err_dmdtda'].iloc[0] * 1000
+        except KeyError:
+            if override_missing is None:
+                raise
+            ref_mb = override_missing
 
         ref_mb_use = {
             'value': ref_mb,
@@ -4534,34 +4517,20 @@ def mb_calibration_from_geodetic_mb(gdir, *,
 
     temp_bias = 0
     if informed_threestep:
+        if temp_bias_file_path is None:
+            raise InvalidParamsError('`informed_threestep` needs a temperature '
+                                     'bias prior file: set `temp_bias_file_path` '
+                                     'to the file matching your setup (see '
+                                     'utils.get_temp_bias_dataframe).')
+        bias_df = get_temp_bias_dataframe(temp_bias_file_path)
         climinfo = gdir.get_climate_info()
-        climsource = climinfo['baseline_climate_source']
-        if temp_bias_file_path is not None:
-            bias_df = get_temp_bias_dataframe(file_path=temp_bias_file_path,
-                                              regional=use_regional_avg)
-        elif 'w5e5' in climsource.lower():
-            bias_df = get_temp_bias_dataframe('w5e5',
-                                              rgi_version=gdir.rgi_version,
-                                              regional=use_regional_avg)
-        elif 'era5' in climsource.lower():
-            bias_df = get_temp_bias_dataframe('era5',
-                                              rgi_version=gdir.rgi_version,
-                                              regional=use_regional_avg)
-        else:
-            raise InvalidWorkflowError('Dataset not suitable for '
-                                       f'informed 3-steps: {climsource}')
         ref_lon = climinfo['baseline_climate_ref_pix_lon']
         ref_lat = climinfo['baseline_climate_ref_pix_lat']
         # Take nearest
         dis = ((bias_df.lon_val - ref_lon)**2 + (bias_df.lat_val - ref_lat)**2)**0.5
         assert dis.min() < 1, 'Somethings wrong with lons'
         sel_df = bias_df.iloc[np.argmin(dis)]
-        # Which bias central value to use?
-        if use_regional_avg:
-            centralval = 'median_temp_bias_w_area_grouped'
-        else:
-            centralval = 'median_temp_bias_w_err_grouped'
-        temp_bias = sel_df[centralval]
+        temp_bias = sel_df['median_temp_bias_w_err_grouped']
         assert np.isfinite(temp_bias), 'Temp bias not finite?'
 
         if gdir.settings['prcp_fac'] is not None:

--- a/oggm/tests/__init__.py
+++ b/oggm/tests/__init__.py
@@ -9,6 +9,18 @@ from packaging.version import Version
 from oggm import cfg
 from oggm.utils import SAMPLE_DATA_COMMIT
 
+# The temperature bias prior file to use in the tests: this is the file the
+# OGGM v1.6 preprocessed directories were calibrated with (W5E5, RGI6). There
+# is no default in OGGM, it always has to be given explicitly.
+TEMP_BIAS_FILE_W5E5_RGI6 = ('https://cluster.klima.uni-bremen.de/~oggm/'
+                            'ref_mb_params/oggm_v1.6/'
+                            'w5e5_rgi6_perglacier_temp_bias_v2025.6.2.csv')
+
+# Regional averages of the geodetic observations. OGGM calibrates on the
+# per-glacier values only, but this is a useful reference in the tests.
+GEODETIC_MB_REGIONAL_AVG = ('https://cluster.klima.uni-bremen.de/~oggm/'
+                            'geodetic_ref_mb/hugonnet_2021_regional_avg.csv')
+
 # Some logic to see which environment we are running on
 
 # Matplotlib version changes plots, too

--- a/oggm/tests/test_benchmarks.py
+++ b/oggm/tests/test_benchmarks.py
@@ -447,14 +447,6 @@ class TestSouthGlacier(unittest.TestCase):
         df = utils.compile_fixed_geometry_mass_balance(gdirs)
         assert len(df) > 100
         df.columns = ['glacier']
-
-        # recalibrate with regio values
-        execute_entity_task(tasks.mb_calibration_from_geodetic_mb, gdirs,
-                            use_regional_avg=True,
-                            overwrite_gdir=True,
-                            ref_mb_period='2000-01-01_2005-01-01')
-        df['region'] = utils.compile_fixed_geometry_mass_balance(gdirs)['RGI60-01.16195']
-        assert 0.99 < df.corr().iloc[0, 1] < 1
         assert np.all(df.std() > 450)
 
         if do_plot:

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -25,6 +25,7 @@ from oggm.utils import _downloads
 from oggm import cfg
 from oggm.cfg import SEC_IN_YEAR
 from oggm.utils._workflow import compile_to_netcdf
+from oggm.tests import TEMP_BIAS_FILE_W5E5_RGI6, GEODETIC_MB_REGIONAL_AVG
 from oggm.tests.funcs import (get_test_dir, init_hef, TempEnvironmentVariable,
                               characs_apply_func)
 from oggm.utils import shape_factor_adhikari
@@ -1728,6 +1729,7 @@ class TestPreproCLI:
                           elev_bands=True,
                           mb_model_class=mb_model_class,
                           inversion_volume_dataset='consensus',
+                          temp_bias_file_path=TEMP_BIAS_FILE_W5E5_RGI6,
                           continue_on_error=False,
                           override_params={}
                           )
@@ -1763,7 +1765,7 @@ class TestPreproCLI:
         odf['AREA'] = df.rgi_area_km2
         smb_oggm = np.average(odf['SMB'], weights=odf['AREA'])
 
-        dfh = utils.get_geodetic_mb_dataframe(regional=True)
+        dfh = pd.read_csv(utils.file_downloader(GEODETIC_MB_REGIONAL_AVG))
         dfh = dfh.loc[dfh.period == '2000-01-01_2020-01-01'].set_index('reg')
         smb_ref = dfh.loc[11, 'dmdtda'] * 1000
         np.testing.assert_allclose(smb_oggm, smb_ref, atol=200)  # Whole Alps
@@ -1890,6 +1892,7 @@ class TestPreproCLI:
                           elev_bands=True,
                           max_level=3,
                           inversion_volume_dataset='consensus',
+                          temp_bias_file_path=TEMP_BIAS_FILE_W5E5_RGI6,
                           add_distributed_thickness=True,
                           add_export_thickness_geotiff=True,
                           continue_on_error=False,
@@ -1953,6 +1956,7 @@ class TestPreproCLI:
                           elev_bands=True,
                           max_level=4,
                           inversion_volume_dataset='consensus',
+                          temp_bias_file_path=TEMP_BIAS_FILE_W5E5_RGI6,
                           store_hydro_output=True,
                           store_monthly_hydro=True,
                           ref_area_yr=2000,
@@ -2036,7 +2040,7 @@ class TestPreproCLI:
         odf['AREA'] = df.rgi_area_km2
         smb_oggm = np.average(odf['SMB'], weights=odf['AREA'])
 
-        dfh = utils.get_geodetic_mb_dataframe(regional=True)
+        dfh = pd.read_csv(utils.file_downloader(GEODETIC_MB_REGIONAL_AVG))
         dfh = dfh.loc[dfh.period == '2000-01-01_2020-01-01'].set_index('reg')
         smb_ref = dfh.loc[11, 'dmdtda'] * 1000
         np.testing.assert_allclose(smb_oggm, smb_ref, atol=150)  # Whole Alps
@@ -2459,6 +2463,7 @@ class TestPreproCLI:
                           rgi_file=rgidf, intersects_file=inter,
                           logging_level='INFO',
                           inversion_volume_dataset='consensus',
+                          temp_bias_file_path=TEMP_BIAS_FILE_W5E5_RGI6,
                           test_topofile=topof, dem_source='ALL')
 
         rid = rgidf.iloc[0].RGIId
@@ -2767,6 +2772,12 @@ class TestTempBiasCLI:
             run_prepro_levels(rgi_version='61', rgi_reg='11', border=20,
                               output_folder=odir, working_dir=wdir,
                               temp_bias_run=True,
+                              mb_calibration_strategy='informed_threestep')
+
+        # And informed_threestep needs the file we are about to create
+        with pytest.raises(InvalidParamsError):
+            run_prepro_levels(rgi_version='61', rgi_reg='11', border=20,
+                              output_folder=odir, working_dir=wdir,
                               mb_calibration_strategy='informed_threestep')
 
         # The statistics file is the only thing this run is good for
@@ -3548,6 +3559,21 @@ class TestDataFiles(unittest.TestCase):
         with pytest.warns(DeprecationWarning, match="hdf"):
             df = _downloads.get_dataframe_from_file(hdf_path)
         pd.testing.assert_frame_equal(df, df_orig)
+
+    @pytest.mark.slow
+    def test_get_geodetic_mb_dataframe(self):
+
+        df = utils.get_geodetic_mb_dataframe(rgi_version='62')
+        assert df.index[0].startswith('RGI60-')
+        # RGI6 is the default
+        assert cfg.PARAMS['rgi_version'] == '62'
+        assert utils.get_geodetic_mb_dataframe().index[0].startswith('RGI60-')
+
+        df = utils.get_geodetic_mb_dataframe(rgi_version='70G')
+        assert df.index[0].startswith('RGI2000-v7.0-G-')
+
+        with pytest.raises(NotImplementedError):
+            utils.get_geodetic_mb_dataframe(rgi_version='70C')
 
     def test_srtmzone(self):
 

--- a/oggm/tests/test_workflow.py
+++ b/oggm/tests/test_workflow.py
@@ -20,7 +20,7 @@ import oggm
 import oggm.cfg as cfg
 from oggm import workflow
 from oggm.utils import get_demo_file, write_centerlines_to_shape, ModelSettings
-from oggm.tests import mpl_image_compare
+from oggm.tests import mpl_image_compare, TEMP_BIAS_FILE_W5E5_RGI6
 from oggm.tests.funcs import get_test_dir, use_multiprocessing, characs_apply_func
 from oggm.shop import cru
 from oggm.core import flowline, gis, inversion, centerlines, massbalance
@@ -31,7 +31,7 @@ from oggm.core.massbalance import (MonthlyTIModel, MultipleFlowlineMassBalance,
 from oggm.core.flowline import (run_from_climate_data, run_random_climate,
                                 init_present_time_glacier, run_constant_climate, MixedBedFlowline)
 from oggm.core.inversion import get_inversion_volume
-from oggm.exceptions import InvalidWorkflowError
+from oggm.exceptions import InvalidWorkflowError, InvalidParamsError
 
 # Globals
 pytestmark = pytest.mark.test_env("workflow")
@@ -702,6 +702,7 @@ class TestGdirSettings:
                                      gdirs,
                                      overwrite_gdir=True,
                                      informed_threestep=True,
+                                     temp_bias_file_path=TEMP_BIAS_FILE_W5E5_RGI6,
                                      settings_filesuffix='_informed_threestep',
                                      )
         mb_calib_threestep = gdirs[0].read_yml('settings',
@@ -716,6 +717,15 @@ class TestGdirSettings:
                         mb_calib_threestep['temp_bias'],
                         atol=6e-2)
 
+        # the temp bias prior file is not optional
+        with pytest.raises(InvalidParamsError):
+            tasks.mb_calibration_from_geodetic_mb(
+                gdir,
+                overwrite_gdir=True,
+                informed_threestep=True,
+                settings_filesuffix='_informed_threestep',
+            )
+
         # recalibration without overwrite_gdir should raise an error
         prcp_fac_original = settings_informed_threestep['prcp_fac']
         with pytest.raises(InvalidWorkflowError):
@@ -724,6 +734,7 @@ class TestGdirSettings:
                                          gdirs,
                                          overwrite_gdir=False,
                                          informed_threestep=True,
+                                         temp_bias_file_path=TEMP_BIAS_FILE_W5E5_RGI6,
                                          settings_filesuffix='_informed_threestep',
                                          )
 
@@ -1010,6 +1021,7 @@ class TestGdirObservations:
                                      gdirs,
                                      overwrite_gdir=True,
                                      informed_threestep=True,
+                                     temp_bias_file_path=TEMP_BIAS_FILE_W5E5_RGI6,
                                      settings_filesuffix='_informed_threestep',
                                      )
         # check that observation was added to the observation files and that the
@@ -1039,6 +1051,7 @@ class TestGdirObservations:
                                      gdirs,
                                      overwrite_gdir=True,
                                      informed_threestep=True,
+                                     temp_bias_file_path=TEMP_BIAS_FILE_W5E5_RGI6,
                                      settings_filesuffix='_informed_threestep',
                                      observations_filesuffix='_hugonnet_adapted',
                                      use_observations_file=True,

--- a/oggm/utils/_downloads.py
+++ b/oggm/utils/_downloads.py
@@ -1260,7 +1260,7 @@ def get_dataframe_from_file(file_path: Path | str, **kwargs) -> pd.DataFrame:
     return df
 
 
-def get_geodetic_mb_dataframe(file_path=None, regional=False):
+def get_geodetic_mb_dataframe(file_path=None, rgi_version=None):
     """Fetches the reference geodetic dataframe for calibration.
 
     Currently that's the data from Hughonnet et al 2021, corrected for
@@ -1268,13 +1268,17 @@ def get_geodetic_mb_dataframe(file_path=None, regional=False):
     available at
     https://nbviewer.jupyter.org/urls/cluster.klima.uni-bremen.de/~oggm/geodetic_ref_mb/convert.ipynb
 
+    The data is indexed by glacier id, i.e. there is one file per RGI version.
+
     Parameters
     ----------
     file_path : str
         in case you have your own file to parse (check the format first!).
-        Can be a url as well
-    regional : bool
-        to fetch the regional file instead - this is a different format!
+        Can be a url as well. If provided, `rgi_version` is ignored.
+    rgi_version : str
+        the RGI version to fetch the file for: '62' (or the equivalent '60',
+        '61') or '70G'. RGI70C is not available yet. Defaults to the one
+        specified in cfg.PARAMS.
 
     Returns
     -------
@@ -1283,13 +1287,21 @@ def get_geodetic_mb_dataframe(file_path=None, regional=False):
 
     # fetch the file online or read custom file
     if file_path is None:
-        base_url = 'https://cluster.klima.uni-bremen.de/~oggm/geodetic_ref_mb/'
-        if regional:
-            file_name = 'hugonnet_2021_regional_avg.csv'
-            file_path = file_downloader(base_url + file_name)
+        if rgi_version is None:
+            rgi_version = cfg.PARAMS['rgi_version']
+
+        if rgi_version in ['60', '61', '62']:
+            rgi_str = 'rgi60'
+        elif rgi_version == '70G':
+            rgi_str = 'rgi70G'
         else:
-            file_name = 'hugonnet_2021_ds_rgi60_pergla_rates_10_20_worldwide_filled.parquet'
-            file_path = file_downloader(base_url + file_name)
+            raise NotImplementedError('No geodetic mass balance data available '
+                                      f'for RGI version: {rgi_version}')
+
+        base_url = 'https://cluster.klima.uni-bremen.de/~oggm/geodetic_ref_mb/'
+        file_name = (f'hugonnet_2021_ds_{rgi_str}_pergla_rates_10_20_'
+                     'worldwide_filled.parquet')
+        file_path = file_downloader(base_url + file_name)
 
     if file_path.startswith('http'):
         file_path = file_downloader(file_path)
@@ -1310,67 +1322,33 @@ def get_geodetic_mb_dataframe(file_path=None, regional=False):
     return df
 
 
-def get_temp_bias_dataframe(dataset=None, regional=False, rgi_version='62',
-                            file_path=None):
-    """Fetches the temperature bias dataframe.
+def get_temp_bias_dataframe(file_path):
+    """Reads the temperature bias dataframe used by `informed_threestep`.
 
-    The dataframe was created by the OGGM>=v16 pre-calibration
-    (further explained in the `OGGM mass balance tutorial <https://tutorials.oggm.org/stable/notebooks/tutorials/massbalance_calibration.html>`_
+    There is no default file: it has to be created for the exact setup it is
+    used with (climate dataset, RGI version, OGGM version...), and its path
+    given explicitly. To create such a file, run the preprocessing with the
+    `temp_melt` calibration strategy (``oggm_prepro --temp-bias-run``) and
+    summarize its glacier statistics with the ``oggm_temp_bias`` command (see
+    :py:func:`utils.compute_temp_bias_dataframe`). The method is further
+    explained in the `OGGM mass balance tutorial <https://tutorials.oggm.org/stable/notebooks/tutorials/massbalance_calibration.html>`_.
 
-    To create such a file yourself (e.g. for a custom climate dataset), run the
-    preprocessing with the `temp_melt` calibration strategy
-    (``oggm_prepro --temp-bias-run``) and summarize its glacier statistics with
-    the ``oggm_temp_bias`` command (see
-    :py:func:`utils.compute_temp_bias_dataframe`).
-
-    The file differs between climate datasets and OGGM versions. For W5E5 and OGGM v162, it is e.g.
-    https://cluster.klima.uni-bremen.de/~oggm/ref_mb_params/oggm_v1.6/w5e5_temp_bias_v2023.4.csv
+    The files used by the OGGM preprocessed directories are available on the
+    cluster, e.g. for W5E5 and RGI6:
+    https://cluster.klima.uni-bremen.de/~oggm/ref_mb_params/oggm_v1.6/w5e5_rgi6_perglacier_temp_bias_v2025.6.2.csv
 
     Parameters
     ----------
-    dataset : str
-        climate dataset used to choose temperature bias dataframe
-        (currently only w5e5 and era5 are available). Ignored if `file_path`
-        is provided.
-    regional : bool
-        fetch the regional file instead of the per-glacier one. Ignored if
-        `file_path` is provided.
-    rgi_version : str
-        the RGI version to fetch the file for. Ignored if `file_path` is
-        provided.
     file_path : str
-        in case you have your own file to parse (check the format first!).
-        Can be a url as well. If provided, `dataset`, `regional` and
-        `rgi_version` are ignored for fetching the file.
+        path to the temperature bias file (check the format first!).
+        Can be a url as well.
 
     Returns
     -------
     a DataFrame with the data.
     """
 
-    if file_path is None:
-        if dataset not in ['w5e5', 'era5']:
-            raise NotImplementedError(f'No such dataset available yet: {dataset}')
-        if rgi_version == '60':
-            rgi_version = '62'
-        if rgi_version not in ['62', '70G', '70C']:
-            raise NotImplementedError(f'RGI version not available yet: {rgi_version}')
-
-        # fetch the file online
-        base_url = 'https://cluster.klima.uni-bremen.de/~oggm/ref_mb_params/oggm_v1.6/'
-        calibtype = 'regional' if regional else 'perglacier'
-        if rgi_version in ['70G', '70C']:
-            file_version = '1'
-        if rgi_version == '62':
-            file_version = '3' if regional else '2'
-            rgi_version = '6'
-        if dataset == 'w5e5':
-            base_url += f'w5e5_rgi{rgi_version}_{calibtype}_temp_bias_v2025.6.{file_version}.csv'
-        if dataset == 'era5':
-            base_url += f'era5_rgi{rgi_version}_{calibtype}_temp_bias_v2025.6.{file_version}.csv'
-
-        file_path = file_downloader(base_url)
-    elif file_path.startswith('http'):
+    if file_path.startswith('http'):
         file_path = file_downloader(file_path)
 
     # Did we open it yet?


### PR DESCRIPTION
Three breaking changes to how the MB calibration gets its reference data.

### 1. The temperature bias prior file is always explicit

The old code guessed a URL from climate dataset + RGI version + regional flag. That default is silently wrong for any setup other than the one the file was made for (which is more likely now that the file can be generated per run: #1973).

- `utils.get_temp_bias_dataframe(file_path)`: one argument, no default file, no URL logic.
- `informed_threestep` raises if `temp_bias_file_path` is not set. `run_prepro_levels` checks this up front, not once per glacier in L3.

Migration: pass the file you calibrated against, `oggm_prepro --temp-bias-file-path <path or url> ...`. The cluster files are unchanged, e.g. `w5e5_rgi6_perglacier_temp_bias_v2025.6.2.csv` for W5E5 + RGI6 for the previous OGGM versions.

### 2. Regional calibration removed

- `use_regional_avg` is gone from `mb_calibration_from_geodetic_mb`; always glacier-specific observations.
- The `_regional` strategy suffix is gone (`informed_threestep_regional` etc.); `--mb-calibration-strategy` now has explicit choices, validated up front.
- The prior always reads `median_temp_bias_w_err_grouped`.
- `get_geodetic_mb_dataframe` loses `regional`. The regional csv stays on the cluster, OGGM just has no API for it.

### 3. Geodetic observations per RGI version

The observations are indexed by glacier id, so RGI6 and RGI7G need different files. New `rgi_version` argument (defaults to `cfg.PARAMS['rgi_version']`):

- `'50'`/`'60'`/`'61'`/`'62'` → `hugonnet_2021_ds_rgi60_...parquet` (unchanged)
- `'70G'` → `hugonnet_2021_ds_rgi70G_...parquet`
- anything else, incl. `'70C'` → `NotImplementedError` (no product yet)

`mb_calibration_from_geodetic_mb` passes `gdir.rgi_version`, so **RGI7G directories now calibrate on RGI7G observations out of the box** — before, they hit the RGI6 table and raised `KeyError`.


- [ ] Tests added/passed
- [ ] Fully documented
- [ ] Entry in `whats-new.rst` 
