### PR TITLE
run_* tasks do not return model objects when run with execute_entity_task

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -209,15 +209,11 @@ Bug fixes
   longer silently calving with the default configuration. ``do_calving`` is now
   also ignored for non-tidewater glaciers (:pull:`1961`).
   By `Nicolas Gampierakis <https://github.com/gampnico>`_.
-- ``workflow.execute_entity_task`` no longer collects the model objects
-  returned by the ``run_*`` tasks. With multiprocessing these were pickled
-  back to the main process and kept in a list with one entry per glacier,
-  which nothing ever used but which was enough to run the main process out of
-  memory on large RGI regions - dramatically so with ``SfcTypeTIModel``, whose
-  models carry the full mass balance history. Entity tasks can now declare
-  ``@entity_task(log, workflow_return_value=False)``, which
-  ``execute_entity_task`` honours unless the caller passes ``return_value=True``
-  explicitly. Calling the tasks directly is unaffected (:pull:`1976`).
+- Entity tasks can now declare ``@entity_task(log, workflow_return_value=False)``,
+  which leads to ``execute_entity_task`` discarding the tasks output when
+  multiprocessing. The caller can still pass ``return_value=True`` explicitly, and
+  calling the tasks directly is unaffected. This has been applied to all
+  "run_*" tasks to avoid memory issues (see "breaking changes") (:pull:`1977`).
   By `Fabien Maussion <https://github.com/fmaussion>`_
 
 Breaking changes
@@ -291,6 +287,12 @@ Breaking changes
 - Renamed ``rho`` to ``ice_density`` at several locations, to not get confused
   with ``snow_density``, intoduced with ``SfcTypeTIModel`` (:pull:`1899`).
   By `Patrick Schmitt <https://github.com/pat-schmitt>`_
+- ``workflow.execute_entity_task`` no longer collects the model objects
+  returned by the ``run_*`` tasks. With multiprocessing this would
+  run the main process out of memory on large RGI regions (:pull:`1977`).
+  By `Fabien Maussion <https://github.com/fmaussion>`_
+
+
 
 v1.6.3 (April 13, 2026)
 -----------------------

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -209,6 +209,16 @@ Bug fixes
   longer silently calving with the default configuration. ``do_calving`` is now
   also ignored for non-tidewater glaciers (:pull:`1961`).
   By `Nicolas Gampierakis <https://github.com/gampnico>`_.
+- ``workflow.execute_entity_task`` no longer collects the model objects
+  returned by the ``run_*`` tasks. With multiprocessing these were pickled
+  back to the main process and kept in a list with one entry per glacier,
+  which nothing ever used but which was enough to run the main process out of
+  memory on large RGI regions - dramatically so with ``SfcTypeTIModel``, whose
+  models carry the full mass balance history. Entity tasks can now declare
+  ``@entity_task(log, workflow_return_value=False)``, which
+  ``execute_entity_task`` honours unless the caller passes ``return_value=True``
+  explicitly. Calling the tasks directly is unaffected (:pull:`1976`).
+  By `Fabien Maussion <https://github.com/fmaussion>`_
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/oggm/core/dynamic_spinup.py
+++ b/oggm/core/dynamic_spinup.py
@@ -28,7 +28,7 @@ from oggm.core.flowline import (decide_evolution_model, FileModel,
 log = logging.getLogger(__name__)
 
 
-@entity_task(log)
+@entity_task(log, workflow_return_value=False)
 def run_dynamic_spinup(gdir, settings_filesuffix='',
                        observations_filesuffix='', overwrite_observations=False,
                        target_yr=None, target_value=None,
@@ -1939,7 +1939,8 @@ def dynamic_melt_f_run_fallback(
     return model
 
 
-@entity_task(log, writes=['inversion_flowlines'])
+@entity_task(log, writes=['inversion_flowlines'],
+             workflow_return_value=False)
 def run_dynamic_melt_f_calibration(
         gdir, settings_filesuffix='', observations_filesuffix='',
         overwrite_observations=False,

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -3826,7 +3826,7 @@ def decide_evolution_model(gdir=None, evolution_model=None):
     return evolution_model
 
 
-@entity_task(log)
+@entity_task(log, workflow_return_value=False)
 def flowline_model_run(gdir, settings_filesuffix='',
                        output_filesuffix=None, mb_model=None,
                        ys=None, ye=None, zero_initial_glacier=False,
@@ -4055,7 +4055,7 @@ def flowline_model_run(gdir, settings_filesuffix='',
     return model
 
 
-@entity_task(log)
+@entity_task(log, workflow_return_value=False)
 def run_random_climate(gdir, settings_filesuffix='',
                        nyears=1000, y0=None, halfsize=15,
                        ys=None, ye=None,
@@ -4191,7 +4191,7 @@ def run_random_climate(gdir, settings_filesuffix='',
                               **kwargs)
 
 
-@entity_task(log)
+@entity_task(log, workflow_return_value=False)
 def run_constant_climate(gdir, settings_filesuffix='',
                          nyears=1000, y0=None, halfsize=15,
                          ys=None, ye=None,
@@ -4315,7 +4315,7 @@ def run_constant_climate(gdir, settings_filesuffix='',
                               **kwargs)
 
 
-@entity_task(log)
+@entity_task(log, workflow_return_value=False)
 def run_from_climate_data(gdir, settings_filesuffix='',
                           ys=None, ye=None, min_ys=None, max_ys=None,
                           fixed_geometry_spinup_yr=None,

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -2634,6 +2634,9 @@ class TestMassBalanceModels:
         dyn_models = workflow.execute_entity_task(
             tasks.run_dynamic_melt_f_calibration,
             gdir,
+            # the run_* tasks don't return their model through the workflow
+            # per default (memory), here we do want it for the checks below
+            return_value=True,
             ys=1979,
             ye=gdir.get_climate_info()['baseline_yr_1'] + 1,
             ignore_errors=True,

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -1,5 +1,6 @@
 import unittest
 import glob
+import logging
 import os
 import shutil
 import subprocess
@@ -62,6 +63,19 @@ def clean_dir(testdir):
 def _read_prcp_fac(gdir):
     # module-level so it can be pickled and sent to multiprocessing workers
     return gdir.settings['prcp_fac']
+
+
+# module-level so they can be pickled and sent to multiprocessing workers
+@utils.entity_task(logging.getLogger(__name__), workflow_return_value=False)
+def _task_with_costly_return(gdir):
+    """Dummy task standing in for the run_* tasks."""
+    return np.zeros(10)
+
+
+@utils.entity_task(logging.getLogger(__name__))
+def _task_with_cheap_return(gdir):
+    """Dummy task whose return value is worth collecting."""
+    return gdir.rgi_id
 
 
 class TestFuncs(object):
@@ -967,6 +981,60 @@ class TestWorkflowTools(unittest.TestCase):
 
         # set prcp_fac back for other tests
         gdir.settings['prcp_fac'] = orig_prcp_fac
+
+    def test_workflow_return_value(self):
+        # tasks flagged with workflow_return_value=False must not have their
+        # return value collected by execute_entity_task - with
+        # multiprocessing this is what gets pickled back to the main process
+        # and kept, one per glacier, until the whole region is done
+        gdir = init_hef()
+
+        assert _task_with_costly_return.workflow_return_value is False
+        assert _task_with_cheap_return.workflow_return_value is True
+
+        # a direct call is unaffected by the flag
+        assert_array_equal(_task_with_costly_return(gdir), np.zeros(10))
+
+        # the outcome must not depend on multiprocessing being used or not
+        for use_mp in [False, True]:
+            cfg.PARAMS['use_multiprocessing'] = use_mp
+            cfg.PARAMS['mp_processes'] = 2
+            cfg.PARAMS['use_mp_spawn'] = False
+
+            # the flagged task returns nothing through the workflow...
+            out = workflow.execute_entity_task(_task_with_costly_return,
+                                               [gdir, gdir])
+            assert out == [None, None]
+
+            # ...but the caller can still ask for the values explicitly
+            out = workflow.execute_entity_task(_task_with_costly_return,
+                                               [gdir, gdir],
+                                               return_value=True)
+            assert len(out) == 2
+            assert_array_equal(out[0], np.zeros(10))
+
+            # unflagged tasks keep returning their values
+            out = workflow.execute_entity_task(_task_with_cheap_return,
+                                               [gdir, gdir])
+            assert out == [gdir.rgi_id, gdir.rgi_id]
+
+    def test_run_tasks_do_not_return_models_to_the_workflow(self):
+        # the run_* tasks return the full model (flowlines and mass balance
+        # model included). Collecting one per glacier is what made large
+        # regions run out of memory, see
+        # https://github.com/OGGM/oggm/issues/1976
+        from oggm.core.dynamic_spinup import (run_dynamic_spinup,
+                                              run_dynamic_melt_f_calibration)
+        for task in [flowline.flowline_model_run,
+                     flowline.run_random_climate,
+                     flowline.run_constant_climate,
+                     flowline.run_from_climate_data,
+                     run_dynamic_spinup,
+                     run_dynamic_melt_f_calibration]:
+            assert task.workflow_return_value is False, task.__name__
+
+        # the default is unchanged for everything else
+        assert tasks.glacier_masks.workflow_return_value is True
 
 
 class TestWorkflowUtils:

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -438,7 +438,8 @@ class entity_task(object):
     exceptions, logging, and (some day) database for job-controlling.
     """
 
-    def __init__(self, log, writes=[], fallback=None):
+    def __init__(self, log, writes=[], fallback=None,
+                 workflow_return_value=True):
         """Decorator syntax: ``@entity_task(log, writes=['dem', 'outlines'])``
 
         Parameters
@@ -450,15 +451,22 @@ class entity_task(object):
             available in ``cfg.BASENAMES``)
         fallback: python function
             will be executed on gdir if entity_task fails
-        return_value: bool
-            whether the return value from the task should be passed over
-            to the caller or not. In general you will always want this to
-            be true, but sometimes the task return things which are not
-            useful in production and my use a lot of memory, etc,
+        workflow_return_value: bool
+            whether ``workflow.execute_entity_task`` collects the return
+            value of this task. Set this to False for tasks returning objects
+            which are not useful in production but use a lot of memory (the
+            model objects returned by the ``run_*`` tasks, for example): with
+            multiprocessing these are pickled back to the main process and
+            kept in a list of one element per glacier, which is enough to
+            blow up the memory of large regions. Calling the task directly
+            (``tasks.run_random_climate(gdir)``) is unaffected by this, and
+            callers of ``execute_entity_task`` can still ask for the values
+            explicitly with ``return_value=True``.
         """
         self.log = log
         self.writes = writes
         self.fallback = fallback
+        self.workflow_return_value = workflow_return_value
 
         cnt = ['    Notes']
         cnt += ['    -----']
@@ -546,6 +554,10 @@ class entity_task(object):
                 return out
 
         _entity_task.__dict__['is_entity_task'] = True
+        # read by workflow.execute_entity_task to decide whether the return
+        # values are worth shipping back to the main process (see __init__)
+        _entity_task.__dict__['workflow_return_value'] = \
+            self.workflow_return_value
         # adds the possibility to use a function, decorated as entity_task,
         # without its decoration.
         _entity_task.unwrapped = task_func

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -455,13 +455,10 @@ class entity_task(object):
             whether ``workflow.execute_entity_task`` collects the return
             value of this task. Set this to False for tasks returning objects
             which are not useful in production but use a lot of memory (the
-            model objects returned by the ``run_*`` tasks, for example): with
-            multiprocessing these are pickled back to the main process and
-            kept in a list of one element per glacier, which is enough to
-            blow up the memory of large regions. Calling the task directly
-            (``tasks.run_random_climate(gdir)``) is unaffected by this, and
-            callers of ``execute_entity_task`` can still ask for the values
-            explicitly with ``return_value=True``.
+            model objects returned by the ``run_*`` tasks, for example).
+            Calling the task directly (``tasks.run_random_climate(gdir)``)
+            is unaffected by this, and callers of ``execute_entity_task``
+            can still ask for the values explicitly with ``return_value=True``.
         """
         self.log = log
         self.writes = writes
@@ -556,8 +553,7 @@ class entity_task(object):
         _entity_task.__dict__['is_entity_task'] = True
         # read by workflow.execute_entity_task to decide whether the return
         # values are worth shipping back to the main process (see __init__)
-        _entity_task.__dict__['workflow_return_value'] = \
-            self.workflow_return_value
+        _entity_task.__dict__['workflow_return_value'] = self.workflow_return_value
         # adds the possibility to use a function, decorated as entity_task,
         # without its decoration.
         _entity_task.unwrapped = task_func

--- a/oggm/workflow.py
+++ b/oggm/workflow.py
@@ -163,6 +163,10 @@ def execute_entity_task(task, gdirs, **kwargs):
     Returns
     -------
     List of results from task. Last task if a list of tasks was given.
+    Tasks declared with ``@entity_task(log, workflow_return_value=False)``
+    (the ``run_*`` tasks, whose model objects are expensive to keep around)
+    return a list of ``None`` instead - pass ``return_value=True`` to get
+    them anyway.
     """
 
     # Normalize task into list of tuples for simplicity
@@ -180,6 +184,23 @@ def execute_entity_task(task, gdirs, **kwargs):
         if t[0].__dict__.get('is_global_task', False):
             raise InvalidWorkflowError('execute_entity_task cannot be used on '
                                        'global tasks.')
+
+    # Some tasks return objects which are useless here but expensive to keep
+    # around (the run_* tasks return the full model, mass balance model
+    # included). With multiprocessing these are pickled back to the main
+    # process and stored in a list of one element per glacier - for large
+    # regions this alone is enough to run out of memory. Unless the caller
+    # explicitly asked for the values, we tell those tasks not to return
+    # anything. This is decided per task and applied with and without
+    # multiprocessing, so that the outcome does not depend on it.
+    if 'return_value' not in kwargs:
+        for i, (t, t_kwargs) in enumerate(tasks):
+            if getattr(t, 'workflow_return_value', True):
+                continue
+            if 'return_value' in t_kwargs:
+                continue
+            # copy: the dict may belong to the caller
+            tasks[i] = (t, _merge_dicts(t_kwargs, {'return_value': False}))
 
     # Should be iterable
     gdirs = utils.tolist(gdirs)


### PR DESCRIPTION
### Problem

oggm_prepro with --mb-model-class SfcTypeTIModel is OOM-killed on every large RGI region
(1, 2, 3, 4, 5, 13, 14, 15, 17). Smaller regions are fine.

From a failing RGI 17 run (15908 glaciers, 32 workers): the kill happens during
run_from_climate_data after 2535 glaciers, mean wall time 0.14 s per glacier. The decisive
detail is a 2.5-minute silence before the kill, during which two dozen workers sat idle
with 13000 glaciers still queued, and every worker traceback is blocked in
multiprocessing/pool.py put((job, i, result)) — blocked sending results back. That is a
stalled main process, not a slow glacier.

### Cause

run_from_climate_data returns the whole FlowlineModel, entity_task passes it through
(return_value defaults to True), and execute_entity_task does pool.map(...), which pickles
every model back to the main process and keeps all 15908 in a list. Nothing uses that list.

Survivable with MonthlyTIModel, where the returned model is basically just the flowlines.
With SfcTypeTIModel the model carries six full-period (nr_timesteps, nx) float64 arrays,
about 30 kB x nx per glacier with nr_timesteps around 624 in prepro L4. The cost scales
with total glacierised length of the region, which is exactly what separates the failing
regions from the working ones.

### Fix

entity_task already documented a return_value parameter it never accepted. This PR closes
that gap:

- entity_task gains workflow_return_value (default True), exposed on the wrapped task.
- execute_entity_task injects return_value=False for tasks declaring it, unless the caller
  passes return_value explicitly. Applied with and without multiprocessing.
- Flagged: flowline_model_run, run_random_climate, run_constant_climate,
  run_from_climate_data, run_dynamic_spinup, run_dynamic_melt_f_calibration.

Direct calls are unaffected: model = tasks.run_random_climate(gdir) still returns the model.

### Behaviour change

execute_entity_task on the run_* tasks now returns a list of None. Pass return_value=True to
get the models back. One test in the repo relied on this and was updated.

### Testing

New tests cover the mechanism (flagged task returns nothing through the workflow, returns
values on explicit opt-in, unaffected when called directly, with and without
multiprocessing) and assert the flag on the real run_* tasks. Green: TestWorkflowTools (7),
test_workflow.py (2), test_models.py -k dynamic_spinup --run-slow (10), -k sfc --run-slow (8).

### Not addressed

This removes the amplification factor but not what a single SfcTypeTIModel costs. Those six
arrays are still allocated for every run even though a plain dynamical run never reads
further back than the current year. Making the history opt-in is a separate change 
 since it touches the SfcTypeTIModel API.
