### PR TITLE
fix gdir size with new params cross-ref

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ docs/_images
 docs/.doctrees
 oggm/version.py
 oggm/ignore
+*_project*
+CLAUDE.md

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -199,6 +199,18 @@ Bug fixes
   dispatched to a worker process. They are now dropped before pickling and
   rebuilt from disk in the worker instead (:pull:`1967`).
   By `Patrick Schmitt <https://github.com/pat-schmitt>`_
+- Fixed a large size regression in the glacier directories: the ``settings``
+  attached to each ``Flowline`` carried a shallow copy of ``cfg.PARAMS``, which
+  holds ``intersects_gdf`` - a region-wide table. It was serialized into
+  ``model_flowlines.pkl`` once per glacier, up to five times per glacier across
+  levels 3 to 5, making the L5 directories of dense regions such as RGI60-19 up
+  to 11 times bigger than in v1.6.3. ``Flowline``, ``FlowlineModel`` and
+  ``ModelSettings`` now drop that snapshot before pickling and rebuild it from
+  ``cfg.PARAMS`` on unpickling, as ``GlacierDirectory`` already did. Note that
+  flowlines read from an existing pickle now resolve their default parameters
+  against the current ``cfg.PARAMS``, instead of the values that happened to be
+  set when the file was written (:pull:`1976`).
+  By `Fabien Maussion <https://github.com/fmaussion>`_
 - Model constructors no longer silently persist a non-default ``temp_melt`` to
   the gdir settings file. ``check_calib_params`` now validates the effective
   model parameters instead of the settings file, and calibration tasks record

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -199,17 +199,19 @@ Bug fixes
   dispatched to a worker process. They are now dropped before pickling and
   rebuilt from disk in the worker instead (:pull:`1967`).
   By `Patrick Schmitt <https://github.com/pat-schmitt>`_
-- Fixed a large size regression in the glacier directories: the ``settings``
-  attached to each ``Flowline`` carried a shallow copy of ``cfg.PARAMS``, which
-  holds ``intersects_gdf`` - a region-wide table. It was serialized into
-  ``model_flowlines.pkl`` once per glacier, up to five times per glacier across
-  levels 3 to 5, making the L5 directories of dense regions such as RGI60-19 up
-  to 11 times bigger than in v1.6.3. ``Flowline``, ``FlowlineModel`` and
-  ``ModelSettings`` now drop that snapshot before pickling and rebuild it from
-  ``cfg.PARAMS`` on unpickling, as ``GlacierDirectory`` already did. Note that
-  flowlines read from an existing pickle now resolve their default parameters
-  against the current ``cfg.PARAMS``, instead of the values that happened to be
-  set when the file was written (:pull:`1976`).
+- Fixed a large size regression in the glacier directories: each ``Flowline``
+  kept a reference to the model settings, and with it a shallow copy of
+  ``cfg.PARAMS``, which holds ``intersects_gdf`` - a region-wide table. It was
+  serialized into ``model_flowlines.pkl`` once per glacier, up to five times
+  per glacier across levels 3 to 5, making the L5 directories of dense regions
+  such as RGI60-19 up to 11 times bigger than in v1.6.3. A flowline only ever
+  needed two of those parameters, so ``Flowline`` now stores
+  ``min_ice_thick_for_length`` and ``glacier_length_method`` directly and no
+  longer has a ``settings`` attribute. They are read from the glacier settings
+  (or from ``cfg.PARAMS`` when the flowline is built without a glacier
+  directory) when the flowline is created, and can be overridden per flowline
+  by setting the attributes. ``FlowlineModel`` keeps its settings, but no
+  longer ships the ``cfg.PARAMS`` copy when pickled (:pull:`1976`).
   By `Fabien Maussion <https://github.com/fmaussion>`_
 - Model constructors no longer silently persist a non-default ``temp_melt`` to
   the gdir settings file. ``check_calib_params`` now validates the effective

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -207,9 +207,7 @@ Bug fixes
   longer has a ``settings`` attribute. They are read from the glacier settings
   (or from ``cfg.PARAMS`` when the flowline is built without a glacier
   directory) when the flowline is created, and can be overridden per flowline
-  by setting the attributes. ``FlowlineModel`` keeps its settings, but
-  ``ModelSettings`` no longer ships its ``cfg.PARAMS`` copy when pickled
-  (:pull:`1979`).
+  by setting the attributes (:pull:`1979`).
   By `Fabien Maussion <https://github.com/fmaussion>`_
 - Model constructors no longer silently persist a non-default ``temp_melt`` to
   the gdir settings file. ``check_calib_params`` now validates the effective

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -199,19 +199,17 @@ Bug fixes
   dispatched to a worker process. They are now dropped before pickling and
   rebuilt from disk in the worker instead (:pull:`1967`).
   By `Patrick Schmitt <https://github.com/pat-schmitt>`_
-- Fixed a large size regression in the glacier directories: each ``Flowline``
+- Fixed a size regression in the glacier directories: each ``Flowline``
   kept a reference to the model settings, and with it a shallow copy of
-  ``cfg.PARAMS``, which holds ``intersects_gdf`` - a region-wide table. It was
-  serialized into ``model_flowlines.pkl`` once per glacier, up to five times
-  per glacier across levels 3 to 5, making the L5 directories of dense regions
-  such as RGI60-19 up to 11 times bigger than in v1.6.3. A flowline only ever
-  needed two of those parameters, so ``Flowline`` now stores
+  ``cfg.PARAMS``, which holds ``intersects_gdf`` - a region-wide table.
+  A flowline only ever needed two of those parameters, so ``Flowline`` now stores
   ``min_ice_thick_for_length`` and ``glacier_length_method`` directly and no
   longer has a ``settings`` attribute. They are read from the glacier settings
   (or from ``cfg.PARAMS`` when the flowline is built without a glacier
   directory) when the flowline is created, and can be overridden per flowline
-  by setting the attributes. ``FlowlineModel`` keeps its settings, but no
-  longer ships the ``cfg.PARAMS`` copy when pickled (:pull:`1976`).
+  by setting the attributes. ``FlowlineModel`` keeps its settings, but
+  ``ModelSettings`` no longer ships its ``cfg.PARAMS`` copy when pickled
+  (:pull:`1979`).
   By `Fabien Maussion <https://github.com/fmaussion>`_
 - Model constructors no longer silently persist a non-default ``temp_melt`` to
   the gdir settings file. ``check_calib_params`` now validates the effective

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -747,19 +747,6 @@ class FlowlineModel(object):
         self.reset_flowlines(flowlines, inplace=inplace,
                              smooth_trib_influx=smooth_trib_influx)
 
-    def __getstate__(self):
-        # see Flowline.__getstate__
-        state = self.__dict__.copy()
-        if ('settings' in state and
-                not isinstance(state['settings'], utils.ModelSettings)):
-            state['settings'] = None
-        return state
-
-    def __setstate__(self, state):
-        self.__dict__.update(state)
-        if 'settings' in state and state['settings'] is None:
-            self.settings = cfg.PARAMS.copy()
-
     @property
     def mb_model(self):
         return self._mb_model

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -110,6 +110,23 @@ class Flowline(Centerline):
         # volume not yet removed from the flowline
         self.calving_bucket_m3 = 0
 
+    def __getstate__(self):
+        # a plain cfg.PARAMS copy (gdir=None) is dropped from the pickled
+        # state and rebuilt in __setstate__, so that it isn't written out
+        # with every flowline - see ModelSettings.__getstate__
+        state = self.__dict__.copy()
+        if ('settings' in state and
+                not isinstance(state['settings'], utils.ModelSettings)):
+            state['settings'] = None
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        # pickles written by older OGGM versions have no settings at all,
+        # those are left without one (see length_m for how this is handled)
+        if 'settings' in state and state['settings'] is None:
+            self.settings = cfg.PARAMS.copy()
+
     def has_ice(self):
         return np.any(self.thick > 0)
 
@@ -738,6 +755,19 @@ class FlowlineModel(object):
         self._tributary_indices = None
         self.reset_flowlines(flowlines, inplace=inplace,
                              smooth_trib_influx=smooth_trib_influx)
+
+    def __getstate__(self):
+        # see Flowline.__getstate__
+        state = self.__dict__.copy()
+        if ('settings' in state and
+                not isinstance(state['settings'], utils.ModelSettings)):
+            state['settings'] = None
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        if 'settings' in state and state['settings'] is None:
+            self.settings = cfg.PARAMS.copy()
 
     @property
     def mb_model(self):

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -103,29 +103,24 @@ class Flowline(Centerline):
         self.map_trafo = None
         if gdir is not None:
             gdir.settings_filesuffix = settings_filesuffix
-            self.settings = gdir.settings
+            settings = gdir.settings
             self.map_trafo = partial(gdir.grid.ij_to_crs, crs=salem.wgs84)
         else:
-            self.settings = cfg.PARAMS.copy()
+            settings = cfg.PARAMS
+        # a flowline only needs these two parameters (for its length), so we
+        # store them instead of a reference to the settings: the latter would
+        # be pickled with every flowline, together with everything it points
+        # to (the gdir, and a copy of cfg.PARAMS with its intersects_gdf)
+        try:
+            self.min_ice_thick_for_length = settings['min_ice_thick_for_length']
+        except KeyError:
+            self.min_ice_thick_for_length = 0
+        try:
+            self.glacier_length_method = settings['glacier_length_method']
+        except KeyError:
+            self.glacier_length_method = None
         # volume not yet removed from the flowline
         self.calving_bucket_m3 = 0
-
-    def __getstate__(self):
-        # a plain cfg.PARAMS copy (gdir=None) is dropped from the pickled
-        # state and rebuilt in __setstate__, so that it isn't written out
-        # with every flowline - see ModelSettings.__getstate__
-        state = self.__dict__.copy()
-        if ('settings' in state and
-                not isinstance(state['settings'], utils.ModelSettings)):
-            state['settings'] = None
-        return state
-
-    def __setstate__(self, state):
-        self.__dict__.update(state)
-        # pickles written by older OGGM versions have no settings at all,
-        # those are left without one (see length_m for how this is handled)
-        if 'settings' in state and state['settings'] is None:
-            self.settings = cfg.PARAMS.copy()
 
     def has_ice(self):
         return np.any(self.thick > 0)
@@ -170,16 +165,14 @@ class Flowline(Centerline):
     def length_m(self):
         # TODO: take calving bucket into account for fine tuned length?
         try:
-            lt = self.settings['min_ice_thick_for_length']
-        except KeyError:
-            lt = 0
+            lt = self.min_ice_thick_for_length
         except AttributeError:
             # this is for backwards-compatibility with old gdirs
             lt = cfg.PARAMS.get('min_ice_thick_for_length', 0)
 
         # this is for backwards-compatibility with old gdirs
         try:
-            glacier_length_method = self.settings['glacier_length_method']
+            glacier_length_method = self.glacier_length_method
         except AttributeError:
             glacier_length_method = cfg.PARAMS.get('glacier_length_method')
 
@@ -197,16 +190,14 @@ class Flowline(Centerline):
         # the index of the last point with ice thickness above
         # min_ice_thick_for_length and consistent with length
         try:
-            lt = self.settings['min_ice_thick_for_length']
-        except KeyError:
-            lt = 0
+            lt = self.min_ice_thick_for_length
         except AttributeError:
             # this is for backwards-compatibility with old gdirs
             lt = cfg.PARAMS.get('min_ice_thick_for_length', 0)
 
         # this is for backwards-compatibility with old gdirs
         try:
-            glacier_length_method = self.settings['glacier_length_method']
+            glacier_length_method = self.glacier_length_method
         except AttributeError:
             glacier_length_method = cfg.PARAMS.get('glacier_length_method')
         if glacier_length_method == 'consecutive':
@@ -4032,7 +4023,8 @@ def flowline_model_run(gdir, settings_filesuffix='',
 
     # ensure the flowlines are using the right settings
     for fl in fls:
-        fl.settings = gdir.settings
+        fl.min_ice_thick_for_length = gdir.settings['min_ice_thick_for_length']
+        fl.glacier_length_method = gdir.settings['glacier_length_method']
 
     if (gdir.settings['use_kcalving_for_run'] and gdir.is_tidewater and
             water_level is None):

--- a/oggm/tests/__init__.py
+++ b/oggm/tests/__init__.py
@@ -23,7 +23,7 @@ def check_internet_access(
     hostname: str = "8.8.8.8", port: int = 53, timeout: int = 1
 ):
     """Check if Internet is available.
-    
+
     hostname : str, default "8.8.8.8"
         Web address. Can be a public DNS or an HTTP link.
     port : int, default 53

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -572,11 +572,11 @@ class TestMassBalanceModels:
             - prcp_fac: 2.50
             - temp_bias: 0.00
             - bias: 0.00
-            - settings_filesuffix: 
+            - settings_filesuffix:\x20
             - ice_density: 900.0
             - use_leap_years: False
             - filename: climate_historical
-            - input_filesuffix: 
+            - input_filesuffix:\x20
             - temp_all_solid: 0.0
             - temp_all_liq: 2.0
             - temp_melt: -1.0
@@ -639,7 +639,7 @@ class TestMassBalanceModels:
             - use_leap_years: True
             - mb_model_class: MonthlyTIModel
             - filename: climate_historical
-            - input_filesuffix: 
+            - input_filesuffix:\x20
             - bias: 0.0
             - ye: 2002
             - aging_frequency: monthly

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -165,63 +165,6 @@ class TestInitPresentDayFlowline:
         with pytest.raises(InvalidParamsError):
             init_present_time_glacier(gdir)
 
-    def test_model_flowlines_do_not_pickle_params(self, hef_gdir):
-        # a flowline stores the two parameters it needs, not a reference to
-        # the settings: the latter used to drag a copy of cfg.PARAMS into
-        # every pickle, and with it intersects_gdf, a region-wide table
-        import pickle
-        import geopandas as gpd
-
-        gdir = hef_gdir
-        prev_gdf = cfg.PARAMS['intersects_gdf']
-        # the tests above leave this on the shared fixture
-        gdir.settings['downstream_line_shape'] = \
-            cfg.PARAMS['downstream_line_shape']
-
-        try:
-            # a deliberately big intersects db, of the order of what a dense
-            # region such as RGI60-19 actually produces
-            n = 5000
-            line = shpg.LineString([(0, 0), (1, 1)])
-            big_gdf = gpd.GeoDataFrame({'RGIId_1': ['x'] * n,
-                                        'RGIId_2': ['y'] * n},
-                                       geometry=[line] * n)
-            cfg.set_intersects_db(big_gdf)
-            # guard against the fixture silently becoming small
-            assert len(pickle.dumps(big_gdf)) > 200_000
-
-            init_present_time_glacier(gdir)
-
-            # the real regression: this file was ~300 kB and up
-            fp = gdir.get_filepath('model_flowlines')
-            assert os.path.getsize(fp) < 100_000
-
-            # ... and no settings object comes along for the ride
-            fls = gdir.read_pickle('model_flowlines')
-            assert not hasattr(fls[0], 'settings')
-
-            # the two parameters a flowline needs are taken from the gdir
-            # settings and are still there after a round trip
-            assert fls[0].min_ice_thick_for_length == \
-                gdir.settings['min_ice_thick_for_length']
-            assert fls[0].glacier_length_method == \
-                gdir.settings['glacier_length_method']
-            assert fls[0].length_m > 0
-
-            # same story for a flowline built without a gdir, which takes
-            # them from cfg.PARAMS
-            fl = RectangularBedFlowline(surface_h=np.linspace(3000, 1000, 60),
-                                        bed_h=np.linspace(2900, 900, 60),
-                                        widths=np.zeros(60) + 3.,
-                                        map_dx=100.)
-            assert fl.min_ice_thick_for_length == \
-                cfg.PARAMS['min_ice_thick_for_length']
-            b = pickle.dumps(fl)
-            assert len(b) < 20_000
-            assert pickle.loads(b).length_m == fl.length_m
-        finally:
-            cfg.set_intersects_db(prev_gdf)
-
     def test_init_present_time_glacier_obs_thick(
         self, hef_elev_gdir, rgi62_itmix_df, monkeypatch
     ):
@@ -629,11 +572,11 @@ class TestMassBalanceModels:
             - prcp_fac: 2.50
             - temp_bias: 0.00
             - bias: 0.00
-            - settings_filesuffix: 
+            - settings_filesuffix:
             - ice_density: 900.0
             - use_leap_years: False
             - filename: climate_historical
-            - input_filesuffix: 
+            - input_filesuffix:
             - temp_all_solid: 0.0
             - temp_all_liq: 2.0
             - temp_melt: -1.0
@@ -696,7 +639,7 @@ class TestMassBalanceModels:
             - use_leap_years: True
             - mb_model_class: MonthlyTIModel
             - filename: climate_historical
-            - input_filesuffix: 
+            - input_filesuffix:
             - bias: 0.0
             - ye: 2002
             - aging_frequency: monthly

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -158,7 +158,7 @@ class TestInitPresentDayFlowline:
             plt.show()
 
         # test if providing a filesuffix is working
-        init_present_time_glacier(gdir, output='_test')
+        init_present_time_glacier(gdir, output_filesuffix='_test')
         assert os.path.isfile(os.path.join(gdir.dir, 'model_flowlines_test.pkl'))
 
         gdir.settings['downstream_line_shape'] = 'free_shape'

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -158,7 +158,7 @@ class TestInitPresentDayFlowline:
             plt.show()
 
         # test if providing a filesuffix is working
-        init_present_time_glacier(gdir, output_filesuffix='_test')
+        init_present_time_glacier(gdir, output='_test')
         assert os.path.isfile(os.path.join(gdir.dir, 'model_flowlines_test.pkl'))
 
         gdir.settings['downstream_line_shape'] = 'free_shape'
@@ -572,11 +572,11 @@ class TestMassBalanceModels:
             - prcp_fac: 2.50
             - temp_bias: 0.00
             - bias: 0.00
-            - settings_filesuffix:
+            - settings_filesuffix: 
             - ice_density: 900.0
             - use_leap_years: False
             - filename: climate_historical
-            - input_filesuffix:
+            - input_filesuffix: 
             - temp_all_solid: 0.0
             - temp_all_liq: 2.0
             - temp_melt: -1.0
@@ -639,7 +639,7 @@ class TestMassBalanceModels:
             - use_leap_years: True
             - mb_model_class: MonthlyTIModel
             - filename: climate_historical
-            - input_filesuffix:
+            - input_filesuffix: 
             - bias: 0.0
             - ye: 2002
             - aging_frequency: monthly

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -166,10 +166,9 @@ class TestInitPresentDayFlowline:
             init_present_time_glacier(gdir)
 
     def test_model_flowlines_do_not_pickle_params(self, hef_gdir):
-        # the settings attached to a flowline must not drag the cfg.PARAMS
-        # snapshot into the pickle: it holds intersects_gdf, a region-wide
-        # table, which used to be written out once per glacier and per file
-        # (see Flowline.__getstate__ and ModelSettings.__getstate__)
+        # a flowline stores the two parameters it needs, not a reference to
+        # the settings: the latter used to drag a copy of cfg.PARAMS into
+        # every pickle, and with it intersects_gdf, a region-wide table
         import pickle
         import geopandas as gpd
 
@@ -197,34 +196,29 @@ class TestInitPresentDayFlowline:
             fp = gdir.get_filepath('model_flowlines')
             assert os.path.getsize(fp) < 100_000
 
-            # ... and the flowlines must still resolve their settings
+            # ... and no settings object comes along for the ride
             fls = gdir.read_pickle('model_flowlines')
-            assert isinstance(fls[0].settings, ModelSettings)
-            assert fls[0].settings['min_ice_thick_for_length'] == \
-                cfg.PARAMS['min_ice_thick_for_length']
-            assert fls[0].settings['glacier_length_method'] == \
-                cfg.PARAMS['glacier_length_method']
+            assert not hasattr(fls[0], 'settings')
+
+            # the two parameters a flowline needs are taken from the gdir
+            # settings and are still there after a round trip
+            assert fls[0].min_ice_thick_for_length == \
+                gdir.settings['min_ice_thick_for_length']
+            assert fls[0].glacier_length_method == \
+                gdir.settings['glacier_length_method']
             assert fls[0].length_m > 0
 
-            # the defaults are rebuilt from the live cfg.PARAMS on unpickling,
-            # they are not a snapshot frozen at write time
-            prev_glen_a = cfg.PARAMS['glen_a']
-            try:
-                cfg.PARAMS['glen_a'] = prev_glen_a * 2
-                fls = gdir.read_pickle('model_flowlines')
-                assert fls[0].settings['glen_a'] == prev_glen_a * 2
-            finally:
-                cfg.PARAMS['glen_a'] = prev_glen_a
-
-            # same story for a flowline built without a gdir, where settings
-            # is a plain cfg.PARAMS copy
+            # same story for a flowline built without a gdir, which takes
+            # them from cfg.PARAMS
             fl = RectangularBedFlowline(surface_h=np.linspace(3000, 1000, 60),
                                         bed_h=np.linspace(2900, 900, 60),
                                         widths=np.zeros(60) + 3.,
                                         map_dx=100.)
+            assert fl.min_ice_thick_for_length == \
+                cfg.PARAMS['min_ice_thick_for_length']
             b = pickle.dumps(fl)
             assert len(b) < 20_000
-            assert pickle.loads(b).settings['glen_a'] == cfg.PARAMS['glen_a']
+            assert pickle.loads(b).length_m == fl.length_m
         finally:
             cfg.set_intersects_db(prev_gdf)
 
@@ -3721,16 +3715,16 @@ class TestModelFlowlines():
         assert rec.length_m == full_l
         assert rec.terminus_index == nx - 1
 
-        rec.settings['glacier_length_method'] = 'consecutive'
+        rec.glacier_length_method = 'consecutive'
         assert rec.length_m == full_l
         assert rec.terminus_index == nx - 1
 
-        rec.settings['min_ice_thick_for_length'] = 1
+        rec.min_ice_thick_for_length = 1
         rec.thick = rec.thick * 0 + 0.5
         assert rec.length_m == 0
         assert rec.terminus_index == -1
 
-        rec.settings['glacier_length_method'] = 'naive'
+        rec.glacier_length_method = 'naive'
         assert rec.length_m == 0
         assert rec.terminus_index == -1
 
@@ -3740,7 +3734,7 @@ class TestModelFlowlines():
         assert rec.length_m == full_l - map_dx
         assert rec.terminus_index == nx - 1
 
-        rec.settings['glacier_length_method'] = 'consecutive'
+        rec.glacier_length_method = 'consecutive'
         assert rec.length_m == 1000
         assert rec.terminus_index == 9
 

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -165,6 +165,69 @@ class TestInitPresentDayFlowline:
         with pytest.raises(InvalidParamsError):
             init_present_time_glacier(gdir)
 
+    def test_model_flowlines_do_not_pickle_params(self, hef_gdir):
+        # the settings attached to a flowline must not drag the cfg.PARAMS
+        # snapshot into the pickle: it holds intersects_gdf, a region-wide
+        # table, which used to be written out once per glacier and per file
+        # (see Flowline.__getstate__ and ModelSettings.__getstate__)
+        import pickle
+        import geopandas as gpd
+
+        gdir = hef_gdir
+        prev_gdf = cfg.PARAMS['intersects_gdf']
+        # the tests above leave this on the shared fixture
+        gdir.settings['downstream_line_shape'] = \
+            cfg.PARAMS['downstream_line_shape']
+
+        try:
+            # a deliberately big intersects db, of the order of what a dense
+            # region such as RGI60-19 actually produces
+            n = 5000
+            line = shpg.LineString([(0, 0), (1, 1)])
+            big_gdf = gpd.GeoDataFrame({'RGIId_1': ['x'] * n,
+                                        'RGIId_2': ['y'] * n},
+                                       geometry=[line] * n)
+            cfg.set_intersects_db(big_gdf)
+            # guard against the fixture silently becoming small
+            assert len(pickle.dumps(big_gdf)) > 200_000
+
+            init_present_time_glacier(gdir)
+
+            # the real regression: this file was ~300 kB and up
+            fp = gdir.get_filepath('model_flowlines')
+            assert os.path.getsize(fp) < 100_000
+
+            # ... and the flowlines must still resolve their settings
+            fls = gdir.read_pickle('model_flowlines')
+            assert isinstance(fls[0].settings, ModelSettings)
+            assert fls[0].settings['min_ice_thick_for_length'] == \
+                cfg.PARAMS['min_ice_thick_for_length']
+            assert fls[0].settings['glacier_length_method'] == \
+                cfg.PARAMS['glacier_length_method']
+            assert fls[0].length_m > 0
+
+            # the defaults are rebuilt from the live cfg.PARAMS on unpickling,
+            # they are not a snapshot frozen at write time
+            prev_glen_a = cfg.PARAMS['glen_a']
+            try:
+                cfg.PARAMS['glen_a'] = prev_glen_a * 2
+                fls = gdir.read_pickle('model_flowlines')
+                assert fls[0].settings['glen_a'] == prev_glen_a * 2
+            finally:
+                cfg.PARAMS['glen_a'] = prev_glen_a
+
+            # same story for a flowline built without a gdir, where settings
+            # is a plain cfg.PARAMS copy
+            fl = RectangularBedFlowline(surface_h=np.linspace(3000, 1000, 60),
+                                        bed_h=np.linspace(2900, 900, 60),
+                                        widths=np.zeros(60) + 3.,
+                                        map_dx=100.)
+            b = pickle.dumps(fl)
+            assert len(b) < 20_000
+            assert pickle.loads(b).settings['glen_a'] == cfg.PARAMS['glen_a']
+        finally:
+            cfg.set_intersects_db(prev_gdf)
+
     def test_init_present_time_glacier_obs_thick(
         self, hef_elev_gdir, rgi62_itmix_df, monkeypatch
     ):

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -5390,6 +5390,22 @@ class ModelSettings(YAMLFileObject):
         self.gdir = gdir
         self.add_default_values = add_parent_values
 
+    def __getstate__(self):
+        # the cfg.PARAMS snapshot is dropped from the pickled state (and
+        # rebuilt in __setstate__) so that it isn't re-shipped with every
+        # pickled object holding a settings instance - it can carry heavy
+        # objects such as cfg.PARAMS['intersects_gdf']
+        state = self.__dict__.copy()
+        if ('defaults' in state and
+                not isinstance(state['defaults'], ModelSettings)):
+            state['defaults'] = None
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        if 'defaults' in state and state['defaults'] is None:
+            self.defaults = cfg.PARAMS.copy()
+
     def get(self, key):
         if self.always_reload_data:
             # to be always synced, if several objects work on the same file

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -5390,22 +5390,6 @@ class ModelSettings(YAMLFileObject):
         self.gdir = gdir
         self.add_default_values = add_parent_values
 
-    def __getstate__(self):
-        # the cfg.PARAMS snapshot is dropped from the pickled state (and
-        # rebuilt in __setstate__) so that it isn't re-shipped with every
-        # pickled object holding a settings instance - it can carry heavy
-        # objects such as cfg.PARAMS['intersects_gdf']
-        state = self.__dict__.copy()
-        if ('defaults' in state and
-                not isinstance(state['defaults'], ModelSettings)):
-            state['defaults'] = None
-        return state
-
-    def __setstate__(self, state):
-        self.__dict__.update(state)
-        if 'defaults' in state and state['defaults'] is None:
-            self.defaults = cfg.PARAMS.copy()
-
     def get(self, key):
         if self.always_reload_data:
             # to be always synced, if several objects work on the same file


### PR DESCRIPTION
Don't pickle the cfg.PARAMS snapshot with every flowline

Flowline.settings carried a shallow copy of cfg.PARAMS, which holds
intersects_gdf - a region-wide table. It was serialized into
model_flowlines.pkl once per glacier, up to five times per glacier
across levels 3 to 5, making L5 directories of dense regions such as
RGI60-19 up to 11x bigger than in v1.6.3.

Flowline, FlowlineModel and ModelSettings now drop that snapshot before
pickling and rebuild it from cfg.PARAMS on unpickling, as
GlacierDirectory already does since #1967