### PR TITLE
fix: OGGM CLI arguments no longer accept arbitrary strings

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -180,12 +180,13 @@ Enhancements
 - New ``store_hydro_output`` kwarg in ``run_prepro_levels`` (and
   ``--store-hydro-output`` CLI flag) to also compute and store hydrological
   model output during preprocessing, via ``run_with_hydro``. The accompanying
-  ``store_monthly_hydro`` kwarg (and ``--store-monthly-hydro`` CLI flag,
-  default ``True``) additionally stores this hydrological output at monthly
-  resolution. The new ``ref_area_yr`` kwarg (and ``--ref-area-yr`` CLI flag)
-  lets users force the hydrological reference area to the glacier state of a
-  given simulation year, instead of the default largest area during the
-  simulation period (:pull:`1965`).
+  ``store_monthly_hydro`` kwarg (and ``--store-monthly-hydro`` CLI flag)
+  additionally stores this hydrological output at monthly resolution. It is
+  opt-in and defaults to ``False``, like in ``run_with_hydro``, since it
+  increases data usage quite a bit. The new ``ref_area_yr`` kwarg (and
+  ``--ref-area-yr`` CLI flag) lets users force the hydrological reference area
+  to the glacier state of a given simulation year, instead of the default
+  largest area during the simulation period (:pull:`1965`).
   By `Patrick Schmitt <https://github.com/pat-schmitt>`_
 
 Bug fixes
@@ -245,13 +246,24 @@ Bug fixes
   By `Fabien Maussion <https://github.com/fmaussion>`_
 - Multiple fixes to the test suite, missing assertions, test logic (:pull:`1960`).
   By `Nicolas Gampierakis <http://github.com/gampnico>`_.
-- OGGM arguments no longer silently accepts arbitrary strings and evaluates them
-  to True (:pull:`1986`).
+- ``--dynamic-spinup-periods-to-try`` now converts its values to integers.
+  They were passed on as strings, which made the flag unusable: any explicit
+  value crashed the dynamic spinup with a ``TypeError``. Non-numeric values
+  (other than the documented ``none``) now raise an ``InvalidParamsError``
+  (:pull:`1986`).
   By `Nicolas Gampierakis <https://github.com/gampnico>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
+- The boolean flags of the ``oggm_prepro``, ``oggm_benchmark`` and
+  ``oggm_temp_bias`` commands (``--elev-bands``, ``--test``, ``--disable-mp``,
+  and all the others) no longer accept a value. They used to store whatever
+  string followed them, and since every non-empty string is truthy,
+  ``--elev-bands False`` turned elev-bands *on*. Passing a value is now an
+  error: use the bare flag to switch a behaviour on, and omit it to switch it
+  off (:pull:`1986`).
+  By `Nicolas Gampierakis <https://github.com/gampnico>`_.
 - The glacier intersects are no longer stored in
   ``cfg.PARAMS['intersects_gdf']``, but in ``cfg.INTERSECTS_GDF``. They are a
   (potentially large, region wide) dataframe and not a parameter, and having

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -245,6 +245,9 @@ Bug fixes
   By `Fabien Maussion <https://github.com/fmaussion>`_
 - Multiple fixes to the test suite, missing assertions, test logic (:pull:`1960`).
   By `Nicolas Gampierakis <http://github.com/gampnico>`_.
+- OGGM arguments no longer silently accepts arbitrary strings and evaluates them
+  to True (:pull:`1986`).
+  By `Nicolas Gampierakis <https://github.com/gampnico>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/oggm/cli/benchmark.py
+++ b/oggm/cli/benchmark.py
@@ -216,7 +216,7 @@ def parse_args(args):
                         help='path to the directory where to write the '
                              'output. Defaults to current directory or'
                              '$OGGM_OUTDIR.')
-    parser.add_argument('--test', nargs='?', const=True, default=False,
+    parser.add_argument('--test', action='store_true',
                         help='if you want to do a test on a couple of '
                              'glaciers first.')
     args = parser.parse_args(args)

--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -1384,7 +1384,7 @@ def parse_args(args):
         except (TypeError, ValueError):
             raise InvalidParamsError(
                 '--dynamic-spinup-periods-to-try takes spinup periods in '
-                "years, or the single value 'none', but got "
+                'years, or the single value "none", but got '
                 f'{periods_to_try}!'
             )
 
@@ -1420,7 +1420,7 @@ def parse_args(args):
                 dynamic_spinup=dynamic_spinup,
                 ref_mb_err_scaling_factor=args.ref_mb_err_scaling_factor,
                 dynamic_spinup_start_year=args.dynamic_spinup_start_year,
-                dynamic_spinup_periods_to_try=args.dynamic_spinup_periods_to_try,
+                dynamic_spinup_periods_to_try=periods_to_try,
                 mb_model_class=args.mb_model_class,
                 mb_calibration_strategy=args.mb_calibration_strategy,
                 geodetic_mb_file_path=args.geodetic_mb_file_path,

--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -1313,7 +1313,7 @@ def parse_args(args):
                              'match the setup it is used with. It is created '
                              'with --temp-bias-run and the `oggm_temp_bias` '
                              'command.')
-    parser.add_argument('--temp-bias-run', nargs='?', const=True, default=False,
+    parser.add_argument('--temp-bias-run', action='store_true',
                         help='run the preprocessing needed to create the '
                              'temperature bias prior file. This forces '
                              '--max-level 3 and --skip-inversion, and writes '

--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -1169,13 +1169,13 @@ def parse_args(args):
     parser.add_argument('--logging-level', type=str, default='WORKFLOW',
                         help='the logging level to use (DEBUG, INFO, WARNING, '
                              'WORKFLOW).')
-    parser.add_argument('--elev-bands', nargs='?', const=True, default=False,
+    parser.add_argument('--elev-bands', action='store_true',
                         help='compute the flowlines based on the Huss & Farinotti '
                              '2012 method.')
-    parser.add_argument('--centerlines', nargs='?', const=True, default=False,
+    parser.add_argument('--centerlines', action='store_true',
                         help='compute the flowlines based on the OGGM '
                              'centerline(s) method.')
-    parser.add_argument('--skip-inversion', nargs='?', const=True, default=False,
+    parser.add_argument('--skip-inversion', action='store_true',
                         help='do not run the inversion (level 3 files). '
                              'this is a temporary workaround for workflows '
                              'that wont run that far into level 3.')
@@ -1212,40 +1212,40 @@ def parse_args(args):
                         'If you set it to "BY_RES" here, COPDEM will be used and '
                         'its resolution chosen based on the gdirs map resolution '
                         '(COPDEM30 for dx < 60 m, COPDEM90 elsewhere).')
-    parser.add_argument('--keep-dem-folders', nargs='?', const=True, default=False,
+    parser.add_argument('--keep-dem-folders', action='store_true',
                         help='if `select_source_from_dir` is used, wether to keep '
                         'the original DEM folders in or not.')
-    parser.add_argument('--add-consensus-thickness', nargs='?', const=True, default=False,
+    parser.add_argument('--add-consensus-thickness', action='store_true',
                         help='adds (reprojects) the consensus thickness '
                              'estimates to the glacier directories. '
                              'With --elev-bands, the data will also be '
                              'binned.')
-    parser.add_argument('--add-itslive-velocity', nargs='?', const=True, default=False,
+    parser.add_argument('--add-itslive-velocity', action='store_true',
                         help='adds (reprojects) the ITS_LIVE velocity '
                              'estimates to the glacier directories. '
                              'With --elev-bands, the data will also be '
                              'binned.')
-    parser.add_argument('--add-millan-thickness', nargs='?', const=True, default=False,
+    parser.add_argument('--add-millan-thickness', action='store_true',
                         help='adds (reprojects) the millan thickness '
                              'estimates to the glacier directories. '
                              'With --elev-bands, the data will also be '
                              'binned.')
-    parser.add_argument('--add-millan-velocity', nargs='?', const=True, default=False,
+    parser.add_argument('--add-millan-velocity', action='store_true',
                         help='adds (reprojects) the millan velocity '
                              'estimates to the glacier directories. '
                              'With --elev-bands, the data will also be '
                              'binned.')
-    parser.add_argument('--add-hugonnet-dhdt', nargs='?', const=True, default=False,
+    parser.add_argument('--add-hugonnet-dhdt', action='store_true',
                         help='adds (reprojects) the hugonnet dhdt '
                              'maps to the glacier directories. '
                              'With --elev-bands, the data will also be '
                              'binned.')
-    parser.add_argument('--add-bedmachine', nargs='?', const=True, default=False,
+    parser.add_argument('--add-bedmachine', action='store_true',
                         help='adds (reprojects) the Bedmachine ice thickness '
                              'maps to the glacier directories. '
                              'With --elev-bands, the data will also be '
                              'binned.')
-    parser.add_argument('--add-glathida', nargs='?', const=True, default=False,
+    parser.add_argument('--add-glathida', action='store_true',
                         help='adds (reprojects) the glathida point thickness '
                              'observations to the glacier directories. '
                              'The data points are stored as csv.')
@@ -1254,18 +1254,18 @@ def parse_args(args):
                             'If provided, it replaces the default process_climate_data.')
     parser.add_argument('--custom-climate-task-kwargs', type=json.loads, default=None,
                         help='JSON dict of kwargs passed to the custom climate task.')
-    parser.add_argument('--add-distributed-thickness', nargs='?', const=True, default=False,
+    parser.add_argument('--add-distributed-thickness', action='store_true',
                         help='adds a thickness field to gridded_data using '
                              'distribute_thickness_per_altitude.')
-    parser.add_argument('--add-export-thickness-geotiff', nargs='?', const=True, default=False,
+    parser.add_argument('--add-export-thickness-geotiff', action='store_true',
                         help='exports the distributed thickness field to '
                              'GeoTIFF files in a subfolder of the L3 summary '
                              'directory. Requires --add-distributed-thickness.')
-    parser.add_argument('--compute-hypsometry', nargs='?', const=True, default=False,
+    parser.add_argument('--compute-hypsometry', action='store_true',
                         help='Compute the hypsometry tables for all glaciers, '
                              'added to the glacier directory and compiled in '
                              'the summary folder')
-    parser.add_argument('--test', nargs='?', const=True, default=False,
+    parser.add_argument('--test', action='store_true',
                         help='if you want to do a test on a couple of '
                              'glaciers first.')
     parser.add_argument('--test-ids', nargs='+',
@@ -1277,7 +1277,7 @@ def parse_args(args):
     parser.add_argument('--intersects-file', type=str, default=None,
                         help='path to an intersects shapefile to use instead '
                              'of the default RGI intersects file.')
-    parser.add_argument('--disable-mp', nargs='?', const=True, default=False,
+    parser.add_argument('--disable-mp', action='store_true',
                         help='if you want to disable multiprocessing.')
     parser.add_argument('--dynamic-spinup', type=str, default='',
                         help="include a dynamic spinup for matching glacier area "
@@ -1322,15 +1322,17 @@ def parse_args(args):
                              'Feed the result to the `oggm_temp_bias` command '
                              '(together with the other regions) to create the '
                              'file.')
-    parser.add_argument('--store-fl-diagnostics', nargs='?', const=True, default=False,
+    parser.add_argument('--store-fl-diagnostics', action='store_true',
                         help="Also compute and store flowline diagnostics during "
                              "preprocessing. This can increase data usage quite "
                              "a bit.")
-    parser.add_argument('--store-hydro-output', nargs='?', const=True, default=False,
+    parser.add_argument('--store-hydro-output', action='store_true',
                         help='Add optional hydrological model output')
-    parser.add_argument('--store-monthly-hydro', nargs='?', const=True, default=True,
+    parser.add_argument('--store-monthly-hydro', default=True,
+                        action=argparse.BooleanOptionalAction,
                         help='If store-hydro-output is True, also store the '
-                             'hydrological model output in monthly resolution.')
+                             'hydrological model output in monthly resolution. '
+                             'Use --no-store-monthly-hydro to switch it off.')
     parser.add_argument('--ref-area-yr', type=int, default=None,
                         help='Force the reference area used for the hydrological '
                              'output to the glacier state of the given simulation '
@@ -1373,8 +1375,18 @@ def parse_args(args):
 
     dynamic_spinup = False if args.dynamic_spinup == '' else args.dynamic_spinup
 
-    if args.dynamic_spinup_periods_to_try == ['none']:
-        args.dynamic_spinup_periods_to_try = None
+    periods_to_try = args.dynamic_spinup_periods_to_try
+    if periods_to_try == ['none']:
+        periods_to_try = None
+    elif periods_to_try is not None:
+        try:
+            periods_to_try = [int(p) for p in periods_to_try]
+        except (TypeError, ValueError):
+            raise InvalidParamsError(
+                '--dynamic-spinup-periods-to-try takes spinup periods in '
+                "years, or the single value 'none', but got "
+                f'{periods_to_try}!'
+            )
 
     # All good
     return dict(rgi_version=rgi_version, rgi_reg=rgi_reg,

--- a/oggm/cli/prepro_levels.py
+++ b/oggm/cli/prepro_levels.py
@@ -125,7 +125,7 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
                       dynamic_spinup_start_year=1979,
                       dynamic_spinup_periods_to_try=None,
                       continue_on_error=True, store_fl_diagnostics=False,
-                      store_hydro_output=False, store_monthly_hydro=True,
+                      store_hydro_output=False, store_monthly_hydro=False,
                       ref_area_yr=None, temp_bias_run=False):
     """Generate the preprocessed OGGM glacier directories for this OGGM version
 
@@ -279,8 +279,9 @@ def run_prepro_levels(rgi_version=None, rgi_reg=None, border=None,
     store_hydro_output : bool
         if True, also store the hydrological model output.
     store_monthly_hydro : bool
-        if True and store_hydro_output is True the hydrological mode output will
-        also be stored in a monthly resolution (see flowline.run_with_hydro)
+        if True and store_hydro_output is True, the hydrological model output
+        is also stored at monthly resolution (see flowline.run_with_hydro).
+        This increases data usage quite a bit, hence the False default.
     ref_area_yr : int
         the hydrological output is computed over a reference area, which
         per default is the largest area covered by the glacier in the simulation
@@ -1328,11 +1329,10 @@ def parse_args(args):
                              "a bit.")
     parser.add_argument('--store-hydro-output', action='store_true',
                         help='Add optional hydrological model output')
-    parser.add_argument('--store-monthly-hydro', default=True,
-                        action=argparse.BooleanOptionalAction,
-                        help='If store-hydro-output is True, also store the '
-                             'hydrological model output in monthly resolution. '
-                             'Use --no-store-monthly-hydro to switch it off.')
+    parser.add_argument('--store-monthly-hydro', action='store_true',
+                        help='Requires --store-hydro-output. Also store the '
+                             'hydrological model output at monthly resolution. '
+                             'This increases data usage quite a bit.')
     parser.add_argument('--ref-area-yr', type=int, default=None,
                         help='Force the reference area used for the hydrological '
                              'output to the glacier state of the given simulation '

--- a/oggm/cli/temp_bias.py
+++ b/oggm/cli/temp_bias.py
@@ -110,7 +110,7 @@ def parse_args(args):
     parser.add_argument('--output-file', type=str, default='temp_bias.csv',
                         help='path of the csv file to write (default: '
                              '`temp_bias.csv` in the current directory).')
-    parser.add_argument('--no-plots', nargs='?', const=True, default=False,
+    parser.add_argument('--no-plots', action='store_true',
                         help='do not write the diagnostic plots. The '
                              '`_summary.txt` diagnostic file is always '
                              'written.')

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -1526,7 +1526,7 @@ class TestPreproCLI:
         assert kwargs['mb_calibration_strategy'] == 'informed_threestep'
         assert not kwargs['add_consensus_thickness']
         assert not kwargs['store_hydro_output']
-        assert kwargs['store_monthly_hydro']
+        assert not kwargs['store_monthly_hydro']
         assert kwargs['ref_area_yr'] is None
 
         kwargs = prepro_levels.parse_args(['--rgi-reg', '1',
@@ -1702,6 +1702,7 @@ class TestPreproCLI:
                                            'none',
                                            ])
         assert kwargs['dynamic_spinup_periods_to_try'] is None
+        assert kwargs['temp_bias_run'] is False
 
         with pytest.raises(InvalidParamsError):
             prepro_levels.parse_args(['--rgi-reg', '1',
@@ -1709,8 +1710,6 @@ class TestPreproCLI:
                                       '--dynamic-spinup-periods-to-try',
                                       '30', 'abc',
                                       ])
-
-        assert kwargs['temp_bias_run'] is False
 
         kwargs = prepro_levels.parse_args(['--rgi-reg', '1',
                                            '--map-border', '160',
@@ -1736,15 +1735,17 @@ class TestPreproCLI:
                                           flag, 'whatever',
                                           ])
 
-        # --store-monthly-hydro defaults to True, so really dirty fix here 
+        # Monthly hydro output is opt-in, like in flowline.run_with_hydro
         kwargs = prepro_levels.parse_args(['--rgi-reg', '1',
                                            '--map-border', '160',
-                                           '--no-store-monthly-hydro',
+                                           '--store-hydro-output',
                                            ])
+        assert kwargs['store_hydro_output'] is True
         assert kwargs['store_monthly_hydro'] is False
 
         kwargs = prepro_levels.parse_args(['--rgi-reg', '1',
                                            '--map-border', '160',
+                                           '--store-hydro-output',
                                            '--store-monthly-hydro',
                                            ])
         assert kwargs['store_monthly_hydro'] is True

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -1678,31 +1678,72 @@ class TestPreproCLI:
 
         assert kwargs['dynamic_spinup'] == 'area/dmdtda'
         assert kwargs['ref_mb_err_scaling_factor'] == 0.5
+        assert kwargs['dynamic_spinup_periods_to_try'] == [30, 40, 50, 60, 70,
+                                                           80, 90, 100]
 
-        assert kwargs["temp_bias_run"] is False
+        # The spinup periods are years, and 'none' is the documented way to
+        # ask for no additional period at all
+        kwargs = prepro_levels.parse_args(['--rgi-reg', '1',
+                                           '--map-border', '160',
+                                           '--dynamic-spinup-periods-to-try',
+                                           '30', '40',
+                                           ])
+        assert kwargs['dynamic_spinup_periods_to_try'] == [30, 40]
 
-        kwargs = prepro_levels.parse_args(
-            [
-                "--rgi-reg",
-                "1",
-                "--map-border",
-                "160",
-                "--temp-bias-run",
-            ]
-        )
-        assert kwargs["temp_bias_run"] is True
+        kwargs = prepro_levels.parse_args(['--rgi-reg', '1',
+                                           '--map-border', '160',
+                                           '--dynamic-spinup-periods-to-try',
+                                           'none',
+                                           ])
+        assert kwargs['dynamic_spinup_periods_to_try'] is None
 
-        with pytest.raises(SystemExit):
-            prepro_levels.parse_args(
-                [
-                    "--rgi-reg",
-                    "1",
-                    "--map-border",
-                    "160",
-                    "--temp-bias-run",
-                    "whatever",
-                ]
-            )
+        with pytest.raises(InvalidParamsError):
+            prepro_levels.parse_args(['--rgi-reg', '1',
+                                      '--map-border', '160',
+                                      '--dynamic-spinup-periods-to-try',
+                                      '30', 'abc',
+                                      ])
+
+        assert kwargs['temp_bias_run'] is False
+
+        kwargs = prepro_levels.parse_args(['--rgi-reg', '1',
+                                           '--map-border', '160',
+                                           '--temp-bias-run',
+                                           ])
+        assert kwargs['temp_bias_run'] is True
+
+        # The boolean flags are on/off switches: a value is an error, not a
+        # truthy string silently switching them on
+        for flag in ['--elev-bands', '--centerlines', '--skip-inversion',
+                     '--keep-dem-folders', '--add-consensus-thickness',
+                     '--add-itslive-velocity', '--add-millan-thickness',
+                     '--add-millan-velocity', '--add-hugonnet-dhdt',
+                     '--add-bedmachine', '--add-glathida',
+                     '--add-distributed-thickness',
+                     '--add-export-thickness-geotiff', '--compute-hypsometry',
+                     '--test', '--disable-mp', '--store-fl-diagnostics',
+                     '--store-hydro-output', '--store-monthly-hydro',
+                     '--temp-bias-run',
+                     ]:
+            with pytest.raises(SystemExit):
+                prepro_levels.parse_args(['--rgi-reg', '1',
+                                          '--map-border', '160',
+                                          flag, 'whatever',
+                                          ])
+
+        # --store-monthly-hydro defaults to True, so it needs its negated
+        # counterpart to be switchable at all
+        kwargs = prepro_levels.parse_args(['--rgi-reg', '1',
+                                           '--map-border', '160',
+                                           '--no-store-monthly-hydro',
+                                           ])
+        assert kwargs['store_monthly_hydro'] is False
+
+        kwargs = prepro_levels.parse_args(['--rgi-reg', '1',
+                                           '--map-border', '160',
+                                           '--store-monthly-hydro',
+                                           ])
+        assert kwargs['store_monthly_hydro'] is True
 
         with TempEnvironmentVariable(OGGM_RGI_REG='12',
                                      OGGM_MAP_BORDER='120',
@@ -2575,6 +2616,9 @@ class TestTempBiasCLI:
         assert kwargs['err_fill_quantile'] == 0.5
         assert kwargs['rgi_subregion'] == ['11-01']
 
+        with pytest.raises(SystemExit):
+            temp_bias.parse_args(['--input', 'in_dir', '--no-plots', 'whatever'])
+
         with pytest.raises(InvalidParamsError):
             temp_bias.parse_args([])
 
@@ -2940,6 +2984,12 @@ class TestBenchmarkCLI(unittest.TestCase):
         assert kwargs['rgi_reg'] == '01'
         assert kwargs['border'] == 160
         assert kwargs['is_test']
+
+        with pytest.raises(SystemExit):
+            benchmark.parse_args(['--rgi-reg', '1',
+                                  '--map-border', '160',
+                                  '--test', 'whatever',
+                                  ])
 
         kwargs = benchmark.parse_args(['--rgi-reg', '1',
                                        '--map-border', '160',

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -1686,6 +1686,12 @@ class TestPreproCLI:
         kwargs = prepro_levels.parse_args(['--rgi-reg', '1',
                                            '--map-border', '160',
                                            '--dynamic-spinup-periods-to-try',
+                                           '30',
+                                           ])
+        assert kwargs['dynamic_spinup_periods_to_try'] == [30]
+        kwargs = prepro_levels.parse_args(['--rgi-reg', '1',
+                                           '--map-border', '160',
+                                           '--dynamic-spinup-periods-to-try',
                                            '30', '40',
                                            ])
         assert kwargs['dynamic_spinup_periods_to_try'] == [30, 40]
@@ -1712,8 +1718,7 @@ class TestPreproCLI:
                                            ])
         assert kwargs['temp_bias_run'] is True
 
-        # The boolean flags are on/off switches: a value is an error, not a
-        # truthy string silently switching them on
+        # passed values should be treated as errors
         for flag in ['--elev-bands', '--centerlines', '--skip-inversion',
                      '--keep-dem-folders', '--add-consensus-thickness',
                      '--add-itslive-velocity', '--add-millan-thickness',
@@ -1731,8 +1736,7 @@ class TestPreproCLI:
                                           flag, 'whatever',
                                           ])
 
-        # --store-monthly-hydro defaults to True, so it needs its negated
-        # counterpart to be switchable at all
+        # --store-monthly-hydro defaults to True, so really dirty fix here 
         kwargs = prepro_levels.parse_args(['--rgi-reg', '1',
                                            '--map-border', '160',
                                            '--no-store-monthly-hydro',

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -1679,6 +1679,31 @@ class TestPreproCLI:
         assert kwargs['dynamic_spinup'] == 'area/dmdtda'
         assert kwargs['ref_mb_err_scaling_factor'] == 0.5
 
+        assert kwargs["temp_bias_run"] is False
+
+        kwargs = prepro_levels.parse_args(
+            [
+                "--rgi-reg",
+                "1",
+                "--map-border",
+                "160",
+                "--temp-bias-run",
+            ]
+        )
+        assert kwargs["temp_bias_run"] is True
+
+        with pytest.raises(SystemExit):
+            prepro_levels.parse_args(
+                [
+                    "--rgi-reg",
+                    "1",
+                    "--map-border",
+                    "160",
+                    "--temp-bias-run",
+                    "whatever",
+                ]
+            )
+
         with TempEnvironmentVariable(OGGM_RGI_REG='12',
                                      OGGM_MAP_BORDER='120',
                                      OGGM_OUTDIR='local/out',


### PR DESCRIPTION
<!--
Thank you for your pull request!


Below are a few things we ask you kindly to self-check before (or during)
the process!
 
Remove checks that are not relevant.
-->

A bunch of arguments e.g. `--temp-bias-run` were declared in a way that would allow an optional value that is never validated. So for example if someone passed something like: `--temp-bias-run whatever` this would evaluate to True and force a temp bias run. More seriously, if someone tried passing `--elev-bands False` this would evaluate to True.

`--store-monthly-hydro` was set to `const=True` and `default=True`, so it evaluated to `True` whether it was passed or omitted. This meant it could not be switched off from the command line. I personally think this should default to False, but in the meantime I've added an optional `--no-store-monthly-hydro`. @fmaussion this is quite a dirty fix from me and I'd appreciate your input here on what the default should be.

I also added type validation to `--dynamic-spinup-periods-to-try` so that it works.

## Discussion

This breaks any external script which passes a value, e.g. `--elev-bands True`. This will now raise an error, which I think is worth it as the same scripts passing e.g. `--elev-bands False` were silently running with the option set to True, and there was nothing in the output to say so.

- [ ] Tests added/passed
- [x] Fully documented
- [x]  Entry in whats-new.rst