### PR TITLE
New temp_* related diagnostics in run_with_hydro

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -18,11 +18,13 @@ Enhancements
   evolution: this is the diagnostic asked for by GlacierMIP4 (use it together
   with ``ref_area_yr`` or ``ref_area_from_y0``, so that areas and elevations
   refer to the same year). ``temp_on_glacier`` is weighted by the evolving
-  glacier area, at the surface elevation of the model. Both are opt-in: add
-  their name to ``PARAMS['store_diagnostic_variables']``. Note that these are
-  per glacier means, so a regional average has to be area-weighted by the
-  user. ``SfcTypeTIModel`` and ``RandomMassBalance`` gained the
-  ``get_annual_climate`` / ``get_monthly_climate`` methods this needs.
+  glacier area, at the surface elevation of the model. Both are in the default
+  ``PARAMS['store_diagnostic_variables']``, like the other hydro variables, and
+  are only computed by ``run_with_hydro``. Note that these are per glacier
+  means, so a regional average has to be area-weighted by the user.
+  ``SfcTypeTIModel`` and ``RandomMassBalance`` gained the
+  ``get_annual_climate`` / ``get_monthly_climate`` methods this needs
+  (:pull:`1998`).
   By `Fabien Maussion <https://github.com/fmaussion>`_
 - The preprocessing can now be run in chunks, so that a big RGI region does not
   have to fit into a single cluster job. ``oggm_prepro`` gained
@@ -39,7 +41,7 @@ Enhancements
   :py:func:`workflow.count_rgi_chunks` and
   :py:func:`workflow.print_slurm_array` make the same chunking available to
   ordinary runs, and the new ``oggm_prepro_chunks`` command tells you how many
-  chunks a region has. See the documentation for a complete SLURM example.
+  chunks a region has. See the documentation for a complete SLURM example (:pull:`1991`).
   By `Fabien Maussion <https://github.com/fmaussion>`_
 - ``calibrate_inversion_from_ref_table`` gained a ``glen_a_factor`` keyword to
   skip the calibration and invert with a known A factor instead. The factor a

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -9,6 +9,21 @@ v1.x (unreleased)
 Enhancements
 ~~~~~~~~~~~~
 
+- ``run_with_hydro`` can now store two area-weighted air temperature
+  diagnostics, i.e. the downscaled temperature (temperature bias and lapse
+  rate applied) which the mass balance model actually uses for melt and for
+  the solid/liquid precipitation split. ``temp_ref_area`` is weighted by the
+  reference area *and* evaluated at the reference surface elevation, i.e. it
+  is a fixed geometry diagnostic which does not depend on the glacier
+  evolution: this is the diagnostic asked for by GlacierMIP4 (use it together
+  with ``ref_area_yr`` or ``ref_area_from_y0``, so that areas and elevations
+  refer to the same year). ``temp_on_glacier`` is weighted by the evolving
+  glacier area, at the surface elevation of the model. Both are opt-in: add
+  their name to ``PARAMS['store_diagnostic_variables']``. Note that these are
+  per glacier means, so a regional average has to be area-weighted by the
+  user. ``SfcTypeTIModel`` and ``RandomMassBalance`` gained the
+  ``get_annual_climate`` / ``get_monthly_climate`` methods this needs.
+  By `Fabien Maussion <https://github.com/fmaussion>`_
 - The preprocessing can now be run in chunks, so that a big RGI region does not
   have to fit into a single cluster job. ``oggm_prepro`` gained
   ``--chunk-idx`` / ``--chunk-size`` (chunks are blocks of the RGI id space, of

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -4616,6 +4616,21 @@ def run_with_hydro(gdir, settings_filesuffix='',
     ``use_previous_mbs`` is set to True after the dynamical run, because the
     mass balance values stored during the run are revisited here.
 
+    Two area-weighted air temperature diagnostics can be computed as well
+    (the temperature after downscaling, i.e. the one used by the mass balance
+    model for melt and for the solid/liquid precipitation split). They are
+    opt-in: add their name to PARAMS['store_diagnostic_variables'].
+
+    - ``temp_on_glacier``: weighted by the (evolving) glacier area, at the
+      surface elevation of the model at that time.
+    - ``temp_ref_area``: weighted by the reference area, at the reference
+      surface elevation, i.e. fixed geometry. This one is independent of the
+      glacier evolution and is the diagnostic asked for by GlacierMIP4.
+      Note that with the default ``ref_area_yr=None`` the reference area is
+      the largest area of the simulation while the elevations are the ones of
+      the first year of the (reference) geometry file: use ``ref_area_yr`` or
+      ``ref_area_from_y0`` for a consistent fixed geometry.
+
     TODOs:
         - Add the possibility to record MB during run to improve performance
           (requires change in API)
@@ -4787,11 +4802,13 @@ def run_with_hydro(gdir, settings_filesuffix='',
     bin_area_2ds = []
     bin_elev_2ds = []
     ref_areas = []
+    ref_elevs = []
     snow_buckets = []
     for fl in fmod_ref.fls:
         # Glacier area on bins
         bin_area = fl.bin_area_m2
         ref_areas.append(bin_area)
+        ref_elevs.append(fl.surface_h.copy())
         snow_buckets.append(bin_area * 0)
 
         # Output 2d data
@@ -4909,6 +4926,18 @@ def run_with_hydro(gdir, settings_filesuffix='',
                      else np.full(oshape, np.nan)),
         }
 
+    # Area-weighted temperatures are means, not sums: we accumulate the
+    # numerator and the denominator separately and divide at the end
+    out['temp_on_glacier'] = {
+        'description': 'Area-weighted 2m air temperature over the glacierized '
+                       'area, at the surface elevation of the model',
+        'unit': 'degC',
+        'agg': 'mean',
+        'data': np.full(oshape, np.nan),
+    }
+    t_on_num = np.zeros(oshape)
+    t_on_den = np.zeros(oshape)
+
     for i, yr in enumerate(years):
 
         # Now the loop over the months
@@ -4933,12 +4962,12 @@ def run_with_hydro(gdir, settings_filesuffix='',
                         mb_out = mb_mod.get_monthly_mb(bin_elev, fl_id=fl_id,
                                                        year=flt_yr,
                                                        add_climate=True)
-                        mb, _, _, prcp, prcpsol = mb_out
+                        mb, temp, _, prcp, prcpsol = mb_out
                         seconds = mb_mod.sec_in_month(flt_yr)
                     else:
                         mb_out = mb_mod.get_annual_mb(bin_elev, fl_id=fl_id,
                                                       year=yr, add_climate=True)
-                        mb, _, _, prcp, prcpsol = mb_out
+                        mb, temp, _, prcp, prcpsol = mb_out
                         seconds = mb_mod.sec_in_year(yr)
                 except ValueError as e:
                     if 'too many values to unpack' in str(e):
@@ -5016,6 +5045,10 @@ def run_with_hydro(gdir, settings_filesuffix='',
                 out['liq_prcp_on_glacier']['data'][i, m-1] += np.sum(liq_prcp_on_g)
                 out['snowfall_off_glacier']['data'][i, m-1] += np.sum(prcpsol_off_g)
                 out['snowfall_on_glacier']['data'][i, m-1] += np.sum(prcpsol_on_g)
+
+                # Area-weighted temperature (mean - divided by the weights below)
+                t_on_num[i, m-1] += np.sum(temp * bin_area)
+                t_on_den[i, m-1] += np.sum(bin_area)
 
                 # Snow bucket is a state variable - stored at end of timestamp
                 if store_monthly_hydro:
@@ -5121,8 +5154,48 @@ def run_with_hydro(gdir, settings_filesuffix='',
             out['ice_melt_on_glacier']['data'][i, :] += \
                 np.where(has_comp, 0, final_melt)
 
-    # Convert to xarray
+    # Area-weighted temperature: NaN where there is no glacier left
+    out['temp_on_glacier']['data'] = np.where(t_on_den > 0,
+                                              t_on_num / np.where(t_on_den > 0,
+                                                                  t_on_den, 1),
+                                              np.nan)
+
     out_vars = gdir.settings['store_diagnostic_variables']
+
+    if 'temp_ref_area' in out_vars:
+        # Area-weighted temperature over the reference geometry (fixed area
+        # and fixed elevation). This is independent of the dynamical run, so
+        # we compute it in its own loop.
+        num = np.zeros(oshape)
+        den = np.zeros(oshape)
+        for fl_id, (ref_area, ref_elev) in enumerate(zip(ref_areas, ref_elevs)):
+            fl_mb_mod = _get_fl_mb_mod(fl_id)
+            if not hasattr(fl_mb_mod, 'get_annual_climate'):
+                raise InvalidWorkflowError(
+                    "'temp_ref_area' needs a MB model with a "
+                    "`get_annual_climate` (and `get_monthly_climate`) method, "
+                    "which {} does not have."
+                    "".format(type(fl_mb_mod).__name__))
+            for i, yr in enumerate(years):
+                for m in months:
+                    if store_monthly_hydro:
+                        flt_yr = utils.date_to_floatyear(int(yr), m)
+                        t = fl_mb_mod.get_monthly_climate(ref_elev,
+                                                          year=flt_yr)[0]
+                    else:
+                        t = fl_mb_mod.get_annual_climate(ref_elev, year=yr)[0]
+                    num[i, m-1] += np.sum(t * ref_area)
+                    den[i, m-1] += np.sum(ref_area)
+
+        out['temp_ref_area'] = {
+            'description': 'Area-weighted 2m air temperature over the '
+                           'reference geometry (fixed area and elevation)',
+            'unit': 'degC',
+            'agg': 'mean',
+            'data': np.where(den > 0, num / np.where(den > 0, den, 1), np.nan),
+        }
+
+    # Convert to xarray
     ods = xr.Dataset()
     ods.coords['time'] = fmod.years
     if store_monthly_hydro:
@@ -5133,6 +5206,7 @@ def run_with_hydro(gdir, settings_filesuffix='',
         ods.coords['calendar_month_2d'] = ('month_2d', np.arange(1, 13))
     for varname, d in out.items():
         data = d.pop('data')
+        agg = d.pop('agg', 'sum')
         if varname not in out_vars:
             continue
         if len(data.shape) == 2:
@@ -5140,6 +5214,10 @@ def run_with_hydro(gdir, settings_filesuffix='',
             if varname == 'snow_bucket':
                 # Snowbucket is a state variable
                 ods[varname] = ('time', data[:, 0])
+            elif agg == 'mean':
+                # Intensive variables (e.g. temperature) are averaged
+                data[-1, :] = np.nan
+                ods[varname] = ('time', np.mean(data, axis=1))
             else:
                 # Last year is never good
                 data[-1, :] = np.nan

--- a/oggm/core/flowline.py
+++ b/oggm/core/flowline.py
@@ -4618,8 +4618,9 @@ def run_with_hydro(gdir, settings_filesuffix='',
 
     Two area-weighted air temperature diagnostics can be computed as well
     (the temperature after downscaling, i.e. the one used by the mass balance
-    model for melt and for the solid/liquid precipitation split). They are
-    opt-in: add their name to PARAMS['store_diagnostic_variables'].
+    model for melt and for the solid/liquid precipitation split). Like the
+    other hydro variables they are computed if their name is in
+    PARAMS['store_diagnostic_variables'] (the default).
 
     - ``temp_on_glacier``: weighted by the (evolving) glacier area, at the
       surface elevation of the model at that time.

--- a/oggm/core/massbalance.py
+++ b/oggm/core/massbalance.py
@@ -1869,6 +1869,14 @@ class SfcTypeTIModel(MassBalanceModel):
         # Reset state, we do not want to change parameters midway
         self.reset_state()
 
+    def get_monthly_climate(self, heights, year=None):
+        """The climate is the one of the underlying mb model."""
+        return self.mbmod.get_monthly_climate(heights, year=year)
+
+    def get_annual_climate(self, heights, year=None):
+        """The climate is the one of the underlying mb model."""
+        return self.mbmod.get_annual_climate(heights, year=year)
+
     def set_melt_f_buckets(self):
         """Set the melt factor for each bucket."""
         if self.melt_f_change == "linear":
@@ -3451,6 +3459,15 @@ class RandomMassBalance(MassBalanceModel):
     def get_annual_mb(self, heights, year=None, **kwargs):
         ryr = self.get_state_yr(int(year))
         return self.mbmod.get_annual_mb(heights, year=ryr, **kwargs)
+
+    def get_monthly_climate(self, heights, year=None):
+        ryr, m = floatyear_to_date(year)
+        ryr = date_to_floatyear(self.get_state_yr(ryr), m)
+        return self.mbmod.get_monthly_climate(heights, year=ryr)
+
+    def get_annual_climate(self, heights, year=None):
+        ryr = self.get_state_yr(int(year))
+        return self.mbmod.get_annual_climate(heights, year=ryr)
 
 
 class UncertainMassBalance(MassBalanceModel):

--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -435,14 +435,14 @@ store_output_on_error = False
 # Only computed for mass balance models with surface type tracking
 # (e.g. SfcTypeTIModel), NaN otherwise:
 #   snow_melt_on_glacier, firn_melt_on_glacier, ice_melt_on_glacier,
-# Area-weighted downscaled air temperature (not computed unless asked for,
-# temp_ref_area is the GlacierMIP4 diagnostic - see run_with_hydro):
+# Area-weighted downscaled air temperature (temp_ref_area is the GlacierMIP4
+# diagnostic - see run_with_hydro):
 #   temp_on_glacier, temp_ref_area,
 # Probably useful for debugging only
 #   melt_residual_off_glacier, melt_residual_on_glacier
 #   model_mb, residual_mb, snow_bucket,
 # You need to keep all variables in one line unfortunately
-store_diagnostic_variables =  volume, volume_bsl, volume_bwl, area, area_min_h, length, mass, calving, calving_rate, off_area, on_area, melt_off_glacier, melt_on_glacier, liq_prcp_off_glacier, liq_prcp_on_glacier, snowfall_off_glacier, snowfall_on_glacier, snow_melt_on_glacier, firn_melt_on_glacier, ice_melt_on_glacier
+store_diagnostic_variables =  volume, volume_bsl, volume_bwl, area, area_min_h, length, mass, calving, calving_rate, off_area, on_area, melt_off_glacier, melt_on_glacier, liq_prcp_off_glacier, liq_prcp_on_glacier, snowfall_off_glacier, snowfall_on_glacier, snow_melt_on_glacier, firn_melt_on_glacier, ice_melt_on_glacier, temp_on_glacier, temp_ref_area
 
 # Whether to store the model flowline diagnostic files during operational runs
 # This can be useful for advanced diagnostics along the flowlines but is

--- a/oggm/params.cfg
+++ b/oggm/params.cfg
@@ -435,6 +435,9 @@ store_output_on_error = False
 # Only computed for mass balance models with surface type tracking
 # (e.g. SfcTypeTIModel), NaN otherwise:
 #   snow_melt_on_glacier, firn_melt_on_glacier, ice_melt_on_glacier,
+# Area-weighted downscaled air temperature (not computed unless asked for,
+# temp_ref_area is the GlacierMIP4 diagnostic - see run_with_hydro):
+#   temp_on_glacier, temp_ref_area,
 # Probably useful for debugging only
 #   melt_residual_off_glacier, melt_residual_on_glacier
 #   model_mb, residual_mb, snow_bucket,

--- a/oggm/tests/test_models.py
+++ b/oggm/tests/test_models.py
@@ -68,7 +68,7 @@ ALL_DIAGS = ['volume', 'volume_bsl', 'volume_bwl', 'area', 'length', 'mass',
              'melt_on_glacier', 'snow_melt_on_glacier', 'firn_melt_on_glacier',
              'ice_melt_on_glacier', 'liq_prcp_off_glacier', 'liq_prcp_on_glacier',
              'snowfall_off_glacier', 'snowfall_on_glacier', 'model_mb',
-             'residual_mb', 'snow_bucket']
+             'residual_mb', 'snow_bucket', 'temp_on_glacier', 'temp_ref_area']
 
 has_shapely2 = False
 try:
@@ -7578,9 +7578,33 @@ class TestHydro:
         # In the spinup run the residual is zero for the spinup part
         assert_allclose(odf_spin['residual_mb'].loc[:1990], 0)
 
+        # Area-weighted temperatures
+        for vn in ['temp_on_glacier', 'temp_ref_area']:
+            assert np.all(np.isfinite(odf[vn]))
+            assert np.all((odf[vn] > -20) & (odf[vn] < 5))
+        # The fixed geometry one is a pure climate diagnostic: recompute it
+        # here from the reference geometry the task used (default: max area
+        # over the run, surface elevation of the first year)
+        fmod = FileModel(gdir.get_filepath('model_geometry', filesuffix='_hist'))
+        ref_elevs = [fl.surface_h.copy() for fl in fmod.fls]
+        ref_areas = [fl.bin_area_m2 * 0 for fl in fmod.fls]
+        for yr in fmod.years[:-1]:
+            fmod.run_until(yr)
+            for ref_area, fl in zip(ref_areas, fmod.fls):
+                ref_area[:] = np.maximum(ref_area, fl.bin_area_m2)
+        mbmod = massbalance.MonthlyTIModel(gdir)
+        for yr in [odf.index[0], odf.index[-1]]:
+            num, den = 0, 0
+            for ref_area, ref_elev in zip(ref_areas, ref_elevs):
+                t = mbmod.get_annual_climate(ref_elev, year=yr)[0]
+                num += np.sum(t * ref_area)
+                den += np.sum(ref_area)
+            assert_allclose(odf['temp_ref_area'].loc[yr], num / den)
+
         # Also check output stuff
         nds = utils.compile_run_output([gdir], input_filesuffix='_hist')
         assert nds.residual_mb.attrs['unit'] == 'kg yr-1'
+        assert nds.temp_ref_area.attrs['unit'] == 'degC'
         assert_allclose(nds['snowfall_on_glacier'].squeeze()[:-1],
                         odf['snowfall_on_glacier'])
         if 'month_2d' in nds:
@@ -7590,6 +7614,11 @@ class TestHydro:
             odf_ma.columns = [c.replace('_monthly', '') for c in odf_ma.columns]
             # Runoff peak should follow a temperature curve
             assert_allclose(odf_ma['melt_on_glacier'].idxmax(), 8)
+            # Temperature peaks in summer as well
+            assert_allclose(odf_ma['temp_ref_area'].idxmax(), 8)
+            # The annual value is the average of the monthly ones
+            assert_allclose(nds['temp_ref_area_monthly'].mean(dim='month_2d'),
+                            nds['temp_ref_area'])
 
         # check if melt on glacier is always above or equal zero
         assert np.all(odf['melt_on_glacier'] >= 0)

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -1341,7 +1341,8 @@ class TestWorkflowUtils:
                              'snowfall_off_glacier', 'snowfall_on_glacier',
                              'melt_residual_off_glacier',
                              'melt_residual_on_glacier', 'model_mb',
-                             'residual_mb', 'snow_bucket', 'mass']
+                             'residual_mb', 'snow_bucket', 'mass',
+                             'temp_on_glacier', 'temp_ref_area']
         for gi in range(10):
             allowed_data_vars += [f'terminus_thick_{gi}']
 

--- a/oggm/tests/test_utils.py
+++ b/oggm/tests/test_utils.py
@@ -2612,6 +2612,11 @@ class TestPreproCLI:
             assert 'melt_on_glacier_monthly' in ds
             assert 'month_2d' in ds.coords
             assert np.all(np.isfinite(ds['on_area'].sel(time=2000)))
+            # The temperature diagnostics come with the hydro output
+            assert 'temp_ref_area' in ds
+            assert 'temp_on_glacier_monthly' in ds
+            assert ds['temp_ref_area'].attrs['unit'] == 'degC'
+            assert np.all(np.isfinite(ds['temp_ref_area'].sel(time=2000)))
 
     @pytest.mark.slow
     def test_full_run_cru_centerlines(self):

--- a/oggm/utils/_workflow.py
+++ b/oggm/utils/_workflow.py
@@ -1214,7 +1214,10 @@ def compile_run_output(gdirs, path=True, input_filesuffix='',
                   'liq_prcp_off_glacier', 'liq_prcp_on_glacier',
                   'snowfall_off_glacier', 'snowfall_on_glacier',
                   'melt_residual_off_glacier', 'melt_residual_on_glacier',
-                  'snow_bucket', 'residual_mb']
+                  'snow_bucket', 'residual_mb',
+                  # These two are per glacier means, i.e. a regional average
+                  # has to be area-weighted by the user
+                  'temp_on_glacier', 'temp_ref_area']
     for v in hydro_vars:
         allowed_data_vars += [v]
         allowed_data_vars += [v + '_monthly']


### PR DESCRIPTION
GlacierMIP4 asks for a diagnostic OGGM did not compute: the mean near-surface (2 m)
area-weighted air temperature over the initial (year 2000) glacierized area, after
downscaling (temperature bias + lapse rate). This is the temperature actually used by
the mass balance model for melt and for the solid/liquid precipitation split, and its
purpose is to separate model spread caused by different downscaled forcing from spread
caused by the glacier models themselves. The companion precipitation diagnostic was
already recoverable from `run_with_hydro` (`liq_prcp_*` + `snowfall_*` over the
reference area), so only temperature was missing.

Two variables are added, both opt-in via `PARAMS['store_diagnostic_variables']` (neither
is in the default list, so existing runs are unchanged and pay no cost):

- `temp_ref_area` — weighted by the reference bin areas *and* evaluated at the reference
  bin elevations, i.e. fixed geometry. Independent of the glacier evolution, so it is a
  pure forcing diagnostic and comparable across models. **This is the GlacierMIP4 one.**
  Use it with `ref_area_yr` or `ref_area_from_y0`: with the default `ref_area_yr=None`
  the reference area is the largest area of the simulation while the elevations are
  those of the first year of the geometry file.
- `temp_on_glacier` — weighted by the evolving glacier area, at the surface elevation of
  the model. Free to compute: the value was already returned by
  `get_annual_mb(..., add_climate=True)` and discarded.

Both are in degC and are per glacier means, so a regional average has to be
area-weighted by the user.

### Implementation

- `oggm/core/flowline.py`, `run_with_hydro`:
  - the reference surface elevations are now kept alongside `ref_areas`;
  - `temp_on_glacier` accumulates a numerator and a denominator inside the existing main
    loop and is divided at the end (a weighted mean cannot be accumulated additively);
  - `temp_ref_area` is computed in its own loop before the netCDF conversion, using
    `get_annual_climate` / `get_monthly_climate` on the reference elevations. It does not
    touch the mass-conservation and residual correction code. It costs one climate call
    per flowline per timestep, and only when requested;
  - the `out` dict entries carry a new `agg` key, and the monthly-to-annual aggregation
    in the writer averages instead of summing for those.
- `oggm/core/massbalance.py`: `SfcTypeTIModel` and `RandomMassBalance` gained
  `get_annual_climate` / `get_monthly_climate` (delegating to their underlying model, for
  `RandomMassBalance` through `get_state_yr`). A MB model without them raises an explicit
  `InvalidWorkflowError` when `temp_ref_area` is asked for.
- Registered in `params.cfg` (comment block only), in `hydro_vars` of
  `compile_run_output`, and in the variable lists of `test_models.py` / `test_utils.py`.

### Tests

No new test function: the two names were added to `ALL_DIAGS`, which switches them on in
the whole `TestHydro` class (annual/monthly, historical/random/constant, spinup, error
paths). `test_hydro_out_past_climate` gained a handful of assertions, the main one
recomputing `temp_ref_area` independently from `MonthlyTIModel.get_annual_climate` on the
reference geometry.

All 24 `TestHydro` tests pass, including `test_hydro_monthly_vs_annual`, which compares
every column between an annual and a monthly run — so the annual value equals the mean of
the 12 monthly ones for `MonthlyTIModel`, `ConstantMassBalance` and `RandomMassBalance`.
`test_compile_run_output` passes as well.

Checked on Hintereisferner with a 100-year random projection where the glacier shrinks
from 8.04 to 0.30 km²: `temp_ref_area` has a trend of -0.003 degC/100yr (flat, as it
should be for a trendless forcing) while `temp_on_glacier` cools by 3.9 degC/100yr as
only the high-elevation remnant survives.